### PR TITLE
ENH: allow enforce single-line arrays

### DIFF
--- a/src/compwa_policy/utilities/toml.py
+++ b/src/compwa_policy/utilities/toml.py
@@ -14,12 +14,7 @@ def to_toml_array(items: Iterable[Any], multiline: bool | None = None) -> Array:
     array = tomlkit.array()
     array.extend(items)
     if multiline is None:
-        if len(array) > 1:
-            array.multiline(True)
-        else:
-            array.multiline(False)
-    elif multiline:
-        array.multiline(True)
+        array.multiline(len(array) > 1)
     else:
-        array.multiline(False)
+        array.multiline(multiline)
     return array

--- a/src/compwa_policy/utilities/toml.py
+++ b/src/compwa_policy/utilities/toml.py
@@ -10,10 +10,15 @@ if TYPE_CHECKING:
     from tomlkit.items import Array
 
 
-def to_toml_array(items: Iterable[Any], multiline: bool = False) -> Array:
+def to_toml_array(items: Iterable[Any], multiline: bool | None = None) -> Array:
     array = tomlkit.array()
     array.extend(items)
-    if multiline or len(array) > 1:
+    if multiline is None:
+        if len(array) > 1:
+            array.multiline(True)
+        else:
+            array.multiline(False)
+    elif multiline:
         array.multiline(True)
     else:
         array.multiline(False)

--- a/tests/utilities/test_toml.py
+++ b/tests/utilities/test_toml.py
@@ -27,17 +27,48 @@ def test_to_toml_array_single_item():
     assert _dump(array) == expected.strip()
 
 
-@pytest.mark.parametrize("multiline", [False, True])
-def test_to_toml_array_multiple_items(multiline: bool):
-    lst = [1, 2, 3]
+@pytest.mark.parametrize(
+    ("lst", "multiline", "expected"),
+    [
+        ([0], False, "a = [0]"),
+        (
+            [0],
+            True,
+            """
+            a = [
+                0,
+            ]
+            """,
+        ),
+        ([0], None, "a = [0]"),
+        ([1, 2, 3], False, "a = [1, 2, 3]"),
+        (
+            [1, 2, 3],
+            True,
+            """
+            a = [
+                1,
+                2,
+                3,
+            ]
+            """,
+        ),
+        (
+            [1, 2, 3],
+            None,
+            """
+            a = [
+                1,
+                2,
+                3,
+            ]
+            """,
+        ),
+    ],
+)
+def test_to_toml_array_multiple_items(lst: list[int], multiline: bool, expected: str):
     array = to_toml_array(lst, multiline)
-    expected = dedent("""
-        a = [
-            1,
-            2,
-            3,
-        ]
-    """)
+    expected = dedent(expected).strip()
     assert _dump(array) == expected.strip()
 
 


### PR DESCRIPTION
The `multiline` now defaults to `None`, which is the old behavior: the array is multiline if there is more than one item in the array. Setting `multiline=False` will force the array to be single line.