### PR TITLE
DX: define `addopts` as array

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -217,12 +217,12 @@ reportUnusedVariable = true
 typeCheckingMode = "strict"
 
 [tool.pytest.ini_options]
-addopts = """
---color=yes
---doctest-continue-on-failure
---doctest-modules
---durations=3
-"""
+addopts = [
+    "--color=yes",
+    "--doctest-continue-on-failure",
+    "--doctest-modules",
+    "--durations=3",
+]
 filterwarnings = [
     "error",
     "ignore: Importing ErrorTree directly from the jsonschema package is deprecated.*",


### PR DESCRIPTION
`tool.pytest.ini_options.addopts` can be defined as an array, which is easier to format.