### PR TITLE
FIX: keep `black` in `doc` dependencies

### DIFF
--- a/src/compwa_policy/check_dev_files/ruff.py
+++ b/src/compwa_policy/check_dev_files/ruff.py
@@ -60,11 +60,10 @@ def _remove_black(
         do(
             pyproject.remove_dependency,
             package="black",
-            ignored_sections=["doc", "jupyter", "test"],
+            ignored_sections=["doc", "test"],
         )
         do(remove_badge, r".*https://github\.com/psf.*/black.*")
         do(precommit.remove_hook, "black-jupyter")
-        do(precommit.remove_hook, "black")
         do(precommit.remove_hook, "blacken-docs")
         do(vscode.remove_settings, ["black-formatter.importStrategy"])
 


### PR DESCRIPTION
It should still be possible to install `black` in the `doc` or `test` dependencies, even if `black` is removed from the `jupyter` dependencies since #324.