### PR TITLE
DX: specify config file for mypy in VSCode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -38,6 +38,7 @@
   },
   "git.rebaseWhenSync": true,
   "github-actions.workflows.pinned.workflows": [".github/workflows/ci.yml"],
+  "mypy-type-checker.args": ["--config-file", "pyproject.toml"],
   "mypy-type-checker.importStrategy": "fromEnvironment",
   "python.analysis.autoImportCompletions": false,
   "python.analysis.inlayHints.pytestParameters": true,

--- a/src/repoma/check_dev_files/mypy.py
+++ b/src/repoma/check_dev_files/mypy.py
@@ -37,6 +37,7 @@ def _update_vscode_settings() -> None:
     else:
         executor(add_extension_recommendation, "ms-python.mypy-type-checker")
         settings = {
+            "mypy-type-checker.args": ["--config-file", "pyproject.toml"],
             "mypy-type-checker.importStrategy": "fromEnvironment",
             "python.linting.mypyEnabled": False,
         }


### PR DESCRIPTION
The [vscode-mypy](https://github.com/microsoft/vscode-mypy) extension seems not to directly recognise that mypy is configured through `pyproject.toml`. This PR fixes that.