### PR TITLE
BEHAVIOR: activate Ruff preview mode

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -280,6 +280,7 @@ ignore = [
     "D416",
     "E501",
     "PLR0913",
+    "PLW1514",
     "PLW2901",
     "S301",
     "SIM108",
@@ -313,6 +314,7 @@ known-first-party = ["compwa_policy"]
     "PGH001",
     "PLR0913",
     "PLR2004",
+    "PLR6301",
     "S101",
     "T20",
 ]

--- a/src/compwa_policy/check_dev_files/github_workflows.py
+++ b/src/compwa_policy/check_dev_files/github_workflows.py
@@ -29,7 +29,7 @@ if TYPE_CHECKING:
     from ruamel.yaml.main import YAML
 
 
-def main(
+def main(  # noqa: PLR0917
     allow_deprecated: bool,
     doc_apt_packages: list[str],
     github_pages: bool,
@@ -94,7 +94,7 @@ def _update_pr_linting() -> None:
         raise PrecommitError(msg)
 
 
-def _update_ci_workflow(
+def _update_ci_workflow(  # noqa: PLR0917
     allow_deprecated: bool,
     doc_apt_packages: list[str],
     github_pages: bool,
@@ -140,7 +140,7 @@ def _update_ci_workflow(
     executor.finalize()
 
 
-def _get_ci_workflow(
+def _get_ci_workflow(  # noqa: PLR0917
     path: Path,
     doc_apt_packages: list[str],
     github_pages: bool,

--- a/src/compwa_policy/check_dev_files/ruff.py
+++ b/src/compwa_policy/check_dev_files/ruff.py
@@ -281,6 +281,7 @@ def __update_ruff_settings(has_notebooks: bool) -> None:
         "D407",  # missing dashed underline after section
         "D416",  # section name does not have to end with a colon
         "E501",  # line-width already handled by black
+        "PLW1514",  # allow missing encoding in open()
         "SIM108",  # allow if-else blocks
     ]
     if "3.6" in get_supported_python_versions():
@@ -493,6 +494,7 @@ def _update_ruff_per_file_ignores(has_notebooks: bool) -> None:
             "INP001",  # allow implicit-namespace-package
             "PGH001",  # allow eval
             "PLR2004",  # magic-value-comparison
+            "PLR6301",  # allow non-static method
             "S101",  # allow assert
             "T20",  # allow print and pprint
         }


### PR DESCRIPTION
Activates Ruff's [preview mode](https://docs.astral.sh/ruff/preview/#enabling-preview-mode) in preparation to replace `black` with Ruff altogether. For now, we don't replace `black` because Ruff does not yet offer full parity when Black's preview mode is activated. See more info here:
https://docs.astral.sh/ruff/formatter/#preview-style