### PR TITLE
ENH: `project` in `pixi.toml` is now named `workspace`

### DIFF
--- a/src/compwa_policy/check_dev_files/pixi/_update.py
+++ b/src/compwa_policy/check_dev_files/pixi/_update.py
@@ -95,11 +95,8 @@ def _rename_workspace_table(config: ModifiablePyproject) -> None:
     if not __has_table(config, "project"):
         return
     project = __get_table(config, "project")
-    if "workspace" in project:
-        workspace = __get_table(config, "workspace")
-        workspace.update(project)
-    else:
-        project["workspace"] = project
+    workspace = __get_table(config, "workspace", create=True)
+    workspace.update(project)
     del config._document["project"]  # type:ignore[misc] # noqa: SLF001
     msg = 'Renamed "project" table to "workspace" in Pixi configuration'
     config.changelog.append(msg)


### PR DESCRIPTION
Closes #549 