### PR TITLE
FIX: keep `black` in `doc` dependencies

### DIFF
--- a/src/compwa_policy/check_dev_files/jupyter.py
+++ b/src/compwa_policy/check_dev_files/jupyter.py
@@ -22,7 +22,7 @@ def _update_dev_requirements(no_ruff: bool) -> None:
             "python-lsp-server[rope]",
         }
         if not no_ruff:
-            pyproject.remove_dependency("black")
+            pyproject.remove_dependency("black", ignored_sections=["doc", "test"])
             pyproject.remove_dependency("isort")
             pyproject.remove_dependency("jupyterlab-code-formatter")
             ruff_packages = {


### PR DESCRIPTION
Follow-up to #357 