### PR TITLE
BREAK: rename `--no-macos` to `--macos-python-version`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
     uses: ComPWA/actions/.github/workflows/pytest.yml@v2.1
     with:
       coverage-target: compwa_policy
-      macos-python-version: "3.9"
+      macos-python-version: "3.10"
       specific-pip-packages: ${{ inputs.specific-pip-packages }}
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/src/compwa_policy/check_dev_files/__init__.py
+++ b/src/compwa_policy/check_dev_files/__init__.py
@@ -44,12 +44,12 @@ from compwa_policy.check_dev_files.deprecated import remove_deprecated_tools
 from compwa_policy.utilities.executor import Executor
 from compwa_policy.utilities.match import git_ls_files, matches_patterns
 from compwa_policy.utilities.precommit import ModifiablePrecommit
+from compwa_policy.utilities.pyproject import PythonVersion
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
     from compwa_policy.check_dev_files.conda import PackageManagerChoice
-    from compwa_policy.utilities.pyproject import PythonVersion
 
 
 def main(argv: Sequence[str] | None = None) -> int:  # noqa: PLR0915
@@ -58,6 +58,9 @@ def main(argv: Sequence[str] | None = None) -> int:  # noqa: PLR0915
     doc_apt_packages = _to_list(args.doc_apt_packages)
     environment_variables = _get_environment_variables(args.environment_variables)
     is_python_repo = not args.no_python
+    macos_python_version = (
+        None if args.macos_python_version == "disable" else args.macos_python_version
+    )
     repo_name, repo_title = _determine_repo_name_and_title(args)
     has_notebooks = any(
         matches_patterns(file, ["**/*.ipynb"]) for file in git_ls_files(untracked=True)
@@ -86,8 +89,8 @@ def main(argv: Sequence[str] | None = None) -> int:  # noqa: PLR0915
                 environment_variables=environment_variables,
                 github_pages=args.github_pages,
                 keep_pr_linting=args.keep_pr_linting,
+                macos_python_version=macos_python_version,
                 no_cd=args.no_cd,
-                no_macos=args.no_macos,
                 no_milestones=args.no_milestones,
                 no_pypi=args.no_pypi,
                 no_version_branches=args.no_version_branches,
@@ -302,10 +305,10 @@ def _create_argparse() -> ArgumentParser:
         type=str,
     )
     parser.add_argument(
-        "--no-macos",
-        action="store_true",
-        default=False,
-        help="Do not run test job on macOS",
+        "--macos-python-version",
+        choices=[*sorted(PythonVersion.__args__), "disable"],  # type:ignore[attr-defined]
+        default="3.9",
+        help="Run the test job in MacOS on a specific Python version. Use 'disable' to not run the tests on MacOS.",
     )
     parser.add_argument(
         "--no-pypi",

--- a/src/compwa_policy/check_dev_files/__init__.py
+++ b/src/compwa_policy/check_dev_files/__init__.py
@@ -307,7 +307,7 @@ def _create_argparse() -> ArgumentParser:
     parser.add_argument(
         "--macos-python-version",
         choices=[*sorted(PythonVersion.__args__), "disable"],  # type:ignore[attr-defined]
-        default="3.9",
+        default="3.10",
         help="Run the test job in MacOS on a specific Python version. Use 'disable' to not run the tests on MacOS.",
     )
     parser.add_argument(

--- a/src/compwa_policy/check_dev_files/github_workflows.py
+++ b/src/compwa_policy/check_dev_files/github_workflows.py
@@ -42,8 +42,8 @@ def main(
     environment_variables: dict[str, str],
     github_pages: bool,
     keep_pr_linting: bool,
+    macos_python_version: PythonVersion | None,
     no_cd: bool,
-    no_macos: bool,
     no_milestones: bool,
     no_pypi: bool,
     no_version_branches: bool,
@@ -64,7 +64,7 @@ def main(
             doc_apt_packages,
             environment_variables,
             github_pages,
-            no_macos,
+            macos_python_version,
             python_version,
             single_threaded,
             skip_tests,
@@ -132,7 +132,7 @@ def _update_ci_workflow(  # noqa: PLR0917
     doc_apt_packages: list[str],
     environment_variables: dict[str, str],
     github_pages: bool,
-    no_macos: bool,
+    macos_python_version: PythonVersion | None,
     python_version: PythonVersion,
     single_threaded: bool,
     skip_tests: list[str],
@@ -145,7 +145,7 @@ def _update_ci_workflow(  # noqa: PLR0917
             doc_apt_packages,
             environment_variables,
             github_pages,
-            no_macos,
+            macos_python_version,
             python_version,
             single_threaded,
             skip_tests,
@@ -181,7 +181,7 @@ def _get_ci_workflow(  # noqa: PLR0917
     doc_apt_packages: list[str],
     environment_variables: dict[str, str],
     github_pages: bool,
-    no_macos: bool,
+    macos_python_version: PythonVersion | None,
     python_version: PythonVersion,
     single_threaded: bool,
     skip_tests: list[str],
@@ -191,7 +191,9 @@ def _get_ci_workflow(  # noqa: PLR0917
     config = yaml.load(path)
     __update_env_section(config, environment_variables)
     __update_doc_section(config, doc_apt_packages, python_version, github_pages)
-    __update_pytest_section(config, no_macos, single_threaded, skip_tests, test_extras)
+    __update_pytest_section(
+        config, macos_python_version, single_threaded, skip_tests, test_extras
+    )
     __update_style_section(config, python_version, precommit)
     return yaml, config
 
@@ -245,7 +247,7 @@ def __is_remove_style_job(precommit: Precommit) -> bool:
 
 def __update_pytest_section(
     config: CommentedMap,
-    no_macos: bool,
+    macos_python_version: PythonVersion | None,
     single_threaded: bool,
     skip_tests: list[str],
     test_extras: list[str],
@@ -263,8 +265,10 @@ def __update_pytest_section(
                 "CODECOV_TOKEN": "${{ secrets.CODECOV_TOKEN }}",
             }
             config["jobs"]["pytest"]["secrets"] = secrets
-        if not no_macos:
-            with_section["macos-python-version"] = DoubleQuotedScalarString("3.9")
+        if macos_python_version is not None:
+            with_section["macos-python-version"] = DoubleQuotedScalarString(
+                macos_python_version
+            )
         if skip_tests:
             with_section["skipped-python-versions"] = " ".join(skip_tests)
         if single_threaded:


### PR DESCRIPTION
- BEHAVIOR: run MacOS tests on Python 3.10 by default