### PR TITLE
FEAT: move `import`s to top in notebooks

### DIFF
--- a/src/compwa_policy/check_dev_files/__init__.py
+++ b/src/compwa_policy/check_dev_files/__init__.py
@@ -111,7 +111,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             do(pytest.main)
             do(pyupgrade.main, precommit_config, args.no_ruff)
             if not args.no_ruff:
-                do(ruff.main, precommit_config, has_notebooks)
+                do(ruff.main, precommit_config, has_notebooks, args.imports_on_top)
         if args.pin_requirements != "no":
             do(
                 update_pip_constraints.main,
@@ -196,6 +196,12 @@ def _create_argparse() -> ArgumentParser:
         help="Do not overwrite the PR linting workflow",
         action="store_true",
         default=False,
+    )
+    parser.add_argument(
+        "--imports-on-top",
+        action="store_true",
+        default=False,
+        help="Sort notebook imports on the top",
     )
     parser.add_argument(
         "--outsource-pixi-to-tox",

--- a/src/compwa_policy/check_dev_files/__init__.py
+++ b/src/compwa_policy/check_dev_files/__init__.py
@@ -201,7 +201,7 @@ def _create_argparse() -> ArgumentParser:
         "--outsource-pixi-to-tox",
         action="store_true",
         default=False,
-        help="Run ",
+        help="Run tox command through pixi",
     )
     parser.add_argument(
         "--no-cspell-update",

--- a/src/compwa_policy/check_dev_files/ruff.py
+++ b/src/compwa_policy/check_dev_files/ruff.py
@@ -97,11 +97,11 @@ def _remove_isort(
 ) -> None:
     with Executor() as do:
         do(__remove_nbqa_option, pyproject, "black")
-        do(__remove_nbqa_option, pyproject, "isort")
-        do(__remove_tool_table, pyproject, "isort")
         do(vscode.remove_extension_recommendation, "ms-python.isort", unwanted=True)
         do(precommit.remove_hook, "isort")
         if not imports_on_top:
+            do(__remove_tool_table, pyproject, "isort")
+            do(__remove_nbqa_option, pyproject, "isort")
             do(precommit.remove_hook, "nbqa-isort")
         do(vscode.remove_settings, ["isort.check", "isort.importStrategy"])
         do(remove_badge, r".*https://img\.shields\.io/badge/%20imports\-isort")


### PR DESCRIPTION
This is a temporary fix for https://github.com/ComPWA/compwa.github.io/pull/270 and related issues/PRs. It uses `isort` to move all imports to the top of a notebook and then Ruff will do the rest of the sorting.

In practice, by adding the `--imports-on-top` flag to the `check-dev-files hook, the following pre-commit hook will be added:

```yaml
  - repo: https://github.com/nbQA-dev/nbQA
    rev: 1.9.0
    hooks:
      - id: nbqa-isort
        args: [--float-to-top]
        # exclude: >
        #   (?x)^(
        #     my-notebook1\.ipynb|
        #     my-notebook2\.ipynb
        #   )$
```

---

_Update:_ You'll have to add the following to your `pyproject.toml` in order to be compatible with Ruff:

```toml
[tool.isort]
profile = "black"
```