### PR TITLE
ENH: add `pixi.lock` to prettierignore

### DIFF
--- a/src/compwa_policy/check_dev_files/prettier.py
+++ b/src/compwa_policy/check_dev_files/prettier.py
@@ -91,6 +91,7 @@ def __insert_expected_paths() -> None:
     existing = __get_existing_lines()
     obligatory = [
         "LICENSE",
+        "pixi.lock",
     ]
     obligatory = [p for p in obligatory if os.path.exists(p)]
     expected = [*sorted(set(existing + obligatory) - {""}), ""]


### PR DESCRIPTION
Running both `pixi upgrade` and then formatting with Prettier results in a loop of the upgrade-lock workflow.