### PR TITLE
ENH: set `sphinx.configuration`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -375,3 +375,9 @@ commands = [
     ["pre-commit", "run", "--all-files", "{posargs}"],
 ]
 description = "Perform all linting, formatting, and spelling checks"
+
+[tool.uv]
+constraint-dependencies = [
+    "pygments!=2.19.*", # https://github.com/felix-hilden/sphinx-codeautolink/issues/152
+    "sphinx-codeautolink!=0.16.0",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -375,8 +375,3 @@ commands = [
     ["pre-commit", "run", "--all-files", "{posargs}"],
 ]
 description = "Perform all linting, formatting, and spelling checks"
-
-[tool.uv]
-constraint-dependencies = [
-    "pygments!=2.19.*", # https://github.com/felix-hilden/sphinx-codeautolink/issues/152
-]

--- a/tests/check_dev_files/readthedocs/extend/.readthedocs-bad.yml
+++ b/tests/check_dev_files/readthedocs/extend/.readthedocs-bad.yml
@@ -12,3 +12,5 @@ build:
       - mkdir bin
       - ln -s $PWD/julia-1.9.2/bin/julia bin/julia
       - ./bin/julia docs/InstallIJulia.jl
+sphinx:
+  configuration: docs/conf.py

--- a/tests/check_dev_files/readthedocs/extend/.readthedocs-good.yml
+++ b/tests/check_dev_files/readthedocs/extend/.readthedocs-good.yml
@@ -13,3 +13,5 @@ build:
       - mkdir bin
       - ln -s $PWD/julia-1.9.2/bin/julia bin/julia
       - ./bin/julia docs/InstallIJulia.jl
+sphinx:
+  configuration: docs/conf.py

--- a/tests/check_dev_files/readthedocs/overwrite/.readthedocs-bad1.yml
+++ b/tests/check_dev_files/readthedocs/overwrite/.readthedocs-bad1.yml
@@ -6,3 +6,5 @@ build:
   jobs:
     post_install:
       - pip install -e .[doc]
+sphinx:
+  configuration: docs/conf.py

--- a/tests/check_dev_files/readthedocs/overwrite/.readthedocs-bad2.yml
+++ b/tests/check_dev_files/readthedocs/overwrite/.readthedocs-bad2.yml
@@ -3,3 +3,5 @@ build:
   os: ubuntu-20.04
   tools:
     python: "3.7"
+sphinx:
+  configuration: docs/conf.py

--- a/tests/check_dev_files/readthedocs/overwrite/.readthedocs-good.yml
+++ b/tests/check_dev_files/readthedocs/overwrite/.readthedocs-good.yml
@@ -7,3 +7,5 @@ build:
     post_install:
       - python -m pip install 'uv>=0.2.0'
       - python -m uv pip install -e .[doc]
+sphinx:
+  configuration: docs/conf.py


### PR DESCRIPTION
https://about.readthedocs.com/blog/2024/12/deprecate-config-files-without-sphinx-or-mkdocs-config