### PR TITLE
ENH: check multiple `autolink-concat` in `set-nb-cells`

### DIFF
--- a/src/compwa_policy/set_nb_cells.py
+++ b/src/compwa_policy/set_nb_cells.py
@@ -53,11 +53,11 @@ __INSTALL_CELL_METADATA: dict = {
     "tags": ["remove-cell", "skip-execution"],
     # https://github.com/executablebooks/jupyter-book/issues/833
 }
-__AUTOLINK_CONCAT = dedent("""
+__AUTOLINK_CONCAT = """
 ```{autolink-concat}
 
 ```
-""").strip()
+""".strip()
 
 
 def main(argv: Sequence[str] | None = None) -> int:


### PR DESCRIPTION
- Load notebooks in the `set-nb-cell` only once.
- Apply Prettier formatting to hook:
  ````markdown
  ```{autolink-concat}
  
  ```
  ````
  instead of
  ````markdown
  ```{autolink-concat}
  ```
  ````
- Check if notebooks contain multiple `autolink-concat` statements.