### PR TITLE
ENH: respect `.gitignore` with cSpell

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -1,5 +1,4 @@
 {
-  "version": "0.2",
   "enableFiletypes": [
     "git-commit",
     "github-actions-workflow",
@@ -37,27 +36,6 @@
     "pyproject.toml",
     "pyrightconfig.json",
     "typings"
-  ],
-  "language": "en-US",
-  "words": [
-    "Colaboratory",
-    "compwa",
-    "Deepnote",
-    "docstrings",
-    "graphviz",
-    "ipython",
-    "mkdir",
-    "mypy",
-    "oneline",
-    "pixi",
-    "PyPA",
-    "pytest",
-    "PYTHONHASHSEED",
-    "QRules",
-    "rtoml",
-    "sympy",
-    "toctree",
-    "Zenodo"
   ],
   "ignoreWords": [
     "FURB",
@@ -120,5 +98,27 @@
     "tomlsort",
     "unittests",
     "venv"
+  ],
+  "language": "en-US",
+  "version": "0.2",
+  "words": [
+    "Colaboratory",
+    "compwa",
+    "Deepnote",
+    "docstrings",
+    "graphviz",
+    "ipython",
+    "mkdir",
+    "mypy",
+    "oneline",
+    "pixi",
+    "PyPA",
+    "pytest",
+    "PYTHONHASHSEED",
+    "QRules",
+    "rtoml",
+    "sympy",
+    "toctree",
+    "Zenodo"
   ]
 }

--- a/.cspell.json
+++ b/.cspell.json
@@ -120,5 +120,6 @@
     "sympy",
     "toctree",
     "Zenodo"
-  ]
+  ],
+  "useGitignore": true
 }

--- a/src/compwa_policy/.template/.cspell.json
+++ b/src/compwa_policy/.template/.cspell.json
@@ -110,6 +110,7 @@
     "venv"
   ],
   "language": "en-US",
+  "useGitignore": true,
   "version": "0.2",
   "words": [
     "Colaboratory",

--- a/src/compwa_policy/.template/.cspell.json
+++ b/src/compwa_policy/.template/.cspell.json
@@ -1,5 +1,4 @@
 {
-  "version": "0.2",
   "enableFiletypes": [
     "git-commit",
     "github-actions-workflow",
@@ -62,21 +61,6 @@
     "typings",
     "update-www"
   ],
-  "language": "en-US",
-  "words": [
-    "Colaboratory",
-    "compwa",
-    "Deepnote",
-    "docstrings",
-    "graphviz",
-    "ipython",
-    "mkdir",
-    "mypy",
-    "pytest",
-    "PYTHONHASHSEED",
-    "toctree",
-    "Zenodo"
-  ],
   "ignoreWords": [
     "MAINT",
     "PyPI",
@@ -124,5 +108,21 @@
     "tomlkit",
     "unittests",
     "venv"
+  ],
+  "language": "en-US",
+  "version": "0.2",
+  "words": [
+    "Colaboratory",
+    "compwa",
+    "Deepnote",
+    "docstrings",
+    "graphviz",
+    "ipython",
+    "mkdir",
+    "mypy",
+    "pytest",
+    "PYTHONHASHSEED",
+    "toctree",
+    "Zenodo"
   ]
 }

--- a/src/compwa_policy/check_dev_files/cspell.py
+++ b/src/compwa_policy/check_dev_files/cspell.py
@@ -154,7 +154,7 @@ def __get_expected_content(config: dict, section: str, *, extend: bool = False) 
     if section not in __EXPECTED_CONFIG:
         return section_content
     expected_section_content = __EXPECTED_CONFIG[section]
-    if isinstance(expected_section_content, str):
+    if isinstance(expected_section_content, (bool, str)):
         return expected_section_content
     if isinstance(expected_section_content, list):
         if section == "ignorePaths":


### PR DESCRIPTION
`useGitignore` is now set to `true` in the `.cspell.json` configuration file.