### PR TITLE
ENH: clean up classifiers and workflows if `--no-pypi`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,19 +7,6 @@ requires = [
 
 [project]
 authors = [{name = "Common Partial Wave Analysis", email = "compwa-admin@ep1.rub.de"}]
-classifiers = [
-    "Development Status :: 3 - Alpha",
-    "Intended Audience :: Developers",
-    "License :: OSI Approved :: BSD License",
-    "Natural Language :: English",
-    "Operating System :: OS Independent",
-    "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11",
-    "Programming Language :: Python :: 3.12",
-    "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python",
-    "Typing :: Typed",
-]
 dependencies = [
     "PyYAML",
     "attrs >=20.1.0", # https://www.attrs.org/changelog.html#id82

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
     "html2text",
     "ini2toml",
     "nbformat",
+    "packaging",
     "pathspec",
     "pip-tools",
     "rtoml", # fast, read-only parsing

--- a/src/compwa_policy/check_dev_files/__init__.py
+++ b/src/compwa_policy/check_dev_files/__init__.py
@@ -26,6 +26,7 @@ from compwa_policy.check_dev_files import (
     pixi,
     precommit,
     prettier,
+    pyproject,
     pyright,
     pytest,
     pyupgrade,
@@ -111,6 +112,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                     organization=args.repo_organization,
                 )
             do(mypy.main)
+            do(pyproject.main, args.excluded_python_versions)
             do(pyright.main, precommit_config)
             do(pytest.main)
             do(pyupgrade.main, precommit_config, args.no_ruff)
@@ -171,10 +173,14 @@ def _create_argparse() -> ArgumentParser:
     parser.add_argument(
         "--doc-apt-packages",
         default="",
-        help=(
-            "Comma- or space-separated list of APT packages that are required to build"
-            " documentation"
-        ),
+        help="Comma- or space-separated list of APT packages that are required to build documentation",
+        required=False,
+        type=str,
+    )
+    parser.add_argument(
+        "--excluded-python-versions",
+        default="",
+        help="Comma- or space-separated list of Python versions you do NOT want to support",
         required=False,
         type=str,
     )

--- a/src/compwa_policy/check_dev_files/__init__.py
+++ b/src/compwa_policy/check_dev_files/__init__.py
@@ -112,7 +112,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                     organization=args.repo_organization,
                 )
             do(mypy.main)
-            do(pyproject.main, args.excluded_python_versions)
+            do(pyproject.main, args.excluded_python_versions, no_pypi=args.no_pypi)
             do(pyright.main, precommit_config)
             do(pytest.main)
             do(pyupgrade.main, precommit_config, args.no_ruff)

--- a/src/compwa_policy/check_dev_files/cspell.py
+++ b/src/compwa_policy/check_dev_files/cspell.py
@@ -225,4 +225,6 @@ def __sort_section(content: Iterable[Any], section_name: str) -> list[str]:
         return sorted(content, key=sort_key)
     if section_name == "ignoreWords":
         return sorted(content)
-    return sorted(content, key=str.casefold)
+    str_content = [s for s in content if isinstance(s, str)]
+    other_content = [s for s in content if not isinstance(s, str)]
+    return sorted(str_content, key=str.casefold) + other_content

--- a/src/compwa_policy/check_dev_files/pyproject.py
+++ b/src/compwa_policy/check_dev_files/pyproject.py
@@ -1,0 +1,68 @@
+"""Perform updates on the :file:`pyproject.toml` file."""
+
+from __future__ import annotations
+
+from packaging.specifiers import SpecifierSet
+from packaging.version import Version
+
+from compwa_policy.utilities import CONFIG_PATH
+from compwa_policy.utilities.pyproject import ModifiablePyproject
+from compwa_policy.utilities.pyproject.getters import PYTHON_VERSIONS
+from compwa_policy.utilities.toml import to_toml_array
+
+
+def main(excluded_python_versions: set[str]) -> None:
+    if not CONFIG_PATH.pyproject.exists():
+        return
+    with ModifiablePyproject.load() as pyproject:
+        _update_python_version_classifiers(pyproject, excluded_python_versions)
+
+
+def _update_python_version_classifiers(
+    pyproject: ModifiablePyproject, excluded_python_versions: set[str]
+) -> None:
+    if not pyproject.has_table("project"):
+        return
+    project = pyproject.get_table("project")
+    requires_python = project.get("requires-python")
+    if requires_python is None:
+        return
+    prefix = "Programming Language :: Python :: "
+    expected_version_classifiers = [
+        f"{prefix}{v}"
+        for v in __get_allowed_versions(requires_python, excluded_python_versions)
+    ]
+    existing_classifiers = __get_existing_classifiers(pyproject)
+    merged_classifiers = {
+        classifier
+        for classifier in existing_classifiers
+        if not classifier.startswith(f"{prefix}3.")
+    } | set(expected_version_classifiers)
+    if set(existing_classifiers) != merged_classifiers:
+        project["classifiers"] = to_toml_array(sorted(merged_classifiers))
+        pyproject.changelog.append("Updated Python version classifiers")
+
+
+def __get_existing_classifiers(pyproject: ModifiablePyproject) -> list[str]:
+    if not pyproject.has_table("project"):
+        return []
+    project = pyproject.get_table("project")
+    return project.get("classifiers", [])
+
+
+def __get_allowed_versions(
+    version_range: str, exclude: set[str] | None = None
+) -> list[str]:
+    """Get a list of allowed versions from a version range specifier.
+
+    >>> __get_allowed_versions(">=3.9,<3.13")
+    ['3.10', '3.11', '3.12', '3.9']
+    >>> __get_allowed_versions(">=3.9", exclude={"3.9"})
+    ['3.10', '3.11', '3.12']
+    """
+    specifier = SpecifierSet(version_range)
+    versions_to_check = [Version(v) for v in sorted(PYTHON_VERSIONS)]
+    allowed_versions = [str(v) for v in versions_to_check if v in specifier]
+    if exclude is not None:
+        return [v for v in allowed_versions if v not in exclude]
+    return allowed_versions

--- a/src/compwa_policy/check_dev_files/pyproject.py
+++ b/src/compwa_policy/check_dev_files/pyproject.py
@@ -2,45 +2,48 @@
 
 from __future__ import annotations
 
-from packaging.specifiers import SpecifierSet
-from packaging.version import Version
-
 from compwa_policy.utilities import CONFIG_PATH
 from compwa_policy.utilities.pyproject import ModifiablePyproject
-from compwa_policy.utilities.pyproject.getters import PYTHON_VERSIONS
+from compwa_policy.utilities.pyproject.getters import _get_allowed_versions
 from compwa_policy.utilities.toml import to_toml_array
 
 
-def main(excluded_python_versions: set[str]) -> None:
+def main(excluded_python_versions: set[str], no_pypi: bool) -> None:
     if not CONFIG_PATH.pyproject.exists():
         return
     with ModifiablePyproject.load() as pyproject:
-        _update_python_version_classifiers(pyproject, excluded_python_versions)
+        _update_python_version_classifiers(pyproject, excluded_python_versions, no_pypi)
 
 
 def _update_python_version_classifiers(
-    pyproject: ModifiablePyproject, excluded_python_versions: set[str]
+    pyproject: ModifiablePyproject, excluded_python_versions: set[str], no_pypi: bool
 ) -> None:
     if not pyproject.has_table("project"):
         return
     project = pyproject.get_table("project")
-    requires_python = project.get("requires-python")
-    if requires_python is None:
-        return
-    prefix = "Programming Language :: Python :: "
-    expected_version_classifiers = [
-        f"{prefix}{v}"
-        for v in __get_allowed_versions(requires_python, excluded_python_versions)
-    ]
-    existing_classifiers = __get_existing_classifiers(pyproject)
-    merged_classifiers = {
-        classifier
-        for classifier in existing_classifiers
-        if not classifier.startswith(f"{prefix}3.")
-    } | set(expected_version_classifiers)
-    if set(existing_classifiers) != merged_classifiers:
-        project["classifiers"] = to_toml_array(sorted(merged_classifiers))
-        pyproject.changelog.append("Updated Python version classifiers")
+    if no_pypi:
+        if "classifiers" in project:
+            del project["classifiers"]
+            msg = "Removed Python version classifiers because of --no-pypi"
+            pyproject.changelog.append(msg)
+    else:
+        requires_python = project.get("requires-python")
+        if requires_python is None:
+            return
+        prefix = "Programming Language :: Python :: "
+        expected_version_classifiers = [
+            f"{prefix}{v}"
+            for v in _get_allowed_versions(requires_python, excluded_python_versions)
+        ]
+        existing_classifiers = __get_existing_classifiers(pyproject)
+        merged_classifiers = {
+            classifier
+            for classifier in existing_classifiers
+            if not classifier.startswith(f"{prefix}3.")
+        } | set(expected_version_classifiers)
+        if set(existing_classifiers) != merged_classifiers:
+            project["classifiers"] = to_toml_array(sorted(merged_classifiers))
+            pyproject.changelog.append("Updated Python version classifiers")
 
 
 def __get_existing_classifiers(pyproject: ModifiablePyproject) -> list[str]:
@@ -48,21 +51,3 @@ def __get_existing_classifiers(pyproject: ModifiablePyproject) -> list[str]:
         return []
     project = pyproject.get_table("project")
     return project.get("classifiers", [])
-
-
-def __get_allowed_versions(
-    version_range: str, exclude: set[str] | None = None
-) -> list[str]:
-    """Get a list of allowed versions from a version range specifier.
-
-    >>> __get_allowed_versions(">=3.9,<3.13")
-    ['3.10', '3.11', '3.12', '3.9']
-    >>> __get_allowed_versions(">=3.9", exclude={"3.9"})
-    ['3.10', '3.11', '3.12']
-    """
-    specifier = SpecifierSet(version_range)
-    versions_to_check = [Version(v) for v in sorted(PYTHON_VERSIONS)]
-    allowed_versions = [str(v) for v in versions_to_check if v in specifier]
-    if exclude is not None:
-        return [v for v in allowed_versions if v not in exclude]
-    return allowed_versions

--- a/src/compwa_policy/utilities/precommit/setters.py
+++ b/src/compwa_policy/utilities/precommit/setters.py
@@ -66,10 +66,11 @@ def update_single_hook_precommit_repo(
         idx = _determine_expected_repo_index(precommit.document, hook_id)
         repos_yaml = cast(CommentedSeq, repos)
         repos_yaml.insert(idx, expected_yaml)
-        repos_yaml.yaml_set_comment_before_after_key(
-            idx if idx + 1 == len(repos) else idx + 1,
-            before="\n",
-        )
+        if isinstance(repos_yaml, CommentedSeq):
+            repos_yaml.yaml_set_comment_before_after_key(
+                idx if idx + 1 == len(repos) else idx + 1,
+                before="\n",
+            )
         msg = f"Added {hook_id} hook to {CONFIG_PATH.precommit}."
         precommit.changelog.append(msg)
     if idx_and_repo is None:

--- a/src/compwa_policy/utilities/precommit/setters.py
+++ b/src/compwa_policy/utilities/precommit/setters.py
@@ -126,7 +126,7 @@ def update_precommit_hook(
         hook_idx = __determine_expected_hook_idx(hooks, expected_hook["id"])
         hooks.insert(hook_idx, expected_hook)
         if hook_idx == len(hooks) - 1:
-            repos = cast(CommentedMap, precommit.document["repos"])
+            repos = cast(CommentedMap, precommit.document["repos"][hook_idx])
             repos.yaml_set_comment_before_after_key(repo_idx + 1, before="\n")
         msg = f"Added {expected_hook['id']!r} to {repo_name} pre-commit config"
         precommit.changelog.append(msg)

--- a/src/compwa_policy/utilities/pyproject/getters.py
+++ b/src/compwa_policy/utilities/pyproject/getters.py
@@ -5,6 +5,9 @@ from __future__ import annotations
 from textwrap import dedent
 from typing import TYPE_CHECKING, Any, Literal, overload
 
+from packaging.specifiers import SpecifierSet
+from packaging.version import Version
+
 from compwa_policy.errors import PrecommitError
 
 if TYPE_CHECKING:
@@ -84,7 +87,11 @@ def get_supported_python_versions(pyproject: PyprojectTOML) -> list[PythonVersio
         return []
     project_table = get_sub_table(pyproject, "project")
     classifiers = project_table.get("classifiers", [])
-    python_versions = _extract_python_versions(classifiers)
+    if classifiers:
+        python_versions = _extract_python_versions(classifiers)
+    else:
+        requires_python: str = project_table.get("requires-python", "")
+        python_versions = _get_allowed_versions(requires_python)
     if not python_versions:
         msg = "Could not determine Python version classifiers of this package"
         raise PrecommitError(msg)
@@ -110,6 +117,24 @@ def _extract_python_versions(classifiers: list[str]) -> list[PythonVersion]:
     version_classifiers = [s for s in classifiers if s.startswith(identifier)]
     prefix = identifier[:-2]
     return [s.replace(prefix, "") for s in version_classifiers]  # type: ignore[misc]
+
+
+def _get_allowed_versions(
+    version_range: str, exclude: set[str] | None = None
+) -> list[PythonVersion]:
+    """Get a list of allowed versions from a version range specifier.
+
+    >>> _get_allowed_versions(">=3.9,<3.13")
+    ['3.10', '3.11', '3.12', '3.9']
+    >>> _get_allowed_versions(">=3.9", exclude={"3.9"})
+    ['3.10', '3.11', '3.12']
+    """
+    specifier = SpecifierSet(version_range)
+    versions_to_check = [Version(v) for v in sorted(PYTHON_VERSIONS)]
+    allowed_versions = [str(v) for v in versions_to_check if v in specifier]
+    if exclude is not None:
+        allowed_versions = [v for v in allowed_versions if v not in exclude]
+    return allowed_versions  # type:ignore[return-value]
 
 
 def get_sub_table(config: Mapping[str, Any], dotted_header: str) -> Mapping[str, Any]:

--- a/src/compwa_policy/utilities/pyproject/getters.py
+++ b/src/compwa_policy/utilities/pyproject/getters.py
@@ -14,6 +14,7 @@ if TYPE_CHECKING:
 
 
 PythonVersion = Literal["3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+PYTHON_VERSIONS = set(PythonVersion.__args__)  # type:ignore[attr-defined]
 
 
 @overload


### PR DESCRIPTION
This PR fixes a few bugs if `--no-pypi` is specified:
- The `pypi` publish step is removed from the `cd.yml` workflow.
- [`classsifiers`](https://pypi.org/classifiers) are removed from `pyproject.toml`, because they are only used by PyPI.
- Some autofixes for `.pre-commit-config.yaml` are now fixed.