### PR TITLE
FIX: add `--no-dev` flag if using `--group` flag

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ cd policy
 Now it's simply a matter of creating and activating the [virtual environment](https://docs.astral.sh/uv/pip/environments) with [`uv sync`](https://docs.astral.sh/uv/reference/cli/#uv-sync). The dependencies for the project are 'pinned' in each commit through the [`uv.lock` file](https://docs.astral.sh/uv/concepts/projects/#project-lockfile).
 
 ```shell
-uv sync
+uv sync --all-extras
 source .venv/bin/activate
 ```
 

--- a/src/compwa_policy/.template/CONTRIBUTING.md.jinja
+++ b/src/compwa_policy/.template/CONTRIBUTING.md.jinja
@@ -15,7 +15,7 @@ cd {{ REPO_NAME }}
 Now it's simply a matter of creating and activating the [virtual environment](https://docs.astral.sh/uv/pip/environments) with [`uv sync`](https://docs.astral.sh/uv/reference/cli/#uv-sync). The dependencies for the project are 'pinned' in each commit through the [`uv.lock` file](https://docs.astral.sh/uv/concepts/projects/#project-lockfile).
 
 ```shell
-uv sync
+uv sync --all-extras
 source .venv/bin/activate
 ```
 

--- a/src/compwa_policy/check_dev_files/binder.py
+++ b/src/compwa_policy/check_dev_files/binder.py
@@ -88,6 +88,7 @@ def __get_post_builder_for_pixi_with_uv() -> str:
     for groups in __get_notebook_groups():
         expected_content += f"\n  --group {groups} \\"
     expected_content += dedent(R"""
+          --no-dev \
           > requirements.txt
         uv pip install \
           --requirement requirements.txt \
@@ -127,6 +128,7 @@ def __get_post_builder_for_uv() -> str:
     for group in __get_notebook_groups():
         expected_content += f"\n  --group {group} \\"
     expected_content += dedent(R"""
+          --no-dev \
           > requirements.txt
         uv pip install \
           --requirement requirements.txt \

--- a/src/compwa_policy/check_dev_files/readthedocs.py
+++ b/src/compwa_policy/check_dev_files/readthedocs.py
@@ -180,6 +180,7 @@ def _update_build_step_for_pixi(config: ReadTheDocs) -> None:
           uv run \
             --group doc \
             --locked \
+            --no-dev \
             --with tox \
             tox -e doc
         mkdir -p $READTHEDOCS_OUTPUT
@@ -196,12 +197,19 @@ def _update_build_step_for_uv(config: ReadTheDocs) -> None:
     new_command = "export UV_LINK_MODE=copy"
     if "uv.lock" in set(git_ls_files(untracked=True)):
         new_command += dedent(R"""
-            uv run --group doc --locked --with tox \
+            uv run \
+              --group doc \
+              --locked \
+              --no-dev \
+              --with tox \
               tox -e doc
         """)
     else:
         new_command += dedent(R"""
-            uv run --group doc --with tox \
+            uv run \
+              --group doc \
+              --no-dev \
+              --with tox \
               tox -e doc
         """)
     new_command += dedent(R"""
@@ -271,7 +279,7 @@ def __get_install_steps(
     pip_install = "python -m uv pip install"
     constraints_file = get_constraints_file(python_version)
     if package_manager == "uv":
-        install_statement = "python -m uv sync --group=doc"
+        install_statement = "python -m uv sync --group=doc --no-dev"
     elif constraints_file is None:
         install_statement = f"{pip_install} -e .[doc]"
     else:


### PR DESCRIPTION
`uv run` and `uv sync` install all dependency groups by default. To limit the dependencies per job, this adds the [`--no-dev` flag](https://docs.astral.sh/uv/reference/cli/#uv-run).

_See also https://github.com/ComPWA/actions/pull/115_