### PR TITLE
BEHAVIOR: sort ComPWA/policy hooks right after `meta`

### DIFF
--- a/src/compwa_policy/check_dev_files/precommit.py
+++ b/src/compwa_policy/check_dev_files/precommit.py
@@ -49,12 +49,14 @@ def _sort_hooks(precommit: ModifiablePrecommit) -> None:
 def __repo_sort_key(repo: Repo) -> tuple[int, str]:
     repo_url = repo["repo"]
     if repo_url == "meta":
-        return 0, "meta"
+        return 0, repo_url
+    if re.match(r"^.*/(ComPWA-)?policy$", repo_url) is not None:
+        return 1, repo_url
     hooks = repo["hooks"]
     if any(hook["id"] == "nbstripout" for hook in hooks):
-        return 1, repo_url
-    if len(hooks) > 1:
         return 2, repo_url
+    if len(hooks) > 1:
+        return 3, repo_url
     hook_id = hooks[0]["id"]
     formatter_hooks = {
         "black",
@@ -65,8 +67,8 @@ def __repo_sort_key(repo: Repo) -> tuple[int, str]:
         "toml-sort",
     }
     if hook_id in formatter_hooks:
-        return 3, hook_id
-    return 4, hook_id
+        return 4, hook_id
+    return 5, hook_id
 
 
 def _update_policy_hook(precommit: ModifiablePrecommit, has_notebooks: bool) -> None:


### PR DESCRIPTION
The ComPWA/policy hooks will now be moved right after `meta` .