### PR TITLE
DX: disable Ruff rule `E303` in notebooks

### DIFF
--- a/src/compwa_policy/check_dev_files/ruff.py
+++ b/src/compwa_policy/check_dev_files/ruff.py
@@ -343,6 +343,7 @@ def __update_per_file_ignores(
                 "B018",  # useless-expression
                 "C90",  # complex-structure
                 "D",  # pydocstyle
+                "E303",  # too many blank lines, specific for jupyterlab-lsp
                 "E703",  # useless-semicolon
                 "N806",  # non-lowercase-variable-in-function
                 "N816",  # mixed-case-variable-in-global-scope


### PR DESCRIPTION
[`E303`](https://docs.astral.sh/ruff/rules/too-many-blank-lines/) is a false-positive when using [`jupyterlab-lsp`](https://github.com/jupyter-lsp/jupyterlab-lsp) with Ruff.