### PR TITLE
MAINT: remove redundant Taplo config exclusions

### DIFF
--- a/.taplo.toml
+++ b/.taplo.toml
@@ -1,8 +1,4 @@
 exclude = [
-    "**/Cargo.toml",
-    "**/Manifest.toml",
-    "**/Project.toml",
-    "labels*.toml",
     "labels/*.toml",
 ]
 

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -57,13 +57,13 @@
     ".constraints/*.txt": true,
     ".github/workflows/cd.yml": true,
     ".github/workflows/ci.yml": true,
+    ".taplo.toml": true,
     "src/repoma/.github/workflows/clean-caches.yml": true,
     "src/repoma/.github/workflows/pr-linting.yml": true,
     "src/repoma/.github/workflows/release-drafter.yml": true,
     "src/repoma/.template/.cspell.json": true,
     "src/repoma/.template/.gitpod.yml": true,
-    "src/repoma/.template/.prettierrc": true,
-    "src/repoma/.template/.taplo.toml": true
+    "src/repoma/.template/.prettierrc": true
   },
   "yaml.schemas": {
     "https://citation-file-format.github.io/1.2.0/schema.json": "CITATION.cff",

--- a/src/repoma/.template/.taplo.toml
+++ b/src/repoma/.template/.taplo.toml
@@ -1,1 +1,20 @@
-../../../.taplo.toml
+exclude = [
+    "**/Cargo.toml",
+    "**/Manifest.toml",
+    "**/Project.toml",
+    "labels*.toml",
+    "labels/*.toml",
+]
+
+[formatting]
+align_comments = false
+align_entries = false
+allowed_blank_lines = 1
+array_auto_collapse = false
+array_auto_expand = true
+array_trailing_comma = true
+column_width = 88
+compact_inline_tables = true
+indent_string = "    "
+reorder_arrays = true
+reorder_keys = true

--- a/src/repoma/utilities/pyproject.py
+++ b/src/repoma/utilities/pyproject.py
@@ -45,10 +45,10 @@ def write_pyproject(config: TOMLDocument) -> None:
         stream.write(src)
 
 
-def to_toml_array(items: Iterable[Any]) -> Array:
+def to_toml_array(items: Iterable[Any], enforce_multiline: bool = False) -> Array:
     array = tomlkit.array()
     array.extend(items)
-    if len(array) > 1:
+    if enforce_multiline or len(array) > 1:
         array.multiline(True)
     else:
         array.multiline(False)


### PR DESCRIPTION
The [`exclude`](https://taplo.tamasfe.dev/configuration/file.html#exclude) section in the `.taplo` config contained files that do not exist in all repositories. They are now removed automatically.