### PR TITLE
FIX: do not pass filenames to `check-jsonschema` hook

### DIFF
--- a/src/compwa_policy/check_dev_files/citation.py
+++ b/src/compwa_policy/check_dev_files/citation.py
@@ -184,6 +184,7 @@ def add_json_schema_precommit() -> None:
             "https://citation-file-format.github.io/1.2.0/schema.json",
             "CITATION.cff",
         ],
+        pass_filenames=False,
     )
     config, yaml = load_roundtrip_precommit_config()
     repo_url = "https://github.com/python-jsonschema/check-jsonschema"

--- a/src/compwa_policy/utilities/precommit.py
+++ b/src/compwa_policy/utilities/precommit.py
@@ -281,3 +281,4 @@ class Hook(TypedDict):
     always_run: NotRequired[bool]
     verbose: NotRequired[bool]
     log_file: NotRequired[str]
+    pass_filenames: NotRequired[bool]


### PR DESCRIPTION
Fix-up to #272 