### PR TITLE
ENH: always overwrite kernel name to "Python 3 (ipykernel)"

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -109,6 +109,7 @@
     "Deepnote",
     "docstrings",
     "graphviz",
+    "ipykernel",
     "ipython",
     "mkdir",
     "mypy",

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -43,8 +43,6 @@
 
 - id: set-nb-display-name
   name: Revert display name of the notebook kernel
-  description: >
-    Remove the tags metadata field from Jupyter notebooks if there are no tags
   entry: set-nb-display-name
   language: python
   types:

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -40,3 +40,12 @@
   language: python
   types:
     - jupyter
+
+- id: set-nb-display-name
+  name: Revert display name of the notebook kernel
+  description: >
+    Remove the tags metadata field from Jupyter notebooks if there are no tags
+  entry: set-nb-display-name
+  language: python
+  types:
+    - jupyter

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ fix-nbformat-version = "compwa_policy.fix_nbformat_version:main"
 remove-empty-tags = "compwa_policy.remove_empty_tags:main"
 self-check = "compwa_policy.self_check:main"
 set-nb-cells = "compwa_policy.set_nb_cells:main"
+set-nb-display-name = "compwa_policy.set_nb_display_name:main"
 
 [project.urls]
 Source = "https://github.com/ComPWA/policy"

--- a/src/compwa_policy/check_dev_files/precommit.py
+++ b/src/compwa_policy/check_dev_files/precommit.py
@@ -86,13 +86,18 @@ def _update_policy_hook(precommit: ModifiablePrecommit, has_notebooks: bool) -> 
         msg = "Could not find ComPWA/policy pre-commit repo"
         raise KeyError(msg)
     hook_ids = {h["id"] for h in repo["hooks"]}
-    remove_empty_tags_ids = "remove-empty-tags"
-    if remove_empty_tags_ids in hook_ids:
-        return
-    precommit.update_hook(
-        repo_url=repo["repo"],
-        expected_hook=Hook(id=remove_empty_tags_ids),
-    )
+    with Executor() as do:
+        for expected_hook_id in [
+            "remove-empty-tags",
+            "set-nb-display-name",
+        ]:
+            if expected_hook_id in hook_ids:
+                continue
+            do(
+                precommit.update_hook,
+                repo_url=repo["repo"],
+                expected_hook=Hook(id=expected_hook_id),
+            )
 
 
 def _update_precommit_ci_commit_msg(precommit: ModifiablePrecommit) -> None:

--- a/src/compwa_policy/set_nb_display_name.py
+++ b/src/compwa_policy/set_nb_display_name.py
@@ -1,0 +1,51 @@
+"""Remove tags metadata from notebook cells if they are empty."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from typing import TYPE_CHECKING
+
+import nbformat
+
+from compwa_policy.errors import PrecommitError
+from compwa_policy.utilities.executor import Executor
+from compwa_policy.utilities.notebook import load_notebook
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(__doc__)
+    parser.add_argument("filenames", nargs="*", help="Filenames to check.")
+    args = parser.parse_args(argv)
+
+    with Executor(raise_exception=False) as do:
+        for filename in args.filenames:
+            do(_set_nb_display_name, filename)
+    return 1 if do.error_messages else 0
+
+
+def _set_nb_display_name(filename: str) -> None:
+    notebook = load_notebook(filename)
+    display_name = (
+        notebook.get("metadata", {})
+        .get("kernelspec", {})  # cspell:ignore kernelspec
+        .get("display_name")
+    )
+    expected_display_name = "Python 3 (ipykernel)"
+    if display_name != expected_display_name:
+        if "metadata" not in notebook:
+            notebook["metadata"] = {}
+        metadata = notebook["metadata"]
+        if "kernelspec" not in metadata:
+            metadata["kernelspec"] = {}
+        metadata["kernelspec"]["display_name"] = expected_display_name
+        nbformat.write(notebook, filename)
+        msg = f"Set display name to {expected_display_name!r} in {filename}"
+        raise PrecommitError(msg)
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
The Jupyter notebook kernel name in Jupyter Lab is always set to `"Python 3 (ipykernel)"`, while VS Code sets the name to `".venv"` if the `uv` environment is selected. This is annoying in PR diffs.

This PR adds a new hook, `set-nb-display-name`, that always sets the kernel name to the name used by Jupyter Lab. The `check-dev-files` hook installs this hook automatically if the repository contains `*.ipynb` files.