### PR TITLE
BREAK: remove GitPod configuration by default

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,7 +50,6 @@ repos:
         args:
           - --allow-labels
           - --dependabot=update
-          - --no-gitpod
           - --no-notebooks
           - --no-prettierrc
           - --no-pypi

--- a/src/compwa_policy/check_dev_files/__init__.py
+++ b/src/compwa_policy/check_dev_files/__init__.py
@@ -52,6 +52,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     if not args.repo_title:
         args.repo_title = args.repo_name
     has_notebooks = not args.no_notebooks
+    use_gitpod = args.gitpod
     dev_python_version = __get_python_version(args.dev_python_version)
     package_managers: set[conda.PackageManagerChoice] = set(
         _to_list(args.package_managers)  # type: ignore[arg-type]
@@ -120,7 +121,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         do(readthedocs.main, dev_python_version)
         do(remove_deprecated_tools, precommit_config, args.keep_issue_templates)
         do(vscode.main, has_notebooks)
-        do(gitpod.main, args.no_gitpod, dev_python_version)
+        do(gitpod.main, use_gitpod, dev_python_version)
         do(precommit.main, precommit_config, has_notebooks)
         do(tox.main, has_notebooks)
         do(cspell.main, precommit_config, args.no_cspell_update)
@@ -177,6 +178,12 @@ def _create_argparse() -> ArgumentParser:
         action="store_true",
         default=False,
         help="Host documentation on GitHub Pages",
+    )
+    parser.add_argument(
+        "--gitpod",
+        action="store_true",
+        default=False,
+        help="Create a GitPod config file",
     )
     parser.add_argument(
         "--keep-issue-templates",

--- a/src/compwa_policy/check_dev_files/__init__.py
+++ b/src/compwa_policy/check_dev_files/__init__.py
@@ -231,12 +231,6 @@ def _create_argparse() -> ArgumentParser:
         help="Skip check that concern config files for Python projects.",
     )
     parser.add_argument(
-        "--no-gitpod",
-        action="store_true",
-        default=False,
-        help="Do not create a GitPod config file",
-    )
-    parser.add_argument(
         "--no-prettierrc",
         action="store_true",
         default=False,

--- a/src/compwa_policy/check_dev_files/gitpod.py
+++ b/src/compwa_policy/check_dev_files/gitpod.py
@@ -16,11 +16,11 @@ from compwa_policy.utilities.readme import add_badge, remove_badge
 from compwa_policy.utilities.yaml import write_yaml
 
 
-def main(no_gitpod: bool, python_version: PythonVersion) -> None:
-    if no_gitpod:
+def main(use_gitpod: bool, python_version: PythonVersion) -> None:
+    if not use_gitpod:
         if CONFIG_PATH.gitpod.exists():
             os.remove(CONFIG_PATH.gitpod)
-            msg = f"Removed {CONFIG_PATH.gitpod} as requested by --no-gitpod"
+            msg = f"Removed {CONFIG_PATH.gitpod} (add back by setting --gitpod)"
             raise PrecommitError(msg)
         remove_badge(r"\[!\[GitPod\]\(https://img.shields.io/badge/gitpod")
         return


### PR DESCRIPTION
The GitPod configuration can be added back by setting `--gitpod` with the `check-dev-files` hook.