### PR TITLE
DX: install `isort` in `jupyter` dependencies

### DIFF
--- a/src/repoma/check_dev_files/jupyter.py
+++ b/src/repoma/check_dev_files/jupyter.py
@@ -14,6 +14,7 @@ def _update_dev_requirements() -> None:
         return
     hierarchy = ["jupyter", "dev"]
     dependencies = [
+        "isort",
         "jupyterlab",
         "jupyterlab-code-formatter",
         "jupyterlab-git",


### PR DESCRIPTION
Ruff formatting does not yet work well in Jypyter Lab. Therefore we have to keep using `black`+`isort` (the default in `jupyterlab-code-formatter`) for now.