### PR TITLE
ENH: remove redundant paths from requirements workflow

### DIFF
--- a/src/compwa_policy/check_dev_files/update_pip_constraints.py
+++ b/src/compwa_policy/check_dev_files/update_pip_constraints.py
@@ -8,6 +8,7 @@ See Also:
 from __future__ import annotations
 
 import sys
+from glob import glob
 
 from compwa_policy.check_dev_files.github_workflows import (
     remove_workflow,
@@ -71,7 +72,9 @@ def _update_requirement_workflow(frequency: Frequency) -> None:
         if frequency == "outsource":
             del expected_data["on"]["schedule"]
         else:
+            paths: list[str] = expected_data["on"]["pull_request"]["paths"]
             expected_data["on"]["schedule"][0]["cron"] = _to_cron_schedule(frequency)
+            expected_data["on"]["pull_request"]["paths"] = [p for p in paths if glob(p)]
         workflow_path = CONFIG_PATH.github_workflow_dir / workflow_file
         if not workflow_path.exists():
             update_workflow(yaml, expected_data, workflow_path)


### PR DESCRIPTION
This reintroduces a feature that was introduced in #252.