### PR TITLE
DOC: automatically document `check-dev-files` arguments

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -70,6 +70,7 @@
   "ignoreWords": [
     "MAINT",
     "PyPI",
+    "argparse",
     "autonumbering",
     "autoupdate",
     "bdist",

--- a/docs/check-dev-files.md
+++ b/docs/check-dev-files.md
@@ -1,0 +1,34 @@
+# `check-dev-files`
+
+This hook is responsible for standardizing and synchronizing the [developer environment](https://compwa-org.rtfd.io/develop.html) of repositories by the [ComPWA organization](https://github.com/ComPWA). Coding conventions are enforced through automated checks instead of through a contribution guide. These conventions have to be regularly updated across all repositories as developer tools introduce new features and deprecate old ones.
+
+The `check-dev-files` hook can also be used as a **cookie cutter** for new repositories by adding the following to your [`.pre-commit-config.yaml`](https://pre-commit.com/index.html#adding-pre-commit-plugins-to-your-project) file:
+
+```yaml
+repos:
+  - repo: https://github.com/ComPWA/repo-maintenance
+    rev: ""
+    hooks:
+      - id: check-dev-files
+        args:
+          - --repo-name="short name for your repository"
+```
+
+and running
+
+```shell
+pre-commit autoupdate --repo=https://github.com/ComPWA/repo-maintenance
+pre-commit run check-dev-files -a
+```
+
+For more implementation details of this hook, check the {mod}`.check_dev_files` module.
+
+## Hook arguments
+
+The `check-dev-files` hook can be configured with by adding any of the following flags to the [`args`](https://pre-commit.com/#config-args) key in your `.pre-commit-config.yaml` file.
+
+```{argparse}
+:module: repoma.check_dev_files
+:func: _create_argparse
+:prog: check-dev-files
+```

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -85,6 +85,7 @@ extensions = [
     "sphinx.ext.napoleon",
     "sphinx.ext.viewcode",
     "sphinx_copybutton",
+    "sphinxarg.ext",
 ]
 html_copy_source = True  # needed for download notebook button
 html_favicon = "_static/favicon.ico"

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,7 +3,7 @@
 :::{title} Welcome
 :::
 
-This package standardizes and synchronizes the developer environment of repositories by the [ComPWA organization](https://github.com/ComPWA). The maintenance is performed through [pre-commit](https://pre-commit.com) with the use of a number of pre-commit hooks as defined by [`.pre-commit-hooks.yaml`](../.pre-commit-hooks.yaml). The {mod}`check-dev-files <.check_dev_files>` in particular can be used as a **cookie cutter** for new repositories.
+This package standardizes and synchronizes the developer environment of repositories by the [ComPWA organization](https://github.com/ComPWA). The maintenance is performed through [pre-commit](https://pre-commit.com) with the use of a number of pre-commit hooks as defined by [`.pre-commit-hooks.yaml`](../.pre-commit-hooks.yaml). The [`check-dev-files`](./check-dev-files.md) in particular can be used as a **cookie cutter** for new repositories.
 
 ## Usage
 
@@ -34,6 +34,7 @@ pre-commit install
 
 The `repo-maintenance` repository provides the following hooks:
 
+- [`check-dev-files`](./check-dev-files.md)
 - {mod}`check-dev-files <.check_dev_files>`
 - {mod}`colab-toc-visible <.colab_toc_visible>`
 - {mod}`fix-nbformat-version <.fix_nbformat_version>`
@@ -43,6 +44,7 @@ The `repo-maintenance` repository provides the following hooks:
 
 ```{toctree}
 :hidden:
+check-dev-files
 API <api/repoma>
 Changelog <https://github.com/ComPWA/repoma/releases>
 Upcoming features <https://github.com/ComPWA/repoma/milestones?direction=asc&sort=title&state=open>

--- a/setup.cfg
+++ b/setup.cfg
@@ -49,6 +49,7 @@ package_dir =
 doc =
     myst-parser
     Sphinx
+    sphinx-argparse
     sphinx-book-theme
     sphinx-copybutton
 test =


### PR DESCRIPTION
The arguments of the `check-dev-files` hook are now automatically documented on https://compwa.github.io/repo-maintenance/check-dev-files.html with [`sphinx-argparse`](https://sphinx-argparse.rtfd.io).