### PR TITLE
DX: recommend VS Code Jupyter extension

### DIFF
--- a/src/compwa_policy/check_dev_files/jupyter.py
+++ b/src/compwa_policy/check_dev_files/jupyter.py
@@ -1,5 +1,6 @@
 """Update the developer setup when using Jupyter notebooks."""
 
+from compwa_policy.utilities import vscode
 from compwa_policy.utilities.pyproject import (
     ModifiablePyproject,
     has_pyproject_package_name,
@@ -8,6 +9,12 @@ from compwa_policy.utilities.pyproject import (
 
 def main(no_ruff: bool) -> None:
     _update_dev_requirements(no_ruff)
+    # cspell:ignore toolsai
+    vscode.add_extension_recommendation("ms-toolsai.jupyter")
+    vscode.add_extension_recommendation("ms-toolsai.vscode-jupyter-cell-tags")
+    vscode.remove_extension_recommendation(
+        "ms-toolsai.vscode-jupyter-slideshow", unwanted=True
+    )
 
 
 def _update_dev_requirements(no_ruff: bool) -> None:


### PR DESCRIPTION
The [Jupyter](https://marketplace.visualstudio.com/items?itemName=ms-toolsai.jupyter) and [Jupyter Cell Tags](https://marketplace.visualstudio.com/items?itemName=ms-toolsai.vscode-jupyter-cell-tags) are now added to the recommended extensions if the repository contains `*.ipynb` files, while [Jupyter Slide Show](https://marketplace.visualstudio.com/items?itemName=ms-toolsai.vscode-jupyter-slideshow) is listed under 'unwanted'.