### PR TITLE
ENH: run GitPod check after other checks

### DIFF
--- a/src/repoma/check_dev_files/__init__.py
+++ b/src/repoma/check_dev_files/__init__.py
@@ -159,8 +159,6 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         skip_tests=_to_list(args.ci_skipped_tests),
         test_extras=_to_list(args.ci_test_extras),
     )
-    if not args.no_gitpod:
-        executor(gitpod.main)
     executor(nbstripout.main)
     executor(toml.main)  # has to run before pre-commit
     executor(precommit.main)
@@ -178,6 +176,8 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         executor(setup_cfg.main, args.ignore_author)
         executor(tox.main)
     executor(vscode.main)
+    if not args.no_gitpod:
+        executor(gitpod.main)
     return executor.finalize(exception=False)
 
 


### PR DESCRIPTION
Some of the other checks update the list of recommended VSCode extensions under `.vscode/extensions.json`. The list of extensions under `.gitpod` is now updated during the same `pre-commit` run.