### PR TITLE
FIX: remove `mypy-type-checker.importStrategy`

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -38,7 +38,6 @@
   "livePreview.defaultPreviewPath": "docs/_build/html",
   "multiDiffEditor.experimental.enabled": true,
   "mypy-type-checker.args": ["--config-file=${workspaceFolder}/pyproject.toml"],
-  "mypy-type-checker.importStrategy": "fromEnvironment",
   "notebook.codeActionsOnSave": {
     "notebook.source.organizeImports": "explicit"
   },

--- a/src/compwa_policy/check_dev_files/mypy.py
+++ b/src/compwa_policy/check_dev_files/mypy.py
@@ -39,7 +39,6 @@ def _update_vscode_settings(pyproject: Pyproject) -> None:
                 "mypy-type-checker.args": [
                     f"--config-file=${{workspaceFolder}}/{CONFIG_PATH.pyproject}"
                 ],
-                "mypy-type-checker.importStrategy": "fromEnvironment",
             }
             do(vscode.update_settings, settings)
         else:
@@ -48,4 +47,4 @@ def _update_vscode_settings(pyproject: Pyproject) -> None:
                 "ms-python.mypy-type-checker",
                 unwanted=True,
             )
-            do(vscode.remove_settings, ["mypy-type-checker.importStrategy"])
+        do(vscode.remove_settings, ["mypy-type-checker.importStrategy"])


### PR DESCRIPTION
Mypy crashes in VS Code in repositories with a large number of dependencies if [`mypy-type-checker.importStrategy`](https://marketplace.visualstudio.com/items?itemName=ms-python.mypy-type-checker) is set to `fromEnvironment`.