### PR TITLE
ENH: remove GitPod config if `--no-gitpod`

### DIFF
--- a/src/repoma/check_dev_files/__init__.py
+++ b/src/repoma/check_dev_files/__init__.py
@@ -32,7 +32,7 @@ from . import (
 )
 
 
-def main(argv: Optional[Sequence[str]] = None) -> int:  # noqa: PLR0915
+def main(argv: Optional[Sequence[str]] = None) -> int:
     parser = argparse.ArgumentParser(__doc__)
     parser.add_argument(
         "--allow-deprecated-workflows",
@@ -200,8 +200,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:  # noqa: PLR0915
         executor(setup_cfg.main, args.ignore_author)
     executor(remove_deprecated_tools, args.keep_issue_templates)
     executor(vscode.main, has_notebooks)
-    if not args.no_gitpod:
-        executor(gitpod.main)
+    executor(gitpod.main, args.no_gitpod)
     executor(precommit.main)
     return executor.finalize(exception=False)
 

--- a/src/repoma/check_dev_files/gitpod.py
+++ b/src/repoma/check_dev_files/gitpod.py
@@ -14,7 +14,13 @@ from repoma.utilities.yaml import write_yaml
 __CONSTRAINTS_FILE = ".constraints/py3.8.txt"
 
 
-def main() -> None:
+def main(no_gitpod: bool) -> None:
+    if no_gitpod:
+        if CONFIG_PATH.gitpod.exists():
+            os.remove(CONFIG_PATH.gitpod)
+            msg = f"Removed {CONFIG_PATH.gitpod} as requested by --no-gitpod"
+            raise PrecommitError(msg)
+        return
     pin_dependencies = os.path.exists(__CONSTRAINTS_FILE)
     error_message = ""
     expected_config = _generate_gitpod_config(pin_dependencies)


### PR DESCRIPTION
If the `check-dev-files` hook is specified with `--no-gitpod`, remove the [`.gitpod` config file](https://www.gitpod.io/docs/references/gitpod-yml) if it exists.