### PR TITLE
ENH: support `pixi` and `venv` in `.envrc`

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -25,6 +25,7 @@
     "*.ico",
     "*.rst_t",
     ".editorconfig",
+    ".envrc",
     ".gitignore",
     ".gitpod.*",
     ".pre-commit-config.yaml",

--- a/.envrc
+++ b/.envrc
@@ -1,5 +1,4 @@
 if [ -e .venv ]; then
-  uv pip install --editable '.[dev]' --quiet
   source .venv/bin/activate
 elif [ -e venv ]; then
   source venv/bin/activate

--- a/.envrc
+++ b/.envrc
@@ -1,4 +1,5 @@
 if [ -e .venv ]; then
+  uv pip install --editable '.[dev]' --quiet
   source .venv/bin/activate
 elif [ -e venv ]; then
   source venv/bin/activate

--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,7 @@
-layout anaconda
+if [ -e .venv ]; then
+  source .venv/bin/activate
+elif [ -e venv ]; then
+  source venv/bin/activate
+else
+  layout anaconda
+fi

--- a/src/compwa_policy/.template/.cspell.json
+++ b/src/compwa_policy/.template/.cspell.json
@@ -27,6 +27,7 @@
     "*particle*.*ml",
     ".constraints/*.txt",
     ".editorconfig",
+    ".envrc",
     ".gitignore",
     ".gitpod.*",
     ".mypy.ini",

--- a/src/compwa_policy/check_dev_files/direnv.py
+++ b/src/compwa_policy/check_dev_files/direnv.py
@@ -7,7 +7,6 @@ from textwrap import dedent, indent
 from compwa_policy.errors import PrecommitError
 from compwa_policy.utilities import CONFIG_PATH
 from compwa_policy.utilities.pyproject import Pyproject
-from compwa_policy.utilities.python import has_constraint_files
 
 __SCRIPTS = {
     "conda": "layout anaconda",
@@ -16,20 +15,13 @@ __SCRIPTS = {
         eval "$(pixi shell-hook)"
     """,
     "venv": "source venv/bin/activate",
-    "uv-venv": """
-        uv pip install --editable '.[dev]' --quiet
-        source .venv/bin/activate
-    """,
-    "uv-venv-pin": """
-        uv pip sync .constraints/py$(python3 --version | awk '{print $2}' | awk -F. '{print $1"."$2}').txt --quiet
-        uv pip install --editable '.[dev]' --quiet
-    """,
+    "uv-venv": "source .venv/bin/activate",
 }
 
 
 def main() -> None:
     statements: list[tuple[str | None, str]] = [
-        (".venv", __SCRIPTS["uv-venv-pin" if has_constraint_files() else "uv-venv"]),
+        (".venv", __SCRIPTS["uv-venv"]),
         ("venv", __SCRIPTS["venv"]),
     ]
     if (

--- a/src/compwa_policy/check_dev_files/direnv.py
+++ b/src/compwa_policy/check_dev_files/direnv.py
@@ -2,29 +2,58 @@
 
 from __future__ import annotations
 
-from textwrap import dedent
+from textwrap import dedent, indent
 
 from compwa_policy.errors import PrecommitError
 from compwa_policy.utilities import CONFIG_PATH
 from compwa_policy.utilities.pyproject import Pyproject
+from compwa_policy.utilities.python import has_constraint_files
+
+__DIRENV_SCRIPTS = {
+    "conda": "layout anaconda",
+    "pixi": """
+        watch_file pixi.lock
+        eval "$(pixi shell-hook)"
+    """,
+    "venv": "source venv/bin/activate",
+    "uv-venv": "source .venv/bin/activate",
+    "uv-venv-update": """
+        uv pip sync .constraints/py$(python3 --version | awk '{print $2}' | awk -F. '{print $1"."$2}').txt --quiet
+        uv pip install --editable '.[dev]' --quiet
+    """,
+}
 
 
 def main() -> None:
+    uv_venv = __DIRENV_SCRIPTS["uv-venv"]
+    if has_constraint_files():
+        uv_venv += "\n" + dedent(__DIRENV_SCRIPTS["uv-venv-update"])
+    statements: list[tuple[str | None, str]] = [
+        (".venv", uv_venv),
+        ("venv", __DIRENV_SCRIPTS["venv"]),
+    ]
     if (
         CONFIG_PATH.pixi_lock.exists()
         or CONFIG_PATH.pixi_toml.exists()
         or (CONFIG_PATH.pyproject.exists() and Pyproject.load().has_table("tool.pixi"))
     ):
-        _update_envrc("""
-        watch_file pixi.lock
-        eval "$(pixi shell-hook)"
-        """)
-    elif CONFIG_PATH.conda.exists():
-        _update_envrc("layout anaconda")
+        statements.append((".pixi", __DIRENV_SCRIPTS["pixi"]))
+    if CONFIG_PATH.conda.exists():
+        statements.append((None, __DIRENV_SCRIPTS["conda"]))
+    _update_envrc(statements)
 
 
-def _update_envrc(expected: str) -> None:
-    expected = dedent(expected).strip() + "\n"
+def _update_envrc(statements: list[tuple[str | None, str]]) -> None:
+    expected = ""
+    for i, (trigger_path, script) in enumerate(statements):
+        if trigger_path is not None:
+            if_or_elif = "if" if i == 0 else "elif"
+            expected += f"{if_or_elif} [ -e {trigger_path} ]; then\n"
+        else:
+            expected += "else\n"
+        script = dedent(script).strip()
+        expected += indent(script, prefix="  ") + "\n"
+    expected += "fi\n"
     existing = __get_existing_envrc()
     if existing == expected:
         return


### PR DESCRIPTION
Follow-up to #354, now with support for `venv`, `uv venv`, and `pixi` environments.