### PR TITLE
FEAT: create or remove Conda `environment.yml`

### DIFF
--- a/src/compwa_policy/check_dev_files/conda.py
+++ b/src/compwa_policy/check_dev_files/conda.py
@@ -2,41 +2,73 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+import sys
+from typing import NoReturn
 
+from ruamel.yaml.comments import CommentedMap, CommentedSeq
 from ruamel.yaml.scalarstring import PlainScalarString
 
 from compwa_policy.errors import PrecommitError
 from compwa_policy.utilities import CONFIG_PATH
 from compwa_policy.utilities.pyproject import (
+    Pyproject,
     PythonVersion,
     get_build_system,
     get_constraints_file,
 )
 from compwa_policy.utilities.yaml import create_prettier_round_trip_yaml
 
-if TYPE_CHECKING:
-    from ruamel.yaml.comments import CommentedMap, CommentedSeq
+if sys.version_info >= (3, 8):
+    from typing import Literal
+else:
+    from typing_extensions import Literal
+
+PackageManagerChoice = Literal["conda", "pixi", "uv", "venv"]
 
 
-def main(python_version: PythonVersion) -> None:
-    if not CONFIG_PATH.conda.exists():
-        return
+def main(
+    python_version: PythonVersion, package_managers: set[PackageManagerChoice]
+) -> None:
+    if "conda" in package_managers:
+        update_conda_environment(python_version)
+    elif CONFIG_PATH.conda.exists():
+        _remove_conda_configuration(package_managers)
+
+
+def update_conda_environment(python_version: PythonVersion) -> None:
     if get_build_system() is None:
         return
     yaml = create_prettier_round_trip_yaml()
-    conda_env: CommentedMap = yaml.load(CONFIG_PATH.conda)
-    conda_deps: CommentedSeq = conda_env.get("dependencies", [])
-
-    updated = _update_python_version(python_version, conda_deps)
-    updated |= _update_pip_dependencies(python_version, conda_deps)
+    updated = False
+    if CONFIG_PATH.conda.exists():
+        conda_env: CommentedMap = yaml.load(CONFIG_PATH.conda)
+    else:
+        conda_env = __create_conda_environment(python_version)
+        updated = True
+    if "dependencies" not in conda_env:
+        conda_env["dependencies"] = CommentedSeq()
+    conda_deps: CommentedSeq = conda_env["dependencies"]
+    updated |= __update_python_version(python_version, conda_deps)
+    updated |= __update_pip_dependencies(python_version, conda_deps)
     if updated:
         yaml.dump(conda_env, CONFIG_PATH.conda)
-        msg = f"Set the Python version in {CONFIG_PATH.conda} to {python_version}"
+        msg = f"Updated Conda environment for Python {python_version}"
         raise PrecommitError(msg)
 
 
-def _update_python_version(version: PythonVersion, conda_deps: CommentedSeq) -> bool:
+def __create_conda_environment(python_version: PythonVersion) -> CommentedMap:
+    return CommentedMap({
+        "name": Pyproject.load().get_package_name(),
+        "channels": ["defaults"],
+        "dependencies": [
+            f"python=={python_version}.*",
+            "pip",
+            {"pip": ["-e .[dev]"]},
+        ],
+    })
+
+
+def __update_python_version(version: PythonVersion, conda_deps: CommentedSeq) -> bool:
     idx = __find_python_dependency_index(conda_deps)
     expected = f"python=={version}.*"
     if idx is not None and conda_deps[idx] != expected:
@@ -45,7 +77,7 @@ def _update_python_version(version: PythonVersion, conda_deps: CommentedSeq) -> 
     return False
 
 
-def _update_pip_dependencies(version: PythonVersion, conda_deps: CommentedSeq) -> bool:
+def __update_pip_dependencies(version: PythonVersion, conda_deps: CommentedSeq) -> bool:
     pip_deps = __get_pip_dependencies(conda_deps)
     if pip_deps is None:
         return False
@@ -77,3 +109,11 @@ def __get_pip_dependencies(dependencies: CommentedSeq) -> CommentedSeq | None:
         if pip_deps is not None and isinstance(pip_deps, list):
             return pip_deps
     return None
+
+
+def _remove_conda_configuration(
+    package_managers: set[PackageManagerChoice],
+) -> NoReturn:
+    CONFIG_PATH.conda.unlink()
+    msg = f"Removed Conda configuration, because --package-managers={','.join(sorted(package_managers))}"
+    raise PrecommitError(msg)

--- a/src/compwa_policy/check_dev_files/precommit.py
+++ b/src/compwa_policy/check_dev_files/precommit.py
@@ -7,7 +7,6 @@ from pathlib import Path
 from typing import TYPE_CHECKING, cast
 
 from ruamel.yaml.comments import CommentedMap
-from ruamel.yaml.scalarstring import DoubleQuotedScalarString
 
 from compwa_policy.errors import PrecommitError
 from compwa_policy.utilities.executor import Executor
@@ -153,7 +152,7 @@ def _update_conda_environment(precommit: Precommit) -> None:
     key = "PRETTIER_LEGACY_CLI"
     if __has_prettier_v4alpha(precommit.document):
         if key not in variables:
-            variables[key] = DoubleQuotedScalarString("1")
+            variables[key] = 1
             conda_env["variables"] = variables
             yaml.dump(conda_env, path)
             msg = f"Set {key} environment variable in {path}"


### PR DESCRIPTION
- Added a `--package-managers` flag that allows selecting which package managers to use for the developer environment. For now it only removes the `environment.yml` if `conda` is not listed in the `--package-managers`.
- The [`environment.yml`](https://conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html#creating-an-environment-from-an-environment-yml-file) configuration file for Conda is now automatically created if not available.