### PR TITLE
ENH: sort `toml-sort` and `taplo` as formatters

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -71,6 +71,19 @@ repos:
     hooks:
       - id: prettier
 
+  - repo: https://github.com/ComPWA/mirrors-taplo
+    rev: v0.8.1
+    hooks:
+      - id: taplo
+
+  - repo: https://github.com/pappasam/toml-sort
+    rev: v0.23.1
+    hooks:
+      - id: toml-sort
+        args:
+          - --in-place
+        exclude: (?x)^(labels/.*\.toml)$
+
   - repo: https://github.com/streetsidesoftware/cspell-cli
     rev: v8.3.0
     hooks:
@@ -96,6 +109,7 @@ repos:
         require_serial: true
         types:
           - python
+
   - repo: https://github.com/ComPWA/mirrors-pyright
     rev: v1.1.345
     hooks:
@@ -106,16 +120,3 @@ repos:
     hooks:
       - id: ruff
         args: [--fix]
-
-  - repo: https://github.com/ComPWA/mirrors-taplo
-    rev: v0.8.1
-    hooks:
-      - id: taplo
-
-  - repo: https://github.com/pappasam/toml-sort
-    rev: v0.23.1
-    hooks:
-      - id: toml-sort
-        args:
-          - --in-place
-        exclude: (?x)^(labels/.*\.toml)$

--- a/src/compwa_policy/check_dev_files/precommit.py
+++ b/src/compwa_policy/check_dev_files/precommit.py
@@ -57,7 +57,14 @@ def __repo_sort_key(repo: Repo) -> tuple[int, str]:
     if len(hooks) > 1:
         return 2, repo_url
     hook_id = hooks[0]["id"]
-    formatter_hooks = {"black", "blacken-docs", "isort", "prettier"}
+    formatter_hooks = {
+        "black",
+        "blacken-docs",
+        "isort",
+        "prettier",
+        "taplo",
+        "toml-sort",
+    }
     if hook_id in formatter_hooks:
         return 3, hook_id
     return 4, hook_id


### PR DESCRIPTION
Follow-up to #283 