### PR TITLE
FIX: point to absolute mypy config path

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -40,7 +40,7 @@
   },
   "git.rebaseWhenSync": true,
   "github-actions.workflows.pinned.workflows": [".github/workflows/ci.yml"],
-  "mypy-type-checker.args": ["--config-file", "pyproject.toml"],
+  "mypy-type-checker.args": ["--config-file=${workspaceFolder}/pyproject.toml"],
   "mypy-type-checker.importStrategy": "fromEnvironment",
   "python.analysis.autoImportCompletions": false,
   "python.analysis.inlayHints.pytestParameters": true,

--- a/src/repoma/check_dev_files/mypy.py
+++ b/src/repoma/check_dev_files/mypy.py
@@ -37,7 +37,9 @@ def _update_vscode_settings() -> None:
     else:
         executor(add_extension_recommendation, "ms-python.mypy-type-checker")
         settings = {
-            "mypy-type-checker.args": ["--config-file", "pyproject.toml"],
+            "mypy-type-checker.args": [
+                "--config-file=${workspaceFolder}/pyproject.toml"
+            ],
             "mypy-type-checker.importStrategy": "fromEnvironment",
         }
         executor(set_setting, settings)


### PR DESCRIPTION
The [VSCode MyPy extension](https://marketplace.visualstudio.com/items?itemName=ms-python.mypy-type-checker) was incorrectly configured, because `mypy-type-checker.args` specified the [`--config-file`](https://mypy.readthedocs.io/en/stable/command_line.html#cmdoption-mypy-config-file) with a relative path (see https://github.com/microsoft/vscode-mypy/issues/190).