### PR TITLE
FIX: ignore whitespaces in TOML comparison

### DIFF
--- a/src/repoma/check_dev_files/toml.py
+++ b/src/repoma/check_dev_files/toml.py
@@ -104,7 +104,7 @@ def _update_taplo_config() -> None:
         del expected["exclude"]
     with open(CONFIG_PATH.taplo) as f:
         existing = tomlkit.load(f)
-    expected_str = tomlkit.dumps(expected)
+    expected_str = tomlkit.dumps(expected, sort_keys=True)
     existing_str = tomlkit.dumps(existing)
     if existing_str.strip() != expected_str.strip():
         with open(CONFIG_PATH.taplo, "w") as stream:


### PR DESCRIPTION
Since #201, the `check-dev-files` hook keeps saying it updated the `.taplo.toml` config, so the hook never returns success.