### PR TITLE
DX: run tests with all python versions through Tox

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -308,7 +308,7 @@ skip_missing_interpreters = true
 
 [tool.tox.env_run_base]
 commands = [
-    ["pytest", "{posargs}"],
+    ["pytest", "--no-summary", "{posargs}"],
 ]
 dependency_groups = ["test"]
 description = "Run test suite on Python {env_name}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -182,6 +182,7 @@ addopts = [
     "--doctest-modules",
     "--durations-min=0",
     "--durations=3",
+    "--ignore=docs/conf.py",
 ]
 filterwarnings = [
     "error",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -291,6 +291,10 @@ trailing_comma_inline_array = true
 
 [tool.tox]
 env_list = [
+    "3.9",
+    "3.10",
+    "3.11",
+    "3.12",
     "cov",
     "doc",
     "linkcheck",
@@ -302,15 +306,18 @@ skip_install = true
 skip_missing_interpreters = true
 
 [tool.tox.env_run_base]
-allowlist_externals = ["pytest"]
 commands = [
     ["pytest", "{posargs}"],
 ]
-description = "Run all unit tests"
+dependency_groups = ["test"]
+description = "Run test suite on Python {env_name}"
+no_package = false
 pass_env = ["*"]
+runner = "uv-venv-lock-runner"
+skip_install = false
+skip_missing_interpreters = false
 
 [tool.tox.env.cov]
-allowlist_externals = ["pytest"]
 commands = [
     [
         "pytest",
@@ -325,6 +332,7 @@ description = "Compute test coverage"
 
 [tool.tox.env.doc]
 allowlist_externals = ["sphinx-build"]
+base = []
 commands = [
     [
         "sphinx-build",
@@ -340,6 +348,7 @@ description = "Build documentation and API through Sphinx"
 
 [tool.tox.env.doclive]
 allowlist_externals = ["sphinx-autobuild"]
+base = []
 commands = [
     [
         "sphinx-autobuild",
@@ -358,7 +367,7 @@ commands = [
 description = "Set up a server to directly preview changes to the HTML pages"
 
 [tool.tox.env.linkcheck]
-allowlist_externals = ["sphinx-build"]
+base = ["tool.tox.env.doc"]
 commands = [
     [
         "sphinx-build",
@@ -375,7 +384,20 @@ set_env = [
 
 [tool.tox.env.sty]
 allowlist_externals = ["pre-commit"]
+base = []
 commands = [
     ["pre-commit", "run", "--all-files", "{posargs}"],
 ]
 description = "Perform all linting, formatting, and spelling checks"
+
+[tool.tox.labels]
+doc = [
+    "doc",
+    "linkcheck",
+]
+test = [
+    "3.9",
+    "3.10",
+    "3.11",
+    "3.12",
+]


### PR DESCRIPTION
See #496 

The `tox` command will now essentially run all CI checks locally. You can also run all unit tests on all Python versions using the `test` label as follows

```shell
tox -m test
```