### PR TITLE
FIX: do not sort table keys with `toml-sort`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -342,6 +342,5 @@ sort_first = [
     "tool.setuptools",
     "tool.setuptools_scm",
 ]
-sort_table_keys = true
 spaces_indent_inline_array = 4
 trailing_comma_inline_array = true

--- a/src/compwa_policy/check_dev_files/toml.py
+++ b/src/compwa_policy/check_dev_files/toml.py
@@ -55,7 +55,6 @@ def _update_tomlsort_config() -> None:
         ignore_case=True,
         in_place=True,
         sort_first=to_toml_array(sort_first),
-        sort_table_keys=True,
         spaces_indent_inline_array=4,
         trailing_comma_inline_array=True,
     )


### PR DESCRIPTION
Disable [`--sort-table-keys`](https://pypi.org/project/toml-sort) in [`toml-sort`](https://pypi.org/project/toml-sort). It is conflicting with Taplo v0.9.