### PR TITLE
MAINT: recommend `black` extension for vscode

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -22,6 +22,7 @@ vscode:
     - garaioag.garaio-vscode-unwanted-recommendations
     - github.vscode-github-actions
     - github.vscode-pull-request-github
+    - ms-python.black-formatter
     - ms-python.mypy-type-checker
     - ms-python.python
     - ms-python.vscode-pylance

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -9,6 +9,7 @@
     "garaioag.garaio-vscode-unwanted-recommendations",
     "github.vscode-github-actions",
     "github.vscode-pull-request-github",
+    "ms-python.black-formatter",
     "ms-python.mypy-type-checker",
     "ms-python.python",
     "ms-python.vscode-pylance",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -23,6 +23,7 @@
   "[yaml]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
+  "black-formatter.importStrategy": "fromEnvironment",
   "coverage-gutters.coverageFileNames": ["coverage.xml"],
   "coverage-gutters.coverageReportFileName": "**/htmlcov/index.html",
   "coverage-gutters.showGutterCoverage": false,

--- a/src/repoma/check_dev_files/black.py
+++ b/src/repoma/check_dev_files/black.py
@@ -18,6 +18,7 @@ from repoma.utilities.pyproject import (
     write_pyproject,
 )
 from repoma.utilities.setup_cfg import get_supported_python_versions
+from repoma.utilities.vscode import add_extension_recommendation, set_setting
 
 
 def main() -> None:
@@ -28,6 +29,8 @@ def main() -> None:
     executor(_update_black_settings)
     executor(_update_precommit_repo)
     executor(_update_precommit_nbqa_hook)
+    executor(add_extension_recommendation, "ms-python.black-formatter")
+    executor(set_setting, {"black-formatter.importStrategy": "fromEnvironment"})
     executor(update_nbqa_settings, "black", to_toml_array(["--line-length=85"]))
     executor.finalize()
 


### PR DESCRIPTION
As a follow-up to #159, recommend and configure the VSCode [Black Formatter](https://marketplace.visualstudio.com/items?itemName=ms-python.black-formatter).