### PR TITLE
BEHAVIOR: update lock files by default

### DIFF
--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -1,4 +1,4 @@
-name: Update lock files
+name: Update
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -11,7 +11,6 @@ on:
       - main
       - epic/*
     paths:
-      - .constraints/py3.*.txt
       - .pre-commit-config.yaml
   workflow_dispatch:
 

--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -1,0 +1,22 @@
+name: Update lock files
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: |-
+    ${{ github.ref != format('refs/heads/{0}', github.event.repository.default_branch) }}
+
+on:
+  pull_request:
+    branches:
+      - main
+      - epic/*
+    paths:
+      - .constraints/py3.*.txt
+      - .pre-commit-config.yaml
+  workflow_dispatch:
+
+jobs:
+  lock:
+    uses: ComPWA/actions/.github/workflows/lock.yml@v2
+    secrets:
+      token: ${{ secrets.PAT }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -104,6 +104,6 @@ repos:
           - python
 
   - repo: https://github.com/ComPWA/pyright-pre-commit
-    rev: v1.1.384
+    rev: v1.1.383
     hooks:
       - id: pyright

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -104,6 +104,6 @@ repos:
           - python
 
   - repo: https://github.com/ComPWA/pyright-pre-commit
-    rev: v1.1.383
+    rev: v1.1.384
     hooks:
       - id: pyright

--- a/src/compwa_policy/.github/workflows/lock.yml
+++ b/src/compwa_policy/.github/workflows/lock.yml
@@ -1,4 +1,4 @@
-name: Update lock files
+name: Update
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/src/compwa_policy/check_dev_files/__init__.py
+++ b/src/compwa_policy/check_dev_files/__init__.py
@@ -306,7 +306,7 @@ def _create_argparse() -> ArgumentParser:
     parser.add_argument(
         "--update-lock-files",
         choices=update_lock.Frequency.__args__,  # type:ignore[attr-defined]
-        default="no",
+        default="outsource",
         help=(
             "Add a workflow to update lock files, like uv.lock, .pre-commit-config.yml, "
             "and pip .constraints/ files. The argument is the frequency of the cron job"


### PR DESCRIPTION
The default argument for `--update-lock-files` has been set to `outsource`, which means that it waits for [pre-commit.ci](https://pre-commit.ci) to create a PR.