### PR TITLE
MAINT: remove pyupgrade if Ruff is installed

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -101,13 +101,6 @@ repos:
     hooks:
       - id: pyright
 
-  - repo: https://github.com/asottile/pyupgrade
-    rev: v3.15.0
-    hooks:
-      - id: pyupgrade
-        args:
-          - --py36-plus
-
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.1.4
     hooks:

--- a/src/repoma/check_dev_files/__init__.py
+++ b/src/repoma/check_dev_files/__init__.py
@@ -68,7 +68,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         executor(mypy.main)
         executor(pyright.main)
         executor(pytest.main)
-        executor(pyupgrade.main)
+        executor(pyupgrade.main, args.no_ruff)
         if not args.no_ruff:
             executor(ruff.main, has_notebooks)
         executor(setup_cfg.main, args.ignore_author)

--- a/src/repoma/check_dev_files/pyupgrade.py
+++ b/src/repoma/check_dev_files/pyupgrade.py
@@ -6,16 +6,20 @@ from ruamel.yaml.comments import CommentedMap, CommentedSeq
 from repoma.utilities import natural_sorting
 from repoma.utilities.executor import Executor
 from repoma.utilities.precommit import (
+    remove_precommit_hook,
     update_precommit_hook,
     update_single_hook_precommit_repo,
 )
 from repoma.utilities.project_info import get_supported_python_versions
 
 
-def main() -> None:
+def main(no_ruff: bool) -> None:
     executor = Executor()
-    executor(_update_precommit_repo)
-    executor(_update_precommit_nbqa_hook)
+    if no_ruff:
+        executor(_update_precommit_repo)
+        executor(_update_precommit_nbqa_hook)
+    else:
+        executor(_remove_pyupgrade)
     executor.finalize()
 
 
@@ -55,3 +59,10 @@ def __get_pyupgrade_version_argument() -> CommentedSeq:
     lowest_version = supported_python_versions[0]
     yaml = YAML(typ="rt")
     return yaml.load(f"[--py{lowest_version}-plus]")
+
+
+def _remove_pyupgrade() -> None:
+    executor = Executor()
+    executor(remove_precommit_hook, "nbqa-pyupgrade")
+    executor(remove_precommit_hook, "pyupgrade")
+    executor.finalize()


### PR DESCRIPTION
[`pyupgrade`](https://github.com/asottile/pyupgrade) rules are now largely handled by [Ruff `UP` rules](https://docs.astral.sh/ruff/rules/#pyupgrade-up), which [are enforced by repo-maintenance](https://github.com/ComPWA/repo-maintenance/blob/621d1032e28a0c601d7810885a2c9765d39d022b/src/repoma/check_dev_files/ruff.py#L367). The `pyupgrade` hooks can therefore be removed.