### PR TITLE
FEAT: implement `--repo-organization` flag

### DIFF
--- a/src/compwa_policy/.github/release-drafter.yml
+++ b/src/compwa_policy/.github/release-drafter.yml
@@ -36,4 +36,4 @@ template: |
 
   $CHANGES
 
-  _The full changelog as commits can be found [here](https://github.com/ComPWA/<<REPO_NAME>>/compare/$PREVIOUS_TAG...$NEXT_PATCH_VERSION)._
+  _The full changelog as commits can be found [here](https://github.com/<<ORGANIZATION>>/<<REPO_NAME>>/compare/$PREVIOUS_TAG...$NEXT_PATCH_VERSION)._

--- a/src/compwa_policy/check_dev_files/__init__.py
+++ b/src/compwa_policy/check_dev_files/__init__.py
@@ -91,6 +91,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                     args.repo_name,
                     args.repo_title,
                     github_pages=args.github_pages,
+                    organization=args.repo_organization,
                 )
             do(mypy.main)
             do(pyright.main, precommit_config)
@@ -274,6 +275,12 @@ def _create_argparse() -> ArgumentParser:
             " repository on GitHub or GitLab"
         ),
         required=True,
+        type=str,
+    )
+    parser.add_argument(
+        "--repo-organization",
+        default="ComPWA",
+        help="Name of the organization under which the repository lives.",
         type=str,
     )
     parser.add_argument(

--- a/src/compwa_policy/check_dev_files/release_drafter.py
+++ b/src/compwa_policy/check_dev_files/release_drafter.py
@@ -10,14 +10,18 @@ from compwa_policy.utilities import COMPWA_POLICY_DIR, CONFIG_PATH, update_file
 from compwa_policy.utilities.yaml import create_prettier_round_trip_yaml
 
 
-def main(repo_name: str, repo_title: str, github_pages: bool) -> None:
+def main(
+    repo_name: str, repo_title: str, github_pages: bool, organization: str
+) -> None:
     update_file(CONFIG_PATH.release_drafter_workflow)
-    _update_draft(repo_name, repo_title, github_pages)
+    _update_draft(repo_name, repo_title, github_pages, organization)
 
 
-def _update_draft(repo_name: str, repo_title: str, github_pages: bool) -> None:
+def _update_draft(
+    repo_name: str, repo_title: str, github_pages: bool, organization: str
+) -> None:
     yaml = create_prettier_round_trip_yaml()
-    expected = _get_expected_config(repo_name, repo_title, github_pages)
+    expected = _get_expected_config(repo_name, repo_title, github_pages, organization)
     output_path = CONFIG_PATH.release_drafter_config
     if not os.path.exists(output_path):
         yaml.dump(expected, output_path)
@@ -31,7 +35,7 @@ def _update_draft(repo_name: str, repo_title: str, github_pages: bool) -> None:
 
 
 def _get_expected_config(
-    repo_name: str, repo_title: str, github_pages: bool
+    repo_name: str, repo_title: str, github_pages: bool, organization: str
 ) -> dict[str, Any]:
     yaml = create_prettier_round_trip_yaml()
     config = yaml.load(COMPWA_POLICY_DIR / CONFIG_PATH.release_drafter_config)
@@ -41,7 +45,11 @@ def _get_expected_config(
     lines = config[key].split("\n")
     if not os.path.exists(CONFIG_PATH.readthedocs) or github_pages:
         lines = lines[2:]
-    config[key] = "\n".join(lines).replace("<<REPO_NAME>>", repo_name)
+    config[key] = (
+        "\n".join(lines)
+        .replace("<<ORGANIZATION>>", organization)
+        .replace("<<REPO_NAME>>", repo_name)
+    )
     return config
 
 


### PR DESCRIPTION
It is now possible to overwrite the organization with the `--repo-organization` flag for the `check-dev-files` hook.