### PR TITLE
FEAT: add `--github-pages` option to `check-dev-files`

### DIFF
--- a/src/compwa_policy/check_dev_files/__init__.py
+++ b/src/compwa_policy/check_dev_files/__init__.py
@@ -63,6 +63,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             github_workflows.main,
             allow_deprecated=args.allow_deprecated_workflows,
             doc_apt_packages=_to_list(args.doc_apt_packages),
+            github_pages=args.github_pages,
             python_version=dev_python_version,
             no_macos=args.no_macos,
             no_pypi=args.no_pypi,
@@ -79,7 +80,12 @@ def main(argv: Sequence[str] | None = None) -> int:
     if is_python_repo:
         executor(black.main, has_notebooks)
         if not args.no_github_actions:
-            executor(release_drafter.main, args.repo_name, args.repo_title)
+            executor(
+                release_drafter.main,
+                args.repo_name,
+                args.repo_title,
+                github_pages=args.github_pages,
+            )
         executor(mypy.main)
         executor(pyright.main)
         executor(pytest.main)
@@ -132,6 +138,12 @@ def _create_argparse() -> ArgumentParser:
         ),
         required=False,
         type=str,
+    )
+    parser.add_argument(
+        "--github-pages",
+        action="store_true",
+        default=False,
+        help="Host documentation on GitHub Pages",
     )
     parser.add_argument(
         "--keep-issue-templates",

--- a/src/compwa_policy/check_dev_files/release_drafter.py
+++ b/src/compwa_policy/check_dev_files/release_drafter.py
@@ -10,14 +10,14 @@ from compwa_policy.utilities import COMPWA_POLICY_DIR, CONFIG_PATH, update_file
 from compwa_policy.utilities.yaml import create_prettier_round_trip_yaml
 
 
-def main(repo_name: str, repo_title: str) -> None:
+def main(repo_name: str, repo_title: str, github_pages: bool) -> None:
     update_file(CONFIG_PATH.release_drafter_workflow)
-    _update_draft(repo_name, repo_title)
+    _update_draft(repo_name, repo_title, github_pages)
 
 
-def _update_draft(repo_name: str, repo_title: str) -> None:
+def _update_draft(repo_name: str, repo_title: str, github_pages: bool) -> None:
     yaml = create_prettier_round_trip_yaml()
-    expected = _get_expected_config(repo_name, repo_title)
+    expected = _get_expected_config(repo_name, repo_title, github_pages)
     output_path = CONFIG_PATH.release_drafter_config
     if not os.path.exists(output_path):
         yaml.dump(expected, output_path)
@@ -30,14 +30,16 @@ def _update_draft(repo_name: str, repo_title: str) -> None:
         raise PrecommitError(msg)
 
 
-def _get_expected_config(repo_name: str, repo_title: str) -> dict[str, Any]:
+def _get_expected_config(
+    repo_name: str, repo_title: str, github_pages: bool
+) -> dict[str, Any]:
     yaml = create_prettier_round_trip_yaml()
     config = yaml.load(COMPWA_POLICY_DIR / CONFIG_PATH.release_drafter_config)
     key = "name-template"
     config[key] = config[key].replace("<<REPO_TITLE>>", repo_title)
     key = "template"
     lines = config[key].split("\n")
-    if not os.path.exists(CONFIG_PATH.readthedocs):
+    if not os.path.exists(CONFIG_PATH.readthedocs) or github_pages:
         lines = lines[2:]
     config[key] = "\n".join(lines).replace("<<REPO_NAME>>", repo_name)
     return config


### PR DESCRIPTION
Allows hosting pages on GitHub Pages, even if a [`.readthedocs.yaml`](https://docs.readthedocs.io/en/stable/config-file/v2.html) config file is present.