### PR TITLE
DX: remove `python.analysis.typeCheckingMode` setting

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -55,7 +55,6 @@
   "notebook.formatOnSave.enabled": true,
   "python.analysis.autoImportCompletions": false,
   "python.analysis.inlayHints.pytestParameters": true,
-  "python.analysis.typeCheckingMode": "strict",
   "python.terminal.activateEnvironment": false,
   "python.testing.pytestArgs": ["--color=no", "--no-cov", "-vv"],
   "python.testing.pytestEnabled": true,

--- a/src/compwa_policy/check_dev_files/vscode.py
+++ b/src/compwa_policy/check_dev_files/vscode.py
@@ -90,6 +90,7 @@ def _remove_outdated_settings() -> None:
         "githubPullRequests.telemetry.enabled",
         "gitlens.advanced.telemetry.enabled",
         "python.analysis.diagnosticMode",
+        "python.analysis.typeCheckingMode",
         "python.formatting.provider",
         "python.linting.banditEnabled",
         "python.linting.enabled",


### PR DESCRIPTION
The `python.analysis.typeCheckingMode` setting in VS Code is not needed if there is a `pyright` conviguration in `pyproject.toml`.