### PR TITLE
MAINT: clean up Tox configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ dev = [
     "compwa-policy[sty]",
     "compwa-policy[test]",
     "labels",
+    "pydeps",
     "sphinx-autobuild",
     "tox >=1.9", # for skip_install, use_develop
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -63,25 +63,6 @@ passenv = *
 setenv =
   FORCE_COLOR = yes
 
-
-[testenv:docnb]
-allowlist_externals =
-  sphinx-build
-commands =
-  sphinx-build \
-    --builder html \
-    --fail-on-warning \
-    --keep-going \
-    --show-traceback \
-    docs/ docs/_build/html
-description =
-  Build documentation through Sphinx WITH output of Jupyter notebooks
-passenv = *
-setenv =
-  EXECUTE_NB = yes
-  FORCE_COLOR = yes
-  PYTHONHASHSEED = 0
-
 [testenv:linkcheck]
 allowlist_externals =
   sphinx-build

--- a/tox.ini
+++ b/tox.ini
@@ -78,6 +78,8 @@ setenv =
   FORCE_COLOR = yes
 
 [testenv:pydeps]
+allowlist_externals =
+  pydeps
 changedir = src
 commands =
   pydeps compwa_policy \
@@ -85,8 +87,6 @@ commands =
     --exclude *._* \
     --max-bacon=1 \
     --noshow
-deps =
-  pydeps
 description =
   Visualize module dependencies
 passenv = *

--- a/tox.ini
+++ b/tox.ini
@@ -50,10 +50,10 @@ allowlist_externals =
 commands =
   sphinx-autobuild \
     --open-browser \
-    --re-ignore .*.egg-info \
-    --re-ignore .*/__pycache__/.* \
-    --re-ignore docs/_build/.* \
-    --re-ignore docs/api/.* \
+    --re-ignore '.*\.egg-info' \
+    --re-ignore '.*/__pycache__/.*' \
+    --re-ignore 'docs/_build/.*' \
+    --re-ignore 'docs/api/.*' \
     --watch docs \
     --watch src \
     docs/ docs/_build/html
@@ -84,7 +84,7 @@ changedir = src
 commands =
   pydeps compwa_policy \
     -o module_structure.svg \
-    --exclude *._* \
+    --exclude '*._*' \
     --max-bacon=1 \
     --noshow
 description =

--- a/tox.ini
+++ b/tox.ini
@@ -49,22 +49,9 @@ allowlist_externals =
 commands =
   sphinx-autobuild \
     --open-browser \
-    --re-ignore .*/.ipynb_checkpoints/.* \
+    --re-ignore .*.egg-info \
     --re-ignore .*/__pycache__/.* \
-    --re-ignore .*\.gitignore \
-    --re-ignore .*\.tmp \
-    --re-ignore docs/.*\.csv \
-    --re-ignore docs/.*\.gif \
-    --re-ignore docs/.*\.gv \
-    --re-ignore docs/.*\.inv \
-    --re-ignore docs/.*\.json \
-    --re-ignore docs/.*\.pickle \
-    --re-ignore docs/.*\.png \
-    --re-ignore docs/.*\.svg \
-    --re-ignore docs/.*\.yaml \
-    --re-ignore docs/.*\.yml \
     --re-ignore docs/_build/.* \
-    --re-ignore docs/_images/.* \
     --re-ignore docs/api/.* \
     --watch docs \
     --watch src \

--- a/tox.ini
+++ b/tox.ini
@@ -33,9 +33,10 @@ allowlist_externals =
   sphinx-build
 commands =
   sphinx-build \
+    --builder html \
+    --fail-on-warning \
     --keep-going \
-    -TW \
-    -b html \
+    --show-traceback \
     docs/ docs/_build/html
 description =
   Build documentation and API through Sphinx
@@ -68,9 +69,10 @@ allowlist_externals =
   sphinx-build
 commands =
   sphinx-build \
+    --builder html \
+    --fail-on-warning \
     --keep-going \
-    -TW \
-    -b html \
+    --show-traceback \
     docs/ docs/_build/html
 description =
   Build documentation through Sphinx WITH output of Jupyter notebooks
@@ -85,8 +87,8 @@ allowlist_externals =
   sphinx-build
 commands =
   sphinx-build \
-    -T \
-    -b linkcheck \
+    --builder linkcheck \
+    --show-traceback \
     docs/ docs/_build/linkcheck
 description =
   Check external links in the documentation (requires internet connection)
@@ -114,7 +116,7 @@ allowlist_externals =
   pre-commit
 commands =
   mypy src tests # run separately because of potential caching problems
-  pre-commit run {posargs} -a
+  pre-commit run {posargs} --all-files
 description =
   Perform all linting, formatting, and spelling checks
 setenv =

--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,7 @@ allowlist_externals =
   pytest
 commands =
   pytest {posargs} \
-    --cov-fail-under=40 \
+    --cov-fail-under=35 \
     --cov-report=html \
     --cov-report=xml \
     --cov=compwa_policy

--- a/tox.ini
+++ b/tox.ini
@@ -93,12 +93,10 @@ passenv = *
 
 [testenv:sty]
 allowlist_externals =
-  mypy
   pre-commit
 commands =
-  mypy src tests # run separately because of potential caching problems
   pre-commit run {posargs} --all-files
 description =
   Perform all linting, formatting, and spelling checks
 setenv =
-  SKIP = mypy, pyright
+  SKIP = pyright


### PR DESCRIPTION
- Run `mypy` through Tox `sty` job
- Remove redundant `docnb` and `docnblive` job
- Install `pydeps` in developer environment so that it can be run without `tox` as well
- Wrap arguments that contain `*` in single quotation marks