### PR TITLE
FIX: set kernel name to "Pyproject Local"

### DIFF
--- a/src/compwa_policy/set_nb_display_name.py
+++ b/src/compwa_policy/set_nb_display_name.py
@@ -10,7 +10,9 @@ import nbformat
 
 from compwa_policy.errors import PrecommitError
 from compwa_policy.utilities.executor import Executor
+from compwa_policy.utilities.match import filter_files
 from compwa_policy.utilities.notebook import load_notebook
+from compwa_policy.utilities.pyproject import Pyproject, has_dependency
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -35,6 +37,10 @@ def _set_nb_display_name(filename: str) -> None:
         .get("display_name")
     )
     expected_display_name = "Python 3 (ipykernel)"
+    if filter_files(["pyproject.toml"]):
+        pyproject = Pyproject.load()
+        if has_dependency(pyproject, "pyproject-local-kernel"):
+            expected_display_name = "Pyproject Local"
     if display_name != expected_display_name:
         if "metadata" not in notebook:
             notebook["metadata"] = {}


### PR DESCRIPTION
Follow-up to #499 for projects that use [`pyproject-local-kernel`](https://bluss.github.io/pyproject-local-kernel).