### PR TITLE
ENH: set commit message for pre-commit.ci autofixes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 ci:
   autofix_commit_msg: "MAINT: implement pre-commit autofixes"
-  autoupdate_commit_msg: "MAINT: update lock files"
+  autoupdate_commit_msg: "MAINT: upgrade lock files"
   autoupdate_schedule: quarterly
   skip:
     - check-dev-files

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,5 @@
 ci:
+  autofix_commit_msg: "MAINT: implement pre-commit autofixes"
   autoupdate_commit_msg: "MAINT: update lock files"
   autoupdate_schedule: quarterly
   skip:

--- a/src/compwa_policy/check_dev_files/__init__.py
+++ b/src/compwa_policy/check_dev_files/__init__.py
@@ -340,7 +340,7 @@ def _create_argparse() -> ArgumentParser:
         choices=update_lock.Frequency.__args__,  # type:ignore[attr-defined]
         default="outsource",
         help=(
-            "Add a workflow to update lock files, like uv.lock, .pre-commit-config.yml, "
+            "Add a workflow to upgrade lock files, like uv.lock, .pre-commit-config.yml, "
             "and pip .constraints/ files. The argument is the frequency of the cron job"
         ),
         type=str,

--- a/src/compwa_policy/check_dev_files/precommit.py
+++ b/src/compwa_policy/check_dev_files/precommit.py
@@ -118,7 +118,7 @@ def _update_precommit_ci_autoupdate_commit_msg(precommit: ModifiablePrecommit) -
     precommit_ci = precommit.document.get("ci")
     if precommit_ci is None:
         return
-    expected_msg = "MAINT: update lock files"
+    expected_msg = "MAINT: upgrade lock files"
     key = "autoupdate_commit_msg"
     msg = precommit_ci.get(key)
     if msg != expected_msg:

--- a/src/compwa_policy/check_dev_files/precommit.py
+++ b/src/compwa_policy/check_dev_files/precommit.py
@@ -29,7 +29,8 @@ def main(precommit: ModifiablePrecommit, has_notebooks: bool) -> None:
     with Executor() as do:
         do(_sort_hooks, precommit)
         do(_update_conda_environment, precommit)
-        do(_update_precommit_ci_commit_msg, precommit)
+        do(_update_precommit_ci_autofix_commit_msg, precommit)
+        do(_update_precommit_ci_autoupdate_commit_msg, precommit)
         do(_update_precommit_ci_skip, precommit)
         do(_update_policy_hook, precommit, has_notebooks)
         do(_update_repo_urls, precommit)
@@ -100,14 +101,27 @@ def _update_policy_hook(precommit: ModifiablePrecommit, has_notebooks: bool) -> 
             )
 
 
-def _update_precommit_ci_commit_msg(precommit: ModifiablePrecommit) -> None:
+def _update_precommit_ci_autofix_commit_msg(precommit: ModifiablePrecommit) -> None:
+    precommit_ci = precommit.document.get("ci")
+    if precommit_ci is None:
+        return
+    expected_msg = "MAINT: implement pre-commit autofixes"
+    key = "autofix_commit_msg"
+    msg = precommit_ci.get(key)
+    if msg != expected_msg:
+        precommit_ci[key] = expected_msg  # type:ignore[literal-required]
+        msg = f"Set ci.{key} to {expected_msg!r}"
+        precommit.changelog.append(msg)
+
+
+def _update_precommit_ci_autoupdate_commit_msg(precommit: ModifiablePrecommit) -> None:
     precommit_ci = precommit.document.get("ci")
     if precommit_ci is None:
         return
     expected_msg = "MAINT: update lock files"
     key = "autoupdate_commit_msg"
-    autoupdate_commit_msg = precommit_ci.get(key)
-    if autoupdate_commit_msg != expected_msg:
+    msg = precommit_ci.get(key)
+    if msg != expected_msg:
         precommit_ci[key] = expected_msg  # type:ignore[literal-required]
         msg = f"Set ci.{key} to {expected_msg!r}"
         precommit.changelog.append(msg)

--- a/tests/utilities/precommit/test_getters.py
+++ b/tests/utilities/precommit/test_getters.py
@@ -37,7 +37,7 @@ def test_load_precommit_config_path():
     assert "ci" in config
     ci = config.get("ci")
     assert ci is not None
-    assert ci.get("autoupdate_commit_msg") == "MAINT: update lock files"
+    assert ci.get("autoupdate_commit_msg") == "MAINT: upgrade lock files"
 
 
 def test_find_repo(example_yaml: str):


### PR DESCRIPTION
- Sets the [`autofix_commit_msg`](https://pre-commit.ci/#configuration) for pre-commit.ci.
- Changed the PR title to "MAINT: ~update~upgrade lock files" in consistency with `uv lock --upgrade`