### PR TITLE
BEHAVIOR: update PyPI classifiers if there are tests

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,6 +51,7 @@ repos:
         args:
           - --allow-labels
           - --dependabot=update
+          - --excluded-python-versions=3.14
           - --no-pypi
           - --pytest-single-threaded
           - --repo-name=policy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,13 @@ requires = [
 
 [project]
 authors = [{name = "Common Partial Wave Analysis", email = "compwa-admin@ep1.rub.de"}]
+classifiers = [
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.9",
+]
 dependencies = [
     "PyYAML",
     "attrs >=20.1.0", # https://www.attrs.org/changelog.html#id82
@@ -28,7 +35,7 @@ dynamic = ["version"]
 license = {text = "BSD 3-Clause License"}
 maintainers = [{email = "compwa-admin@ep1.rub.de"}]
 name = "compwa-policy"
-requires-python = ">=3.9,<3.14"
+requires-python = ">=3.9"
 
 [project.readme]
 content-type = "text/markdown"

--- a/src/compwa_policy/check_dev_files/__init__.py
+++ b/src/compwa_policy/check_dev_files/__init__.py
@@ -131,7 +131,7 @@ def main(argv: Sequence[str] | None = None) -> int:  # noqa: PLR0915
                     args.repo_organization,
                 )
             do(mypy.main)
-            do(pyproject.main, excluded_python_versions, no_pypi=args.no_pypi)
+            do(pyproject.main, excluded_python_versions)
             do(pyright.main, precommit_config)
             do(pytest.main, args.pytest_single_threaded)
             do(pyupgrade.main, precommit_config, args.no_ruff)


### PR DESCRIPTION
- Closes #533 
- Removed upper limit on `requires-python`.
- If there is a `tests/` directory, update the `classifiers` in `pyproject.toml` to signal the supported Python versions to [ComPWA/actions](https://github.com/ComPWA/actions).