### PR TITLE
FEAT: remove tags from notebook cell if empty

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -19,6 +19,15 @@
   types:
     - jupyter
 
+- id: remove-empty-tags
+  name: Remove empty tags metadata field from Jupyter notebooks
+  description: >
+    Remove the tags metadata field from Jupyter notebooks if there are no tags
+  entry: remove-empty-tags
+  language: python
+  types:
+    - jupyter
+
 - id: set-nb-cells
   name: Add or update default cells in a Jupyter notebook
   description: >

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,6 +87,7 @@ file = "README.md"
 check-dev-files = "compwa_policy.check_dev_files:main"
 colab-toc-visible = "compwa_policy.colab_toc_visible:main"
 fix-nbformat-version = "compwa_policy.fix_nbformat_version:main"
+remove-empty-tags = "compwa_policy.remove_empty_tags:main"
 self-check = "compwa_policy.self_check:main"
 set-nb-cells = "compwa_policy.set_nb_cells:main"
 

--- a/src/compwa_policy/remove_empty_tags.py
+++ b/src/compwa_policy/remove_empty_tags.py
@@ -1,0 +1,45 @@
+"""Remove tags metadata from notebook cells if they are empty."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from typing import Sequence
+
+import nbformat
+
+from compwa_policy.errors import PrecommitError
+from compwa_policy.utilities.executor import Executor
+from compwa_policy.utilities.notebook import load_notebook
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(__doc__)
+    parser.add_argument("filenames", nargs="*", help="Filenames to check.")
+    args = parser.parse_args(argv)
+
+    with Executor(raise_exception=False) as do:
+        for filename in args.filenames:
+            do(_remove_cells, filename)
+    return 1 if do.error_messages else 0
+
+
+def _remove_cells(filename: str) -> None:
+    notebook = load_notebook(filename)
+    updated = False
+    for cell in notebook["cells"]:
+        metadata = cell["metadata"]
+        tags = metadata.get("tags")
+        if tags is None:
+            continue
+        if not tags:
+            metadata.pop("tags")
+            updated = True
+    if updated:
+        nbformat.write(notebook, filename)
+        msg = f'Removed empty tags cell metadata from "{filename}"'
+        raise PrecommitError(msg)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/compwa_policy/set_nb_cells.py
+++ b/src/compwa_policy/set_nb_cells.py
@@ -41,7 +41,6 @@ __CONFIG_CELL_METADATA: dict = {
     "hideOutput": True,
     "hidePrompt": True,
     "jupyter": {"source_hidden": True},
-    "slideshow": {"slide_type": "skip"},
     "tags": ["remove-cell"],
 }
 


### PR DESCRIPTION
Closes #349 

---

Added the following hook:

```yaml
repos:
  - repo: https://github.com/ComPWA/policy
    rev: ""
    hooks:
      - id: remove-empty-tags
```

This removes the `tags` cell metadata field from Jupyter notebooks if it is empty, e.g.:

```yaml
"metadata": {
 "tags": []
}
```

```yaml
"metadata": {}
```

---

Also removing `slideshow` from the configure cell from `set-nb-cells` in order to address https://github.com/ComPWA/qrules/pull/277.