### PR TITLE
FIX: add select to lint option keys

### DIFF
--- a/src/compwa_policy/check_dev_files/ruff.py
+++ b/src/compwa_policy/check_dev_files/ruff.py
@@ -253,6 +253,7 @@ def _move_ruff_lint_config() -> None:
         "pep8-naming",
         "per-file-ignores",
         "pydocstyle",
+        "select",
         "task-tags",
     }
     pyproject = load_pyproject()


### PR DESCRIPTION
Moves `tool.ruff.select` to `tool.ruff.lint.select`.