### PR TITLE
MAINT: add permissions `id-token` to `doc` job

### DIFF
--- a/src/repoma/.github/workflows/ci.yml
+++ b/src/repoma/.github/workflows/ci.yml
@@ -28,6 +28,9 @@ on:
 jobs:
   doc:
     uses: ComPWA/actions/.github/workflows/ci-docs.yml@v1
+    permissions:
+      pages: write
+      id-token: write
     with:
       specific-pip-packages: ${{ inputs.specific-pip-packages }}
   pytest:


### PR DESCRIPTION
Fixes [this problem](https://github.com/redeboer/bossdoc/actions/runs/5507382654):
> The workflow is not valid. .github/workflows/ci.yml (Line: 29, Col: 3): Error calling workflow 'ComPWA/actions/.github/workflows/ci-docs.yml@v1'. The nested job 'Upload to GitHub Pages' is requesting 'id-token: write', but is only allowed 'id-token: none'.