### PR TITLE
FEAT: autoupdate new pre-commit hooks

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,10 @@ module = ["ruamel.*"]
 ignore_missing_imports = true
 module = ["nbformat.*"]
 
+[[tool.mypy.overrides]]
+ignore_missing_imports = true
+module = ["pre_commit.commands.autoupdate.*"]
+
 
 [tool.pyright]
 exclude = [

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,6 +35,7 @@ install_requires =
     ini2toml
     nbformat
     pip-tools
+    pre-commit
     PyYAML
     ruamel.yaml  # better YAML dumping
     tomlkit

--- a/src/repoma/check_dev_files/ruff.py
+++ b/src/repoma/check_dev_files/ruff.py
@@ -5,7 +5,6 @@ from textwrap import dedent
 from typing import List, Set
 
 from ruamel.yaml.comments import CommentedMap
-from ruamel.yaml.scalarstring import DoubleQuotedScalarString
 from tomlkit.items import Array, Table
 
 from repoma.errors import PrecommitError
@@ -268,7 +267,6 @@ def _update_precommit_hook() -> None:
         return
     expected_hook = CommentedMap(
         repo="https://github.com/astral-sh/ruff-pre-commit",
-        rev=DoubleQuotedScalarString(""),
         hooks=[CommentedMap(id="ruff", args=["--fix"])],
     )
     update_single_hook_precommit_repo(expected_hook)


### PR DESCRIPTION
Previously, new `pre-commit` hooks added by the `check-dev-files` hook would set `rev: ""` and then the user would have to run `pre-commit autoupdate`. The latest release for each new hook is now fetched automatically if the user has an internet connection.