### PR TITLE
FIX: make unwanted-recommendations unwanted

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -26,6 +26,7 @@
   "unwantedRecommendations": [
     "bungcip.better-toml",
     "davidanson.vscode-markdownlint",
+    "garaioag.garaio-vscode-unwanted-recommendations",
     "ms-python.flake8",
     "ms-python.isort",
     "ms-python.pylint",

--- a/src/repoma/check_dev_files/vscode.py
+++ b/src/repoma/check_dev_files/vscode.py
@@ -29,6 +29,7 @@ def _update_extensions() -> None:
         vscode.remove_extension_recommendation,
         "garaioag.garaio-vscode-unwanted-recommendations",
         # cspell:ignore garaio garaioag
+        unwanted=True,
     )
     executor(
         vscode.add_extension_recommendation,


### PR DESCRIPTION
Follow-up to #259: make the deprecated extension itself 'unwanted'.