### PR TITLE
FIX: install `uv` through `pip`

### DIFF
--- a/tests/check_dev_files/readthedocs/extend/.readthedocs-good.yml
+++ b/tests/check_dev_files/readthedocs/extend/.readthedocs-good.yml
@@ -5,9 +5,8 @@ build:
     python: "3.9"
   jobs:
     post_install:
-      - curl -LsSf https://astral.sh/uv/install.sh | sh
-      - |-
-        /home/docs/.cargo/bin/uv pip install --system -e .[doc]
+      - python -m pip install 'uv>=0.2.0'
+      - python -m uv pip install -e .[doc]
       - |
         wget https://julialang-s3.julialang.org/bin/linux/x64/1.9/julia-1.9.2-linux-x86_64.tar.gz
       - tar xzf julia-1.9.2-linux-x86_64.tar.gz

--- a/tests/check_dev_files/readthedocs/overwrite/.readthedocs-good.yml
+++ b/tests/check_dev_files/readthedocs/overwrite/.readthedocs-good.yml
@@ -5,6 +5,5 @@ build:
     python: "3.9"
   jobs:
     post_install:
-      - curl -LsSf https://astral.sh/uv/install.sh | sh
-      - |-
-        /home/docs/.cargo/bin/uv pip install --system -e .[doc]
+      - python -m pip install 'uv>=0.2.0'
+      - python -m uv pip install -e .[doc]


### PR DESCRIPTION
Since `uv` [v0.2.0](https://github.com/astral-sh/uv/releases/tag/0.2.0), `uv` is stricter with `python` discovery. It is now cleaner to run `python -m uv` where `python` comes from the virtual environment you are using.

For this, it is required to install `uv` into the environment instead of having it installed system-wide. This can simply be done with `python -m pip install 'uv>=0.2.0`.

_The new `.readthedocs.yml` has been tested on https://github.com/ComPWA/compwa.github.io/pull/279._