### PR TITLE
FIX: remove caches from ref instead of branch

### DIFF
--- a/.github/workflows/clean-cache.yml
+++ b/.github/workflows/clean-cache.yml
@@ -10,7 +10,7 @@ jobs:
   cleanup:
     env:
       REPO: ${{ github.repository }}
-      BRANCH: ${{ github.ref }}
+      REF: refs/pull/${{ github.event.inputs.pr-number || github.event.number }}/merge
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     name: Remove PR caches
     runs-on: ubuntu-latest
@@ -21,7 +21,7 @@ jobs:
         run: |
           set +e
           echo "Deleting caches..."
-          for CACHE_KEY in $(gh actions-cache list -R $REPO -B $BRANCH | cut -f 1); do
-            gh actions-cache delete $CACHE_KEY -R $REPO -B $BRANCH --confirm
+          for CACHE_KEY in $(gh actions-cache list -R $REPO -B $REF | cut -f 1); do
+            gh actions-cache delete $CACHE_KEY -R $REPO -B $REF --confirm
           done
           echo "Done"


### PR DESCRIPTION
Cache clean did not work correctly, see this log:
https://github.com/ComPWA/repo-maintenance/actions/runs/4032179760
This workflow removed the caches for the `main` branch instead of the branch associated to the PR.