### PR TITLE
BREAK: remove `--no-prettierrc` flag

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -99,7 +99,6 @@
     "precommit",
     "prereleased",
     "prettierignore",
-    "prettierrc",
     "pyenv",
     "pyright",
     "pyrightconfig",

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,7 +51,6 @@ repos:
         args:
           - --allow-labels
           - --dependabot=update
-          - --no-prettierrc
           - --no-pypi
           - --repo-name=policy
           - --repo-title=ComPWA repository policy

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -71,7 +71,6 @@
     "src/compwa_policy/.github/workflows/pr-linting.yml": true,
     "src/compwa_policy/.github/workflows/release-drafter.yml": true,
     "src/compwa_policy/.template/.gitpod.yml": true,
-    "src/compwa_policy/.template/.prettierrc": true,
     "tests/**/.pre-commit-config*.yaml": true,
     "tests/**/pyproject*.toml": true,
     "tests/**/pyrightconfig*.json": true

--- a/src/compwa_policy/.template/.cspell.json
+++ b/src/compwa_policy/.template/.cspell.json
@@ -1,6 +1,11 @@
 {
   "version": "0.2",
-  "enableFiletypes": ["git-commit", "github-actions-workflow", "julia", "jupyter"],
+  "enableFiletypes": [
+    "git-commit",
+    "github-actions-workflow",
+    "julia",
+    "jupyter"
+  ],
   "flagWords": [
     "analyse",
     "colour",
@@ -104,7 +109,6 @@
     "precommit",
     "prereleased",
     "prettierignore",
-    "prettierrc",
     "pyright",
     "pyupgrade",
     "redeboer",

--- a/src/compwa_policy/.template/.prettierrc
+++ b/src/compwa_policy/.template/.prettierrc
@@ -1,1 +1,0 @@
-printWidth: 88

--- a/src/compwa_policy/check_dev_files/__init__.py
+++ b/src/compwa_policy/check_dev_files/__init__.py
@@ -103,7 +103,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         )
         do(direnv.main, package_manager, environment_variables)
         do(toml.main, precommit_config)  # has to run before pre-commit
-        do(prettier.main, precommit_config, args.no_prettierrc)
+        do(prettier.main, precommit_config)
         if is_python_repo:
             if args.no_ruff:
                 do(black.main, precommit_config, has_notebooks)
@@ -252,12 +252,6 @@ def _create_argparse() -> ArgumentParser:
         action="store_true",
         default=False,
         help="Skip check that concern config files for Python projects.",
-    )
-    parser.add_argument(
-        "--no-prettierrc",
-        action="store_true",
-        default=False,
-        help="Remove the prettierrc, so that Prettier's default values are used.",
     )
     parser.add_argument(
         "--allow-labels",

--- a/src/compwa_policy/utilities/__init__.py
+++ b/src/compwa_policy/utilities/__init__.py
@@ -32,7 +32,6 @@ class _ConfigFilePaths(NamedTuple):
     pixi_toml: Path = Path("pixi.toml")
     precommit: Path = Path(".pre-commit-config.yaml")
     prettier_ignore: Path = Path(".prettierignore")
-    prettier: Path = Path(".prettierrc")
     pyproject: Path = Path("pyproject.toml")
     pytest_ini: Path = Path("pytest.ini")
     readme: Path = Path("README.md")


### PR DESCRIPTION
Removed the check that updates or removes the [`.prettierrc`](https://prettier.io/docs/en/configuration.html) file.