### PR TITLE
ENH: list ⬆️ Lock label under 🔨 Maintenance

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -19,7 +19,9 @@ categories:
   - title: 📝 Documentation
     label: 📝 Docs
   - title: 🔨 Maintenance
-    label: 🔨 Maintenance
+    labels:
+      - 🔨 Maintenance
+      - ⬆️ Lock
   - title: 🖱️ Developer Experience
     label: 🖱️ DX
 

--- a/src/compwa_policy/.github/release-drafter.yml
+++ b/src/compwa_policy/.github/release-drafter.yml
@@ -19,7 +19,9 @@ categories:
   - title: 📝 Documentation
     label: 📝 Docs
   - title: 🔨 Maintenance
-    label: 🔨 Maintenance
+    labels:
+      - 🔨 Maintenance
+      - ⬆️ Lock
   - title: 🖱️ Developer Experience
     label: 🖱️ DX
 


### PR DESCRIPTION
In the release drafter, the ⬆️ Lock was not categorized under any category. It is now categorized under **🔨 Maintenance**.