### PR TITLE
FIX: do not sort `Manifest.toml` and `Project.toml`

### DIFF
--- a/src/repoma/check_dev_files/toml.py
+++ b/src/repoma/check_dev_files/toml.py
@@ -85,6 +85,8 @@ def _update_tomlsort_hook() -> None:
         excludes.append(r"labels/.*\.toml")
     if glob("labels*.toml"):
         excludes.append(r"labels.*\.toml")
+    if any(glob(f"**/{f}.toml", recursive=True) for f in ("Manifest", "Project")):
+        excludes.append(r".*(Manifest|Project)\.toml")
     if excludes:
         excludes = sorted(excludes, key=str.lower)
         expected_hook["hooks"][0]["exclude"] = "(?x)^(" + "|".join(excludes) + ")$"


### PR DESCRIPTION
Avoid sorting `Manifest.toml` and `Project.toml` with the [`toml-sort`](https://pypi.org/project/toml-sort) pre-commit hook. The sorting shouldn't really matter, but [as recommended by `Manifest.toml` itself](https://github.com/ComPWA/compwa-org/blob/d81e4722c0426f207b599828f91ac547da2596f5/docs/report/019/Manifest.toml#L1), it is not advised to edit it after generation.

```toml
# This file is machine-generated - editing it directly is not advised
```