### PR TITLE
ENH: avoid linebreak on `concurrency` update

### DIFF
--- a/src/compwa_policy/.github/workflows/ci.yml
+++ b/src/compwa_policy/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: >-
+  cancel-in-progress: |-
     ${{ github.ref != format('refs/heads/{0}', github.event.repository.default_branch) }}
 
 env:

--- a/src/compwa_policy/.github/workflows/requirements.yml
+++ b/src/compwa_policy/.github/workflows/requirements.yml
@@ -2,7 +2,7 @@ name: Requirements
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: >-
+  cancel-in-progress: |-
     ${{ github.ref != format('refs/heads/{0}', github.event.repository.default_branch) }}
 
 on:


### PR DESCRIPTION
Follow-up to #291 