### PR TITLE
FIX: prevent double unlink of .zenodo.json

### DIFF
--- a/src/compwa_policy/repo/citation.py
+++ b/src/compwa_policy/repo/citation.py
@@ -24,11 +24,11 @@ if TYPE_CHECKING:
 def main(precommit: ModifiablePrecommit) -> None:
     with Executor() as do:
         if CONFIG_PATH.zenodo.exists():
-            do(convert_zenodo_json)
-            do(remove_zenodo_json)
-        if CONFIG_PATH.citation.exists():
-            if CONFIG_PATH.zenodo.exists():
+            if CONFIG_PATH.citation.exists():
                 do(remove_zenodo_json)
+            else:
+                do(convert_zenodo_json)
+        if CONFIG_PATH.citation.exists():
             do(check_citation_keys)
             do(add_json_schema_precommit, precommit)
             do(vscode.add_extension_recommendation, "redhat.vscode-yaml")

--- a/tests/repo/test_citation.py
+++ b/tests/repo/test_citation.py
@@ -1,0 +1,231 @@
+import io
+import json
+from pathlib import Path
+from textwrap import dedent
+
+import pytest
+
+from compwa_policy.errors import PrecommitError
+from compwa_policy.repo import citation
+from compwa_policy.utilities.precommit import ModifiablePrecommit
+
+_ZENODO = {
+    "title": "My Software",
+    "description": "<p>Some <b>HTML</b> description</p>",
+    "creators": [
+        {"name": "Doe, John", "affiliation": "University", "orcid": "0000-0001"},
+        {"name": "Jane Smith"},
+    ],
+    "keywords": ["physics"],
+    "license": "MIT",
+}
+
+_VALID_CITATION = """
+cff-version: 1.2.0
+message: If you use this software, please cite it as below.
+title: My Software
+abstract: Some description
+authors:
+  - family-names: Doe
+    given-names: John
+keywords:
+  - physics
+license: MIT
+repository-code: https://github.com/ComPWA/policy
+"""
+
+
+def test_convert_zenodo_dict():
+    result = citation._convert_zenodo(_ZENODO)
+    assert result["title"] == "My Software"
+    assert "HTML" in result["abstract"]
+    assert result["authors"][0] == {
+        "family-names": "Doe",
+        "given-names": "John",
+        "affiliation": "University",
+        "orcid": "https://orcid.org/0000-0001",
+    }
+    assert result["authors"][1] == {"family-names": "Smith", "given-names": "Jane"}
+    assert result["keywords"] == ["physics"]
+    assert result["license"] == "MIT"
+
+
+def test_convert_zenodo_json(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".zenodo.json").write_text(json.dumps(_ZENODO))
+    with pytest.raises(PrecommitError, match=r"Converted"):
+        citation.convert_zenodo_json()
+    assert not (tmp_path / ".zenodo.json").exists()
+    assert (tmp_path / "CITATION.cff").exists()
+
+
+def test_remove_zenodo_json(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".zenodo.json").write_text("{}")
+    with pytest.raises(PrecommitError, match=r"Removed"):
+        citation.remove_zenodo_json()
+    assert not (tmp_path / ".zenodo.json").exists()
+
+
+def test_check_citation_keys_missing(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "CITATION.cff").write_text("cff-version: 1.2.0\n")
+    with pytest.raises(PrecommitError, match=r"missing the following keys"):
+        citation.check_citation_keys()
+
+
+def test_check_citation_keys_empty(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "CITATION.cff").write_text("")
+    with pytest.raises(PrecommitError, match=r"is empty"):
+        citation.check_citation_keys()
+
+
+def test_check_citation_keys_complete(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "CITATION.cff").write_text(_VALID_CITATION)
+    citation.check_citation_keys()  # all expected keys present -> no error
+
+
+def test_add_json_schema_precommit(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "CITATION.cff").write_text(_VALID_CITATION)
+    with (
+        pytest.raises(PrecommitError, match=r"Updated pre-commit hook"),
+        ModifiablePrecommit.load(io.StringIO("repos: []\n")) as precommit,
+    ):
+        citation.add_json_schema_precommit(precommit)
+    assert "check-jsonschema" in precommit.dumps()
+
+
+def test_add_json_schema_precommit_is_idempotent(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    # cspell:ignore schemafile
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "CITATION.cff").write_text(_VALID_CITATION)
+    existing = dedent("""
+        repos:
+          - repo: https://github.com/python-jsonschema/check-jsonschema
+            rev: 0.28.0
+            hooks:
+              - id: check-jsonschema
+                name: Check CITATION.cff
+                args:
+                  - --default-filetype
+                  - yaml
+                  - --schemafile
+                  - https://citation-file-format.github.io/1.2.0/schema.json
+                  - CITATION.cff
+                pass_filenames: false
+    """).lstrip()
+    with ModifiablePrecommit.load(io.StringIO(existing)) as precommit:
+        citation.add_json_schema_precommit(precommit)  # already present -> no change
+
+
+def test_add_json_schema_precommit_replaces_outdated_hook(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "CITATION.cff").write_text(_VALID_CITATION)
+    existing = dedent("""
+        repos:
+          - repo: https://github.com/python-jsonschema/check-jsonschema
+            rev: 0.28.0
+            hooks:
+              - id: check-jsonschema
+                name: Check CITATION.cff
+                args:
+                  - --schemafile
+                  - https://example.test/outdated-schema.json
+                  - CITATION.cff
+    """).lstrip()
+    with (
+        pytest.raises(PrecommitError, match=r"Updated pre-commit hook"),
+        ModifiablePrecommit.load(io.StringIO(existing)) as precommit,
+    ):
+        citation.add_json_schema_precommit(precommit)
+    result = precommit.dumps()
+    assert "outdated-schema" not in result  # stale args replaced
+    assert "citation-file-format.github.io/1.2.0/schema.json" in result
+
+
+def test_add_json_schema_precommit_without_citation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.chdir(tmp_path)
+    with ModifiablePrecommit.load(io.StringIO("repos: []\n")) as precommit:
+        citation.add_json_schema_precommit(precommit)  # no CITATION.cff -> no-op
+
+
+def test_main_with_citation(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "CITATION.cff").write_text(_VALID_CITATION)
+    with (
+        pytest.raises(PrecommitError),
+        ModifiablePrecommit.load(io.StringIO("repos: []\n")) as precommit,
+    ):
+        citation.main(precommit)
+    assert "check-jsonschema" in precommit.dumps()
+
+
+def test_main_with_only_zenodo(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Regression test for https://github.com/ComPWA/policy/issues/616."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".zenodo.json").write_text(json.dumps(_ZENODO))
+    with (
+        pytest.raises(PrecommitError),
+        ModifiablePrecommit.load(io.StringIO("repos: []\n")) as precommit,
+    ):
+        citation.main(precommit)
+    assert not (tmp_path / ".zenodo.json").exists()
+    assert (tmp_path / "CITATION.cff").exists()
+    assert "check-jsonschema" in precommit.dumps()
+
+
+def test_main_with_both_zenodo_and_citation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".zenodo.json").write_text(json.dumps(_ZENODO))
+    (tmp_path / "CITATION.cff").write_text(_VALID_CITATION)
+    with (
+        pytest.raises(PrecommitError),
+        ModifiablePrecommit.load(io.StringIO("repos: []\n")) as precommit,
+    ):
+        citation.main(precommit)
+    assert not (tmp_path / ".zenodo.json").exists()
+    assert (tmp_path / "CITATION.cff").exists()
+
+
+def test_convert_zenodo_minimal():
+    result = citation._convert_zenodo({"title": "Bare"})
+    assert result["title"] == "Bare"
+    assert "abstract" not in result
+    assert "authors" not in result  # no creators
+    assert "keywords" not in result
+    assert "license" not in result
+
+
+def test_add_json_schema_precommit_appends_to_existing_repo(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "CITATION.cff").write_text(_VALID_CITATION)
+    existing = dedent("""
+        repos:
+          - repo: https://github.com/python-jsonschema/check-jsonschema
+            rev: 0.28.0
+            hooks:
+              - id: check-jsonschema
+                name: Check GitHub Workflows
+                files: ^\\.github/workflows/
+    """).lstrip()
+    with (
+        pytest.raises(PrecommitError, match=r"Updated pre-commit hook"),
+        ModifiablePrecommit.load(io.StringIO(existing)) as precommit,
+    ):
+        citation.add_json_schema_precommit(precommit)
+    result = precommit.dumps()
+    assert "Check GitHub Workflows" in result  # original hook kept
+    assert "Check CITATION.cff" in result  # new hook appended


### PR DESCRIPTION
Closes #616

## 🐛 Bug fixes

- Prevent a double `unlink` of `.zenodo.json` in `citation.main`. When both `.zenodo.json` and `CITATION.cff` were present, `remove_zenodo_json` was scheduled twice, causing a `FileNotFoundError` on the second removal. The logic now removes `.zenodo.json` when a `CITATION.cff` already exists and otherwise converts it, so the file is only ever unlinked once.

## 🖱️ Developer experience

- Add a `tests/repo/test_citation.py` test module covering `citation.main` and its helpers, including a regression test for the double-unlink scenario (#616) and cases for Zenodo conversion, citation-key checks, and the JSON-schema pre-commit hook.

## Squash commit messages

```text
* DX: add tests for repo.citation
```