### PR TITLE
MAINT: simplify `Executor` syntax with `finalize()`

### DIFF
--- a/src/repoma/check_dev_files/__init__.py
+++ b/src/repoma/check_dev_files/__init__.py
@@ -169,10 +169,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         executor(setup_cfg.main, args.ignore_author)
         executor(tox.main)
     executor(toml.main)
-    if executor.error_messages:
-        print(executor.merge_messages())
-        return 1
-    return 0
+    return executor.finalize(exception=False)
 
 
 def _to_list(arg: str) -> List[str]:

--- a/src/repoma/check_dev_files/black.py
+++ b/src/repoma/check_dev_files/black.py
@@ -27,8 +27,7 @@ def main() -> None:
     executor(_check_option_ordering, config)
     executor(_check_target_versions, config)
     executor(_update_nbqa_hook)
-    if executor.error_messages:
-        raise PrecommitError(executor.merge_messages())
+    executor.finalize()
 
 
 def _load_black_config(content: Optional[str] = None) -> dict:

--- a/src/repoma/check_dev_files/cspell.py
+++ b/src/repoma/check_dev_files/cspell.py
@@ -58,8 +58,7 @@ def main() -> None:
         executor(_sort_config_entries)
         executor(add_badge, __BADGE)
         executor(add_vscode_extension_recommendation, __VSCODE_EXTENSION_NAME)
-    if executor.error_messages:
-        raise PrecommitError(executor.merge_messages())
+    executor.finalize()
 
 
 def _update_cspell_repo_url(path: Path = CONFIG_PATH.precommit) -> None:
@@ -100,8 +99,7 @@ def _remove_configuration() -> None:
     executor = Executor()
     executor(remove_badge, __BADGE_PATTERN)
     executor(remove_vscode_extension_recommendation, __VSCODE_EXTENSION_NAME)
-    if executor.error_messages:
-        raise PrecommitError(executor.merge_messages())
+    executor.finalize()
 
 
 def _check_check_hook_options() -> None:

--- a/src/repoma/check_dev_files/flake8.py
+++ b/src/repoma/check_dev_files/flake8.py
@@ -51,8 +51,7 @@ def main() -> None:
             "TI1",
         ],
     )
-    if executor.error_messages:
-        raise PrecommitError(executor.merge_messages())
+    executor.finalize()
 
 
 def _is_flake8_installed() -> bool:

--- a/src/repoma/check_dev_files/github_templates.py
+++ b/src/repoma/check_dev_files/github_templates.py
@@ -17,8 +17,7 @@ def main() -> None:
     executor = Executor()
     executor(_check_pr_template)
     executor(_check_issue_templates)
-    if executor.error_messages:
-        raise PrecommitError(executor.merge_messages())
+    executor.finalize()
 
 
 def _check_issue_templates() -> None:

--- a/src/repoma/check_dev_files/github_workflows.py
+++ b/src/repoma/check_dev_files/github_workflows.py
@@ -34,8 +34,7 @@ def main(  # pylint: disable=too-many-arguments
         skip_tests,
         test_extras,
     )
-    if executor.error_messages:
-        raise PrecommitError(executor.merge_messages())
+    executor.finalize()
 
 
 def _update_cd_workflow(no_pypi: bool) -> None:
@@ -56,8 +55,7 @@ def _update_cd_workflow(no_pypi: bool) -> None:
     executor = Executor()
     executor(update)
     executor(remove_workflow, "milestone.yml")
-    if executor.error_messages:
-        raise PrecommitError(executor.merge_messages())
+    executor.finalize()
 
 
 def _update_ci_workflow(
@@ -96,8 +94,7 @@ def _update_ci_workflow(
         executor(remove_workflow, "linkcheck.yml")
     executor(_copy_workflow_file, "clean-caches.yml")
     executor(remove_workflow, "clean-cache.yml")
-    if executor.error_messages:
-        raise PrecommitError(executor.merge_messages())
+    executor.finalize()
 
 
 def _get_ci_workflow(

--- a/src/repoma/check_dev_files/prettier.py
+++ b/src/repoma/check_dev_files/prettier.py
@@ -38,8 +38,7 @@ def main(no_prettierrc: bool) -> None:
         executor(add_badge, __BADGE)
         executor(add_vscode_extension_recommendation, __VSCODE_EXTENSION_NAME)
         executor(_update_prettier_ignore)
-        if executor.error_messages:
-            raise PrecommitError(executor.merge_messages())
+        executor.finalize()
 
 
 def _remove_configuration() -> None:

--- a/src/repoma/check_dev_files/pyupgrade.py
+++ b/src/repoma/check_dev_files/pyupgrade.py
@@ -17,8 +17,7 @@ def main() -> None:
     executor = Executor()
     executor(_update_main_pyupgrade_hook)
     executor(_update_nbqa_hook)
-    if executor.error_messages:
-        raise PrecommitError(executor.merge_messages())
+    executor.finalize()
 
 
 def _update_main_pyupgrade_hook() -> None:

--- a/src/repoma/check_dev_files/setup_cfg.py
+++ b/src/repoma/check_dev_files/setup_cfg.py
@@ -20,8 +20,7 @@ def main(ignore_author: bool) -> None:
     if not ignore_author:
         executor(_update_author_data)
     executor(_fix_long_description)
-    if executor.error_messages:
-        raise PrecommitError(executor.merge_messages())
+    executor.finalize()
 
 
 def _check_required_options() -> None:

--- a/src/repoma/check_dev_files/toml.py
+++ b/src/repoma/check_dev_files/toml.py
@@ -36,8 +36,7 @@ def main() -> None:
     executor(_update_taplo_config)
     executor(_update_precommit_config)
     executor(_update_vscode_extensions)
-    if executor.error_messages:
-        raise PrecommitError(executor.merge_messages())
+    executor.finalize()
 
 
 def _rename_taplo_config() -> None:
@@ -97,5 +96,4 @@ def _update_vscode_extensions() -> None:
     executor = Executor()
     executor(add_vscode_extension_recommendation, "tamasfe.even-better-toml")
     executor(remove_vscode_extension_recommendation, "bungcip.better-toml")
-    if executor.error_messages:
-        raise PrecommitError(executor.merge_messages())
+    executor.finalize()

--- a/src/repoma/check_dev_files/tox.py
+++ b/src/repoma/check_dev_files/tox.py
@@ -1,6 +1,5 @@
 """Check contents of a ``tox.ini`` file."""
 
-from repoma.errors import PrecommitError
 from repoma.utilities import CONFIG_PATH
 from repoma.utilities.cfg import extract_config_section
 from repoma.utilities.executor import Executor
@@ -28,5 +27,4 @@ def main() -> None:
         extract_to=CONFIG_PATH.pytest,
         sections=["coverage:run", "pytest"],
     )
-    if executor.error_messages:
-        raise PrecommitError(executor.merge_messages())
+    executor.finalize()

--- a/src/repoma/check_dev_files/update_pip_constraints.py
+++ b/src/repoma/check_dev_files/update_pip_constraints.py
@@ -23,8 +23,7 @@ def main(cron_frequency: str) -> None:
     executor(_remove_script, "pin_requirements.py")
     executor(_remove_script, "upgrade.sh")
     executor(_update_requirement_workflow, cron_frequency)
-    if executor.error_messages:
-        raise PrecommitError(executor.merge_messages())
+    executor.finalize()
 
 
 def _remove_script(script_name: str) -> None:
@@ -53,8 +52,7 @@ def _update_requirement_workflow(frequency: str) -> None:
     executor(overwrite_workflow, "requirements.yml", _to_cron_schedule(frequency))
     executor(remove_workflow, "requirements-cron.yml")
     executor(remove_workflow, "requirements-pr.yml")
-    if executor.error_messages:
-        raise PrecommitError(executor.merge_messages())
+    executor.finalize()
 
 
 def _to_cron_schedule(frequency: str) -> str:

--- a/src/repoma/fix_nbformat_version.py
+++ b/src/repoma/fix_nbformat_version.py
@@ -30,10 +30,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         executor(set_nbformat_version, filename)
         executor(remove_cell_ids, filename)
         executor(check_svg_output_cells, filename)
-    if executor.error_messages:
-        print(executor.merge_messages())
-        return 1
-    return 0
+    return executor.finalize(exception=False)
 
 
 def set_nbformat_version(filename: str) -> None:

--- a/src/repoma/self_check.py
+++ b/src/repoma/self_check.py
@@ -21,10 +21,7 @@ def main() -> int:
     for repo in local_repos:
         for hook in repo.hooks:
             executor(_check_hook_definition, hook)
-    if executor.error_messages:
-        print(executor.merge_messages())
-        return 1
-    return 0
+    return executor.finalize(exception=False)
 
 
 def _check_hook_definition(hook: Hook) -> None:

--- a/src/repoma/utilities/executor.py
+++ b/src/repoma/utilities/executor.py
@@ -20,6 +20,15 @@ class Executor:
             error_message = str("\n".join(exception.args))
             self.error_messages.append(error_message)
 
+    def finalize(self, exception: bool = True) -> int:
+        error_msg = self.merge_messages()
+        if error_msg:
+            if exception:
+                raise PrecommitError(error_msg)
+            print(error_msg)
+            return 1
+        return 0
+
     def merge_messages(self) -> str:
         stripped_messages = (s.strip() for s in self.error_messages)
         return "\n--------------------\n".join(stripped_messages)


### PR DESCRIPTION
Added an extra method, `Executor.finalize()`, that makes it easier to use a construct with an `Executor` class.