### PR TITLE
ENH: allow merging `autolink-concat` with other cells

### DIFF
--- a/src/compwa_policy/set_nb_cells.py
+++ b/src/compwa_policy/set_nb_cells.py
@@ -166,7 +166,7 @@ def _insert_autolink_concat(filename: str) -> None:
         if cell["cell_type"] != "markdown":
             continue
         cell_content: str = cell["source"]
-        if cell_content == expected_cell_content:
+        if expected_cell_content in cell_content:
             return
         new_cell = nbformat.v4.new_markdown_cell(expected_cell_content)
         del new_cell["id"]  # following nbformat_minor = 4


### PR DESCRIPTION
- Currently, the [`autolink-concat`](https://sphinx-codeautolink.readthedocs.io/en/latest/reference.html#directive-autolink-concat) directive is forced to be in a separate cell by [`set-nb-cells`](https://compwa.github.io/policy/api/compwa_policy.set_nb_cells.html). With this PR, it is possible to put merge directive with any other Markdown cell.
- Flags like `--no-autolink-concat` have become `--autolink-concat`. You have to set them specifically in order to activate its functionality.