### PR TITLE
MAINT: do not lint `bib` files in subdirs

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -61,7 +61,6 @@
     "src/repoma/.github/workflows/clean-caches.yml": true,
     "src/repoma/.github/workflows/pr-linting.yml": true,
     "src/repoma/.github/workflows/release-drafter.yml": true,
-    "src/repoma/.template/.cspell.json": true,
     "src/repoma/.template/.gitpod.yml": true,
     "src/repoma/.template/.prettierrc": true
   },

--- a/src/repoma/.template/.cspell.json
+++ b/src/repoma/.template/.cspell.json
@@ -15,8 +15,8 @@
     "transisions"
   ],
   "ignorePaths": [
+    "**/*.bib",
     "**/.cspell.json",
-    "*.bib",
     "*.ico",
     "*.root",
     "*.rst_t",


### PR DESCRIPTION
The `*.bib` glob pattern in `ignorePaths` of the cSpell config did not ignore bibliography files in subdirectories. The pattern has been updated to `**/*.bib`.