### PR TITLE
FIX: remove `cell.attachments` instead of metadata

### DIFF
--- a/src/repoma/check_dev_files/nbstripout.py
+++ b/src/repoma/check_dev_files/nbstripout.py
@@ -13,7 +13,7 @@ from repoma.utilities.yaml import create_prettier_round_trip_yaml
 __REPO_URL = "https://github.com/kynan/nbstripout"
 __HOOK_ID = "nbstripout"
 __EXTRA_KEYS_ARGUMENT = [
-    "cell.metadata.attachments",
+    "cell.attachments",
     "cell.metadata.code_folding",
     "cell.metadata.id",
     "cell.metadata.user_expressions",


### PR DESCRIPTION
Fix-up to #139 