### PR TITLE
FIX: force `ModifiablePyproject` to be non-slotted

### DIFF
--- a/src/compwa_policy/utilities/pyproject/__init__.py
+++ b/src/compwa_policy/utilities/pyproject/__init__.py
@@ -106,7 +106,7 @@ class Pyproject:
         return get_supported_python_versions(self._document)
 
 
-@frozen
+@frozen(slots=False)
 class ModifiablePyproject(Pyproject, AbstractContextManager):
     """Stateful representation of a :code:`pyproject.toml` file.
 


### PR DESCRIPTION
- In Python 3.13, `ModifiablePyproject` could not used as a context manager (which kind of defeats its purpose), because Python 3.13 defines it as a slotted class by default.
- See also https://github.com/ComPWA/policy/issues/421