### PR TITLE
FEAT: recommend VS Code GitHub Actions extension

### DIFF
--- a/src/repoma/check_dev_files/github_workflows.py
+++ b/src/repoma/check_dev_files/github_workflows.py
@@ -13,6 +13,10 @@ from repoma.utilities import CONFIG_PATH, REPOMA_DIR, write
 from repoma.utilities.executor import Executor
 from repoma.utilities.precommit import PrecommitConfig
 from repoma.utilities.setup_cfg import get_pypi_name
+from repoma.utilities.vscode import (
+    add_extension_recommendation,
+    remove_extension_recommendation,
+)
 from repoma.utilities.yaml import create_prettier_round_trip_yaml
 
 
@@ -34,6 +38,7 @@ def main(  # pylint: disable=too-many-arguments
         skip_tests,
         test_extras,
     )
+    executor(_recommend_vscode_extension)
     executor.finalize()
 
 
@@ -207,6 +212,16 @@ def __remove_constraint_pinning(content: str) -> str:
         repl="",
         string=content,
     )
+
+
+def _recommend_vscode_extension() -> None:
+    if not CONFIG_PATH.github_workflow_dir.exists():
+        return
+    # cspell:ignore cschleiden
+    executor = Executor()
+    executor(remove_extension_recommendation, "cschleiden.vscode-github-actions")
+    executor(add_extension_recommendation, "github.vscode-github-actions")
+    executor.finalize()
 
 
 def remove_workflow(filename: str) -> None:


### PR DESCRIPTION
Enforces a switch to the new [GitHub Actions extension](https://github.com/github/vscode-github-actions) for VS Code.