### PR TITLE
FEAT: implement `--allowed-cell-metadata` flag

### DIFF
--- a/src/compwa_policy/check_dev_files/__init__.py
+++ b/src/compwa_policy/check_dev_files/__init__.py
@@ -81,7 +81,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             )
         if has_notebooks:
             do(jupyter.main, args.no_ruff)
-        do(nbstripout.main, precommit_config, args.jupyter_slideshow)
+        do(nbstripout.main, precommit_config, _to_list(args.allowed_cell_metadata))
         do(toml.main, precommit_config)  # has to run before pre-commit
         do(prettier.main, precommit_config, args.no_prettierrc)
         if is_python_repo:
@@ -124,6 +124,13 @@ def _create_argparse() -> ArgumentParser:
         help="Allow deprecated CI workflows, such as ci-docs.yml.",
     )
     parser.add_argument(
+        "--allowed-cell-metadata",
+        default="",
+        help="Comma-separated list of allowed metadata in Jupyter notebook cells, e.g. editable,slideshow.",
+        required=False,
+        type=str,
+    )
+    parser.add_argument(
         "--ci-skipped-tests",
         default="",
         help="Avoid running CI test on the following Python versions",
@@ -158,12 +165,6 @@ def _create_argparse() -> ArgumentParser:
         action="store_true",
         default=False,
         help="Host documentation on GitHub Pages",
-    )
-    parser.add_argument(
-        "--jupyter-slideshow",
-        action="store_true",
-        default=False,
-        help="Allow slideshow tags in Jupyter notebooks, for instance for RISE.",
     )
     parser.add_argument(
         "--keep-issue-templates",
@@ -307,6 +308,8 @@ def _to_list(arg: str) -> list[str]:
 
     >>> _to_list("a c , test,b")
     ['a', 'b', 'c', 'test']
+    >>> _to_list("d")
+    ['d']
     >>> _to_list(" ")
     []
     >>> _to_list("")

--- a/src/compwa_policy/check_dev_files/__init__.py
+++ b/src/compwa_policy/check_dev_files/__init__.py
@@ -81,7 +81,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             )
         if has_notebooks:
             do(jupyter.main, args.no_ruff)
-        do(nbstripout.main, precommit_config)
+        do(nbstripout.main, precommit_config, args.jupyter_slideshow)
         do(toml.main, precommit_config)  # has to run before pre-commit
         do(prettier.main, precommit_config, args.no_prettierrc)
         if is_python_repo:
@@ -158,6 +158,12 @@ def _create_argparse() -> ArgumentParser:
         action="store_true",
         default=False,
         help="Host documentation on GitHub Pages",
+    )
+    parser.add_argument(
+        "--jupyter-slideshow",
+        action="store_true",
+        default=False,
+        help="Allow slideshow tags in Jupyter notebooks, for instance for RISE.",
     )
     parser.add_argument(
         "--keep-issue-templates",

--- a/src/compwa_policy/check_dev_files/nbstripout.py
+++ b/src/compwa_policy/check_dev_files/nbstripout.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
     from compwa_policy.utilities.precommit import ModifiablePrecommit
 
 
-def main(precommit: ModifiablePrecommit, slideshow: bool) -> None:
+def main(precommit: ModifiablePrecommit, allowed_cell_metadata: list[str]) -> None:
     repo_url = "https://github.com/kynan/nbstripout"
     repo = precommit.find_repo(repo_url)
     if repo is None:
@@ -23,6 +23,7 @@ def main(precommit: ModifiablePrecommit, slideshow: bool) -> None:
         "cell.metadata.editable",
         "cell.metadata.id",
         "cell.metadata.pycharm",
+        "cell.metadata.slideshow",
         "cell.metadata.user_expressions",
         "metadata.celltoolbar",
         "metadata.colab.name",
@@ -37,8 +38,7 @@ def main(precommit: ModifiablePrecommit, slideshow: bool) -> None:
         "metadata.varInspector",
         "metadata.vscode",
     }
-    if not slideshow:
-        extra_keys_argument.add("cell.metadata.slideshow")
+    extra_keys_argument -= {f"cell.metadata.{key}" for key in allowed_cell_metadata}
     existing_hooks = repo["hooks"]
     if existing_hooks:
         args = existing_hooks[0].get("args", [])

--- a/src/compwa_policy/check_dev_files/nbstripout.py
+++ b/src/compwa_policy/check_dev_files/nbstripout.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
     from compwa_policy.utilities.precommit import ModifiablePrecommit
 
 
-def main(precommit: ModifiablePrecommit) -> None:
+def main(precommit: ModifiablePrecommit, slideshow: bool) -> None:
     repo_url = "https://github.com/kynan/nbstripout"
     repo = precommit.find_repo(repo_url)
     if repo is None:
@@ -23,7 +23,6 @@ def main(precommit: ModifiablePrecommit) -> None:
         "cell.metadata.editable",
         "cell.metadata.id",
         "cell.metadata.pycharm",
-        "cell.metadata.slideshow",
         "cell.metadata.user_expressions",
         "metadata.celltoolbar",
         "metadata.colab.name",
@@ -38,6 +37,8 @@ def main(precommit: ModifiablePrecommit) -> None:
         "metadata.varInspector",
         "metadata.vscode",
     }
+    if not slideshow:
+        extra_keys_argument.add("cell.metadata.slideshow")
     existing_hooks = repo["hooks"]
     if existing_hooks:
         args = existing_hooks[0].get("args", [])


### PR DESCRIPTION
The `check-dev-files` hook now has a `--allowed-cell-metadata` flag that takes a comma-separated list of cell metadata that should not be removed by `nbstripout`, for example `--allowed-cell-metadata=editable,slideshow`.