### PR TITLE
FEAT: add option to run pytest single-threaded

### DIFF
--- a/src/repoma/check_dev_files/__init__.py
+++ b/src/repoma/check_dev_files/__init__.py
@@ -123,6 +123,12 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         type=str,
     )
     parser.add_argument(
+        "--pytest-single-threaded",
+        action="store_true",
+        default=False,
+        help="Run pytest without the `-n` argument",
+    )
+    parser.add_argument(
         "--repo-name",
         help=(
             "Name of the repository. This can usually be found in the URL of the"
@@ -159,6 +165,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         no_macos=args.no_macos,
         no_pypi=args.no_pypi,
         no_version_branches=args.no_version_branches,
+        single_threaded=args.pytest_single_threaded,
         skip_tests=_to_list(args.ci_skipped_tests),
         test_extras=_to_list(args.ci_test_extras),
     )


### PR DESCRIPTION
In order to run `pytest` in GitHub Actions [single-threaded](https://github.com/ComPWA/actions/blob/ae5e2f318bb762a90e5394607932bbe32e85c220/.github/workflows/pytest.yml#L18C16-L18C16), pass `--pytest-single-threaded` to the arguments in `.pre-commit-config.yaml`:

```yaml
repos:
  - repo: https://github.com/ComPWA/repo-maintenance
    rev: e0179cc
    hooks:
      - id: check-dev-files
        args:
          - --pytest-single-threaded  # new option
```