### PR TITLE
ENH: import environment variables into `ci.yml`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,9 +5,6 @@ concurrency:
   cancel-in-progress: |-
     ${{ github.ref != format('refs/heads/{0}', github.event.repository.default_branch) }}
 
-env:
-  PYTHONHASHSEED: "0"
-
 on:
   push:
     branches:

--- a/src/compwa_policy/check_dev_files/__init__.py
+++ b/src/compwa_policy/check_dev_files/__init__.py
@@ -83,6 +83,7 @@ def main(argv: Sequence[str] | None = None) -> int:  # noqa: PLR0915
                 precommit_config,
                 allow_deprecated=args.allow_deprecated_workflows,
                 doc_apt_packages=doc_apt_packages,
+                environment_variables=environment_variables,
                 github_pages=args.github_pages,
                 keep_pr_linting=args.keep_pr_linting,
                 no_cd=args.no_cd,

--- a/src/compwa_policy/check_dev_files/github_workflows.py
+++ b/src/compwa_policy/check_dev_files/github_workflows.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import os
 import re
 import shutil
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 from ruamel.yaml.scalarstring import DoubleQuotedScalarString
 
@@ -39,6 +39,7 @@ def main(
     *,
     allow_deprecated: bool,
     doc_apt_packages: list[str],
+    environment_variables: dict[str, str],
     github_pages: bool,
     keep_pr_linting: bool,
     no_cd: bool,
@@ -61,6 +62,7 @@ def main(
             precommit,
             allow_deprecated,
             doc_apt_packages,
+            environment_variables,
             github_pages,
             no_macos,
             python_version,
@@ -128,6 +130,7 @@ def _update_ci_workflow(  # noqa: PLR0917
     precommit: Precommit,
     allow_deprecated: bool,
     doc_apt_packages: list[str],
+    environment_variables: dict[str, str],
     github_pages: bool,
     no_macos: bool,
     python_version: PythonVersion,
@@ -159,6 +162,10 @@ def _update_ci_workflow(  # noqa: PLR0917
             existing_data = yaml.load(workflow_path)
             if existing_data != expected_data:
                 update_workflow(yaml, expected_data, workflow_path)
+        env = cast("dict[str, str] | None", expected_data.get("env"))
+        if env is not None:
+            for key, value in environment_variables.items():
+                env[key] = value
 
     with Executor() as do:
         do(update)


### PR DESCRIPTION
Imports the environment variables specified by the `--environment-variables` argument of the `check-dev-files` hook into the `ci.yml` workflow.