### PR TITLE
DX: show code block moves in Git diff editor

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -31,6 +31,7 @@
   "coverage-gutters.showGutterCoverage": false,
   "coverage-gutters.showLineCoverage": true,
   "cSpell.enabled": true,
+  "diffEditor.experimental.showMoves": true,
   "editor.formatOnSave": true,
   "files.watcherExclude": {
     "**/*_cache/**": true,

--- a/src/repoma/check_dev_files/vscode.py
+++ b/src/repoma/check_dev_files/vscode.py
@@ -38,6 +38,7 @@ def _update_settings(has_notebooks: bool) -> None:
     executor(
         vscode.set_setting,
         {
+            "diffEditor.experimental.showMoves": True,
             "editor.formatOnSave": True,
             "rewrap.wrappingColumn": 88,  # black
         },


### PR DESCRIPTION
Show moves of code blocks in the Git diff editor of VSCode. See [these release notes](https://code.visualstudio.com/updates/v1_80#_move-detection).