### PR TITLE
DOC: explain use of `policy` CLI tool

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -94,6 +94,7 @@
     "ruamel",
     "scalarstring",
     "sdist",
+    "settings_customise_sources",
     "setuptools",
     "showcode",
     "showtags",

--- a/.cspell.json
+++ b/.cspell.json
@@ -119,6 +119,7 @@
     "mkdir",
     "MPLBACKEND",
     "oneline",
+    "pipx",
     "pixi",
     "poethepoet",
     "PyPA",

--- a/README.md
+++ b/README.md
@@ -30,3 +30,13 @@ pre-commit autoupdate --repo=https://github.com/ComPWA/policy
 ```
 
 The notebook formatting hooks that used to live here have moved to [ComPWA/nbhooks](https://github.com/ComPWA/nbhooks). When a repository contains notebooks, `check-dev-files` automatically migrates them over and keeps them up to date.
+
+## Command-line interface
+
+The same checks are exposed through a short [Typer](https://typer.tiangolo.com)-based `policy` command, so you can run them on the fly without setting up `pre-commit` first:
+
+```shell
+uvx --from git+https://github.com/ComPWA/policy policy --help
+```
+
+Running `policy` without a subcommand runs every check at once, exactly like the `check-dev-files` hook. Subcommands group the checks by domain, so you can run just a subset (e.g. `policy python` or `policy nb`). Options that apply to the whole repository can be declared once in a `[tool.compwa.policy]` table in your `pyproject.toml` instead of repeating them under `args:`. See the [`check-dev-files` documentation](https://compwa.github.io/policy/check-dev-files) for the full command tree and configuration options.

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The notebook formatting hooks that used to live here have moved to [ComPWA/nbhoo
 > After upgrading, the `check-dev-files` hook fails if your `.pre-commit-config.yaml` still passes area-scoped flags (such as `--no-pypi`) under `args:`. These options now live in a `[tool.compwa.policy]` table in your `pyproject.toml`. Run the following one-off command to migrate automatically; you do not need to install anything first.
 >
 > ```shell
-> uvx --from git+https://github.com/ComPWA/policy policy migrate
+> uvx --from git+https://github.com/ComPWA/policy --refresh policy migrate
 > ```
 
 ## Command-line interface

--- a/README.md
+++ b/README.md
@@ -31,6 +31,13 @@ pre-commit autoupdate --repo=https://github.com/ComPWA/policy
 
 The notebook formatting hooks that used to live here have moved to [ComPWA/nbhooks](https://github.com/ComPWA/nbhooks). When a repository contains notebooks, `check-dev-files` automatically migrates them over and keeps them up to date.
 
+> [!IMPORTANT]
+> After upgrading, the `check-dev-files` hook fails if your `.pre-commit-config.yaml` still passes area-scoped flags (such as `--no-pypi`) under `args:`. These options now live in a `[tool.compwa.policy]` table in your `pyproject.toml`. Run the following one-off command to migrate automatically; you do not need to install anything first.
+>
+> ```shell
+> uvx --from git+https://github.com/ComPWA/policy policy migrate
+> ```
+
 ## Command-line interface
 
 The same checks are exposed through a short [Typer](https://typer.tiangolo.com)-based `policy` command, so you can run them on the fly without setting up `pre-commit` first:

--- a/docs/check-dev-files.md
+++ b/docs/check-dev-files.md
@@ -31,6 +31,19 @@ The checks are also exposed through a short [Typer](https://typer.tiangolo.com)-
 policy --help
 ```
 
+You do not need to install the package to use this command. With [`uv`](https://docs.astral.sh/uv), you can fetch and run it on the fly:
+
+```shell
+uvx --from git+https://github.com/ComPWA/policy policy --help
+```
+
+To install it as a persistent tool instead, use [`uv tool install`](https://docs.astral.sh/uv/concepts/tools) (or `pipx install`):
+
+```shell
+uv tool install git+https://github.com/ComPWA/policy
+policy --help
+```
+
 When the `pwa` command is installed alongside this package, the same command is also available as `pwa policy ...` through a `pwa.commands` entry point.
 
 ## Hook arguments

--- a/docs/check-dev-files.md
+++ b/docs/check-dev-files.md
@@ -105,11 +105,21 @@ Both the native TOML form (arrays, tables, booleans) and the legacy command-line
 
 ### Migrating an existing `args:` list
 
-The `policy migrate` subcommand does this conversion automatically. It reads the `args:` of the `check-dev-files` hook in your `.pre-commit-config.yaml`, writes them into the hierarchical `[tool.compwa.policy]` table of `pyproject.toml`, and removes the now-redundant `args:` from the hook:
+:::{important}
+After upgrading, the `check-dev-files` pre-commit hook **fails** if your `.pre-commit-config.yaml` still passes area-scoped flags (such as `--no-pypi` or `--no-binder`) under `args:`, because the hook now only accepts repository-wide options. Run the one-off `policy migrate` command below to fix this; you do **not** need to install anything first:
 
 ```shell
-policy migrate            # convert .pre-commit-config.yaml in the current directory
-policy migrate --dry-run  # preview the resulting table without changing any files
+uvx --from git+https://github.com/ComPWA/policy policy migrate
 ```
+
+:::
+
+The `policy migrate` subcommand does this conversion automatically: it reads the `args:` of the `check-dev-files` hook in your `.pre-commit-config.yaml`, writes them into the hierarchical `[tool.compwa.policy]` table of `pyproject.toml`, and removes the now-redundant `args:` from the hook. To preview the resulting table without changing any files, add `--dry-run`:
+
+```shell
+uvx --from git+https://github.com/ComPWA/policy policy migrate --dry-run
+```
+
+If you already installed the `policy` command, you can drop the `uvx --from git+https://github.com/ComPWA/policy` prefix and simply run `policy migrate`.
 
 The same command also relocates any notebook formatting hooks (such as `set-nb-cells` or `fix-nbformat-version`) that are still listed under the `ComPWA/policy` repo to a separate [`ComPWA/nbhooks`](https://github.com/ComPWA/nbhooks) repo entry, since those hooks were [extracted into their own repository](https://github.com/ComPWA/policy/issues/612).

--- a/docs/check-dev-files.md
+++ b/docs/check-dev-files.md
@@ -88,10 +88,12 @@ gitpod = true
 
 Both the native TOML form (arrays, tables, booleans) and the legacy command-line string form (`"mypy,pyright"`, `"A=1,B=2"`) are accepted, so an existing `args:` list can be moved into `pyproject.toml` verbatim.
 
-### Migrating an existing `args:` list
+## Migrating after breaking changes
+
+Some policy updates introduce breaking changes to a repository's configuration. The `check-dev-files` pre-commit hook cannot rewrite your files to apply such a change itself — it can only detect it and fail. The `policy migrate` command applies these migrations for you, but because it modifies configuration files it has to be run **outside of `pre-commit`**, as a one-off command.
 
 :::{important}
-After upgrading, the `check-dev-files` pre-commit hook **fails** if your `.pre-commit-config.yaml` still passes area-scoped flags (such as `--no-pypi` or `--no-binder`) under `args:`, because the hook now only accepts repository-wide options. Run the one-off `policy migrate` command below to fix this; you do **not** need to install anything first:
+If the `check-dev-files` hook starts failing after an upgrade, run `policy migrate` to bring your configuration up to date. You do **not** need to install anything first:
 
 ```shell
 uvx --from git+https://github.com/ComPWA/policy policy migrate
@@ -99,7 +101,7 @@ uvx --from git+https://github.com/ComPWA/policy policy migrate
 
 :::
 
-The `policy migrate` subcommand does this conversion automatically: it reads the `args:` of the `check-dev-files` hook in your `.pre-commit-config.yaml`, writes them into the hierarchical `[tool.compwa.policy]` table of `pyproject.toml`, and removes the now-redundant `args:` from the hook. To preview the resulting table without changing any files, add `--dry-run`:
+To preview the changes without writing any files, add `--dry-run`:
 
 ```shell
 uvx --from git+https://github.com/ComPWA/policy policy migrate --dry-run
@@ -107,4 +109,7 @@ uvx --from git+https://github.com/ComPWA/policy policy migrate --dry-run
 
 If you already installed the `policy` command, you can drop the `uvx --from git+https://github.com/ComPWA/policy` prefix and simply run `policy migrate`.
 
-The same command also relocates any notebook formatting hooks (such as `set-nb-cells` or `fix-nbformat-version`) that are still listed under the `ComPWA/policy` repo to a separate [`ComPWA/nbhooks`](https://github.com/ComPWA/nbhooks) repo entry, since those hooks were [extracted into their own repository](https://github.com/ComPWA/policy/issues/612).
+At the moment, `policy migrate` applies two migrations:
+
+- It moves area-scoped flags (such as `--no-pypi`) out of the `args:` of the `check-dev-files` hook in `.pre-commit-config.yaml` into the hierarchical `[tool.compwa.policy]` table of `pyproject.toml` (see [above](#configuration)), removing the now-redundant `args:`.
+- It relocates any notebook formatting hooks (such as `set-nb-cells` or `fix-nbformat-version`) that are still listed under the `ComPWA/policy` repo to a separate [`ComPWA/nbhooks`](https://github.com/ComPWA/nbhooks) repo entry, since those hooks were [extracted into their own repository](https://github.com/ComPWA/policy/issues/612).

--- a/docs/check-dev-files.md
+++ b/docs/check-dev-files.md
@@ -33,7 +33,9 @@ You do not need to install anything: with [`uv`](https://docs.astral.sh/uv), `uv
 uvx --from git+https://github.com/ComPWA/policy policy --help
 ```
 
+:::{tip}
 `uvx` caches the Git checkout, so add `--refresh` directly after `uvx` to pull the latest commit from the default branch.
+:::
 
 If you run the command often, you can install it as a persistent tool with [`uv tool install`](https://docs.astral.sh/uv/concepts/tools) (or `pipx install`) and call `policy` directly, updating it with `uv tool upgrade --reinstall compwa-policy`. When the `pwa` command is installed alongside this package, the same command is also available as `pwa policy ...` through a `pwa.commands` entry point.
 
@@ -96,7 +98,7 @@ Some policy updates introduce breaking changes to a repository's configuration. 
 If the `check-dev-files` hook starts failing after an upgrade, run `policy migrate` to bring your configuration up to date. You do **not** need to install anything first:
 
 ```shell
-uvx --from git+https://github.com/ComPWA/policy policy migrate
+uvx --from git+https://github.com/ComPWA/policy --refresh policy migrate
 ```
 
 :::
@@ -104,12 +106,7 @@ uvx --from git+https://github.com/ComPWA/policy policy migrate
 To preview the changes without writing any files, add `--dry-run`:
 
 ```shell
-uvx --from git+https://github.com/ComPWA/policy policy migrate --dry-run
+uvx --from git+https://github.com/ComPWA/policy --refresh policy migrate --dry-run
 ```
 
 If you already installed the `policy` command, you can drop the `uvx --from git+https://github.com/ComPWA/policy` prefix and simply run `policy migrate`.
-
-At the moment, `policy migrate` applies two migrations:
-
-- It moves area-scoped flags (such as `--no-pypi`) out of the `args:` of the `check-dev-files` hook in `.pre-commit-config.yaml` into the hierarchical `[tool.compwa.policy]` table of `pyproject.toml` (see [above](#configuration)), removing the now-redundant `args:`.
-- It relocates any notebook formatting hooks (such as `set-nb-cells` or `fix-nbformat-version`) that are still listed under the `ComPWA/policy` repo to a separate [`ComPWA/nbhooks`](https://github.com/ComPWA/nbhooks) repo entry, since those hooks were [extracted into their own repository](https://github.com/ComPWA/policy/issues/612).

--- a/docs/check-dev-files.md
+++ b/docs/check-dev-files.md
@@ -44,6 +44,12 @@ uv tool install git+https://github.com/ComPWA/policy
 policy --help
 ```
 
+Both commands install from the default branch, but `uv` caches the Git checkout and reuses it on later runs. To update an already-installed copy to the latest commit, add `--reinstall` (which implies `--refresh`):
+
+```shell
+uv tool upgrade --reinstall compwa-policy
+```
+
 When the `pwa` command is installed alongside this package, the same command is also available as `pwa policy ...` through a `pwa.commands` entry point.
 
 ## Hook arguments

--- a/docs/check-dev-files.md
+++ b/docs/check-dev-files.md
@@ -25,32 +25,17 @@ For more implementation details of this hook, check the {mod}`compwa_policy.cli`
 
 ## Command-line interface
 
-The checks are also exposed through a short [Typer](https://typer.tiangolo.com)-based `policy` command. Running `policy` without a subcommand runs every check at once, which is exactly what the `check-dev-files` pre-commit hook does. The subcommands group the checks by domain, so you can run just a subset. To see which subcommands are available, run:
+The checks are also exposed through a short [Typer](https://typer.tiangolo.com)-based `policy` command. Running `policy` without a subcommand runs every check at once, which is exactly what the `check-dev-files` pre-commit hook does. The subcommands group the checks by domain, so you can run just a subset.
 
-```shell
-policy --help
-```
-
-You do not need to install the package to use this command. With [`uv`](https://docs.astral.sh/uv), you can fetch and run it on the fly:
+You do not need to install anything: with [`uv`](https://docs.astral.sh/uv), `uvx` fetches and runs the command on the fly. For example, to see which subcommands are available:
 
 ```shell
 uvx --from git+https://github.com/ComPWA/policy policy --help
 ```
 
-To install it as a persistent tool instead, use [`uv tool install`](https://docs.astral.sh/uv/concepts/tools) (or `pipx install`):
+`uvx` caches the Git checkout, so add `--refresh` directly after `uvx` to pull the latest commit from the default branch.
 
-```shell
-uv tool install git+https://github.com/ComPWA/policy
-policy --help
-```
-
-Both commands install from the default branch, but `uv` caches the Git checkout and reuses it on later runs. To update an already-installed copy to the latest commit, add `--reinstall` (which implies `--refresh`):
-
-```shell
-uv tool upgrade --reinstall compwa-policy
-```
-
-When the `pwa` command is installed alongside this package, the same command is also available as `pwa policy ...` through a `pwa.commands` entry point.
+If you run the command often, you can install it as a persistent tool with [`uv tool install`](https://docs.astral.sh/uv/concepts/tools) (or `pipx install`) and call `policy` directly, updating it with `uv tool upgrade --reinstall compwa-policy`. When the `pwa` command is installed alongside this package, the same command is also available as `pwa policy ...` through a `pwa.commands` entry point.
 
 ## Hook arguments
 

--- a/src/compwa_policy/cli/_settings.py
+++ b/src/compwa_policy/cli/_settings.py
@@ -145,6 +145,17 @@ def _read_policy_config() -> dict[str, Any]:
 
 
 def _join(values: Any) -> str:
+    """Render a value as the legacy comma-separated command-line string.
+
+    >>> _join("3.6, 3.7")
+    '3.6, 3.7'
+    >>> _join(["3.6", "3.7"])
+    '3.6,3.7'
+    >>> _join({"A": "1", "B": "2"})
+    'A=1,B=2'
+    >>> _join(3)
+    '3'
+    """
     if isinstance(values, str):
         return values
     if isinstance(values, Mapping):
@@ -200,7 +211,7 @@ class Settings(BaseSettings):
     keep_issue_templates: bool = False
 
     @classmethod
-    def settings_customize_sources(
+    def settings_customise_sources(
         cls,
         settings_cls: type[BaseSettings],
         init_settings: PydanticBaseSettingsSource,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -150,6 +150,16 @@ class TestPyprojectConfig:
         with pytest.raises(ValueError, match="does_not_exist"):
             load_settings()
 
+    def test_environment_variables_do_not_leak(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _write_policy(tmp_path, monkeypatch, '[project]\nname = "x"\n')
+        monkeypatch.setenv("NO_PYPI", "true")
+        monkeypatch.setenv("PACKAGE_MANAGER", "pixi")
+        settings = load_settings()
+        assert settings.no_pypi is False
+        assert settings.package_manager == "uv"
+
 
 class TestBuildPolicy:
     def test_groups_into_sub_tables(self) -> None:


### PR DESCRIPTION
Closes #606

## 🐛 Bug fixes

- Stopped environment variables from leaking into the policy settings. The `pydantic-settings` source override was misspelled (`settings_customize_sources` instead of the British `settings_customise_sources` that `pydantic-settings` actually calls), so the custom source list was never applied and the default sources stayed active. As a result, variables such as `NO_PYPI` or `PACKAGE_MANAGER` present in the environment could silently override the `pyproject.toml` configuration. Renamed the method so only the intended sources are used, and added a regression test.

## 📝 Documentation

- Documented the Typer-based `policy` command in both the README and `docs/check-dev-files.md`, leading with the install-free `uvx --from git+https://github.com/ComPWA/policy policy ...` invocation and treating `uv tool install` / `pipx` as an afterthought.
- Added a prominent **`policy migrate`** section explaining that it applies breaking configuration changes the `check-dev-files` hook can only detect (and fail on), and therefore must be run **outside of `pre-commit`**. Surfaced it as a `[!IMPORTANT]` callout in the README and an admonition in the docs.
- Reframed the former "Migrating an existing `args:` list" subsection into a general "Migrating after breaking changes" section, listing the `args:`-to-`pyproject.toml` move and the `ComPWA/nbhooks` relocation as the two migrations it currently performs.
- Noted that `uvx` caches the Git checkout, documenting `--refresh` (and `uv tool upgrade --reinstall`) to pull the latest commit from the default branch.
- Added a doctest to the `_join` helper illustrating the legacy comma-separated string rendering.

## Squash commit messages

```text
* FIX: block environment variables from leaking into settings
* MAINT: add words to cSpell dictionary
```