### PR TITLE
FEAT: add option to outsource requirements schedule

### DIFF
--- a/src/repoma/check_dev_files/__init__.py
+++ b/src/repoma/check_dev_files/__init__.py
@@ -90,7 +90,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     if args.pin_requirements != "no":
         executor(
             update_pip_constraints.main,
-            cron_frequency=args.pin_requirements,
+            frequency=args.pin_requirements,
         )
     executor(readthedocs.main, dev_python_version)
     executor(remove_deprecated_tools, args.keep_issue_templates)
@@ -229,7 +229,7 @@ def _create_argparse() -> ArgumentParser:
     )
     parser.add_argument(
         "--pin-requirements",
-        choices=["no", "biweekly", "monthly", "bimonthly", "quarterly", "biannually"],
+        choices=update_pip_constraints.Frequency.__args__,  # type:ignore[attr-defined]
         default="no",
         help=(
             "Add a script to pin developer requirements to a constraint file."


### PR DESCRIPTION
If a repository uses [pre-commit.ci](https://pre-commit.ci), it will always have a cron schedule job for updating `.pre-commit-config.yaml`. PRs created by this cron job will then trigger to the requirements workflow if available, so there is no need to have that workflow also have its own cron schedule.

Set `--pin-requirements=outsource` to remove the schedule from the `requirements.yml` workflow.

> [!WARNING]
> Note this only triggers a PR if there updates to the pre-commit hooks. This is less frequently the case than that there are updates in all the indirect dependencies.