### PR TITLE
FIX: update local pre-commit hooks by ID

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,7 +127,6 @@ no-pypi = true
 
 [tool.compwa.policy.python]
 branch-coverage = false
-keep-local-precommit = true
 type-checker = ["ty"]
 
 [tool.coverage.report]

--- a/src/compwa_policy/__init__.py
+++ b/src/compwa_policy/__init__.py
@@ -45,7 +45,6 @@ class Arguments:
     imports_on_top: bool
     keep_contributing_md: bool
     keep_issue_templates: bool
-    keep_local_precommit: bool
     keep_pr_linting: bool
     keep_workflow: set[str] = field(converter=set)
     macos_python_version: PythonVersion | None

--- a/src/compwa_policy/cli/_checks.py
+++ b/src/compwa_policy/cli/_checks.py
@@ -190,7 +190,7 @@ def run_checks(  # noqa: C901, PLR0912, PLR0915
         do(pyproject.main, args.excluded_python_versions)
         do(mypy.main, "mypy" in args.type_checker, precommit_config)
         do(pyright.main, "pyright" in args.type_checker, precommit_config)
-        do(ty.main, args.type_checker, args.keep_local_precommit, precommit_config)
+        do(ty.main, args.type_checker, precommit_config)
         do(
             pytest.main,
             args.allow_vscode_coverage_gutters,

--- a/src/compwa_policy/cli/_options.py
+++ b/src/compwa_policy/cli/_options.py
@@ -125,12 +125,6 @@ TypeCheckerOption = Annotated[
         "--type-checker", help="Specify which type checker to use for the project."
     ),
 ]
-KeepLocalPrecommit = Annotated[
-    bool | None,
-    typer.Option(
-        "--keep-local-precommit", help="Do not remove local pre-commit hooks."
-    ),
-]
 PytestSingleThreaded = Annotated[
     bool | None,
     typer.Option(

--- a/src/compwa_policy/cli/_settings.py
+++ b/src/compwa_policy/cli/_settings.py
@@ -68,7 +68,6 @@ _SCOPED_OPTIONS: dict[str, frozenset[str]] = {
         "branch_coverage",
         "excluded_python_versions",
         "imports_on_top",
-        "keep_local_precommit",
         "type_checker",
     }),
     "github": frozenset({
@@ -188,7 +187,6 @@ class Settings(BaseSettings):
     imports_on_top: bool = False
     branch_coverage: bool = True
     type_checker: list[str] = []
-    keep_local_precommit: bool = False
     pytest_single_threaded: bool = False
     allow_vscode_coverage_gutters: bool = False
     allow_labels: bool = False

--- a/src/compwa_policy/cli/migrate.py
+++ b/src/compwa_policy/cli/migrate.py
@@ -57,7 +57,6 @@ GROUP_FLAGS: dict[str, tuple[str, ...]] = {
         "--branch-coverage",
         "--excluded-python-versions",
         "--imports-on-top",
-        "--keep-local-precommit",
         "--no-branch-coverage",
         "--no-ruff",
         "--pytest-single-threaded",

--- a/src/compwa_policy/cli/python.py
+++ b/src/compwa_policy/cli/python.py
@@ -9,7 +9,6 @@ from compwa_policy.cli._options import (
     DevPythonVersion,
     ExcludedPythonVersions,
     ImportsOnTop,
-    KeepLocalPrecommit,
     NoRuff,
     PytestSingleThreaded,
     Python,
@@ -26,7 +25,6 @@ def python(  # noqa: PLR0917
     no_ruff: NoRuff = None,
     imports_on_top: ImportsOnTop = None,
     branch_coverage: BranchCoverage = None,
-    keep_local_precommit: KeepLocalPrecommit = None,
     pytest_single_threaded: PytestSingleThreaded = None,
     allow_vscode_coverage_gutters: AllowVscodeCoverageGutters = None,
 ) -> None:
@@ -39,7 +37,6 @@ def python(  # noqa: PLR0917
         no_ruff=no_ruff,
         imports_on_top=imports_on_top,
         branch_coverage=branch_coverage,
-        keep_local_precommit=keep_local_precommit,
         pytest_single_threaded=pytest_single_threaded,
         allow_vscode_coverage_gutters=allow_vscode_coverage_gutters,
     )

--- a/src/compwa_policy/python/ty.py
+++ b/src/compwa_policy/python/ty.py
@@ -21,18 +21,13 @@ TypeChecker = Literal["mypy", "pyright", "ty"]
 """The type of type checkers supported."""
 
 
-def main(
-    type_checkers: set[TypeChecker],
-    keep_precommit: bool,
-    precommit: ModifiablePrecommit,
-) -> None:
+def main(type_checkers: set[TypeChecker], precommit: ModifiablePrecommit) -> None:
     with Executor() as do, ModifiablePyproject.load() as pyproject:
         do(_update_vscode_settings, type_checkers)
         if "ty" in type_checkers:
             do(_update_configuration, pyproject)
             do(pyproject.add_dependency, "ty", dependency_group=["style", "dev"])
-            if not keep_precommit:
-                do(_update_precommit_config, precommit)
+            do(_update_precommit_config, precommit)
         else:
             do(_remove_ty, precommit, pyproject)
 

--- a/src/compwa_policy/utilities/precommit/setters.py
+++ b/src/compwa_policy/utilities/precommit/setters.py
@@ -60,8 +60,11 @@ def update_single_hook_precommit_repo(
     expected_yaml = CommentedMap(expected)
     repos = precommit.document.get("repos", [])
     repo_url = expected["repo"]
-    idx_and_repo = find_repo_with_index(precommit.document, repo_url)
     hook_id = expected["hooks"][0]["id"]
+    if repo_url == "local":
+        idx_and_repo = __find_local_repo_and_hook_idx(precommit.document, hook_id)
+    else:
+        idx_and_repo = find_repo_with_index(precommit.document, repo_url)
     if idx_and_repo is None:
         if not expected_yaml.get("rev") and repo_url != "local":
             expected_yaml.pop("rev", None)
@@ -78,9 +81,11 @@ def update_single_hook_precommit_repo(
         precommit.changelog.append(msg)
     if idx_and_repo is None:
         return
-    idx, existing_hook = idx_and_repo
-    if not _is_equivalent_repo(existing_hook, expected):
-        existing_rev = existing_hook.get("rev")
+    idx, existing_repo = idx_and_repo
+    if repo_url == "local":
+        __update_local_hook(precommit, existing_repo, expected["hooks"][0])
+    elif not _is_equivalent_repo(existing_repo, expected):
+        existing_rev = existing_repo.get("rev")
         if existing_rev is not None:
             expected_yaml.insert(1, "rev", PlainScalarString(existing_rev))
         repos[idx] = expected_yaml  # ty:ignore[invalid-assignment]
@@ -88,6 +93,32 @@ def update_single_hook_precommit_repo(
         repos_map.yaml_set_comment_before_after_key(idx + 1, before="\n")
         msg = f"Updated {hook_id} hook"
         precommit.changelog.append(msg)
+
+
+def __find_local_repo_and_hook_idx(
+    config: PrecommitConfig, hook_id: str
+) -> tuple[int, Repo] | None:
+    repos = config.get("repos", [])
+    for idx, repo in enumerate(repos):
+        if repo.get("repo") != "local":
+            continue
+        if __find_hook_idx(repo.get("hooks", []), hook_id) is not None:
+            return idx, repo
+    return None
+
+
+def __update_local_hook(
+    precommit: ModifiablePrecommit, existing_repo: Repo, expected_hook: Hook
+) -> None:
+    hooks = existing_repo["hooks"]
+    hook_idx = __find_hook_idx(hooks, expected_hook["id"])
+    if hook_idx is None:
+        return
+    if hooks[hook_idx] == expected_hook:
+        return
+    hooks[hook_idx] = expected_hook
+    msg = f"Updated {expected_hook['id']} hook"
+    precommit.changelog.append(msg)
 
 
 def _determine_expected_repo_index(config: PrecommitConfig, hook_id: str) -> int:

--- a/tests/python/test_ty.py
+++ b/tests/python/test_ty.py
@@ -154,7 +154,7 @@ def describe_main():
             pytest.raises(PrecommitError),
             ModifiablePrecommit.load(io.StringIO("repos: []\n")) as precommit,
         ):
-            main({"ty"}, keep_precommit=False, precommit=precommit)
+            main({"ty"}, precommit=precommit)
         # All steps are applied in a single pass (no per-step short-circuit).
         pyproject_text = (tmp_path / "pyproject.toml").read_text()
         assert "[tool.ty.rules]" in pyproject_text
@@ -180,6 +180,6 @@ def describe_main():
             pytest.raises(PrecommitError),
             ModifiablePrecommit.load(io.StringIO(precommit_yaml)) as precommit,
         ):
-            main(set(), keep_precommit=False, precommit=precommit)
+            main(precommit=precommit, type_checkers=set())
         assert "tool.ty" not in (tmp_path / "pyproject.toml").read_text()
         assert "id: ty" not in precommit.dumps()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -197,7 +197,6 @@ def describe_build_policy():
         policy = _build_policy([
             "--allow-labels",
             "--no-branch-coverage",
-            "--keep-local-precommit",
             "--no-pypi",
             "--pytest-single-threaded",
             "--repo-name=policy",
@@ -208,7 +207,6 @@ def describe_build_policy():
             "github": {"allow-labels": True, "no-pypi": True},
             "python": {
                 "branch-coverage": False,
-                "keep-local-precommit": True,
                 "type-checker": ["ty"],
             },
             "pytest-single-threaded": True,

--- a/tests/utilities/precommit/test_setters.py
+++ b/tests/utilities/precommit/test_setters.py
@@ -1,0 +1,101 @@
+import io
+from textwrap import dedent
+
+import pytest
+
+from compwa_policy.errors import PrecommitError
+from compwa_policy.utilities.precommit import ModifiablePrecommit
+from compwa_policy.utilities.precommit.struct import Hook, Repo
+
+
+def _expected_ty_repo() -> Repo:
+    return Repo(
+        repo="local",
+        hooks=[
+            Hook(
+                id="ty",
+                name="ty",
+                entry="ty check",
+                language="system",
+            )
+        ],
+    )
+
+
+def describe_update_single_hook_precommit_repo():
+    def preserves_unrelated_local_repo_when_adding_managed_hook():
+        config = dedent("""
+            repos:
+              - repo: local
+                hooks:
+                  - id: check-foo
+                    name: check-foo
+                    entry: check-foo
+                    language: system
+        """).lstrip()
+
+        with (
+            pytest.raises(PrecommitError),
+            ModifiablePrecommit.load(io.StringIO(config)) as precommit,
+        ):
+            precommit.update_single_hook_repo(_expected_ty_repo())
+
+        result = precommit.dumps()
+        assert "id: check-foo" in result
+        assert "id: ty" in result
+        assert result.count("repo: local") == 2
+
+    def updates_managed_local_hook_by_id():
+        config = dedent("""
+            repos:
+              - repo: local
+                hooks:
+                  - id: check-foo
+                    name: check-foo
+                    entry: check-foo
+                    language: system
+
+              - repo: local
+                hooks:
+                  - id: ty
+                    name: ty
+                    entry: ty
+                    language: system
+        """).lstrip()
+
+        with (
+            pytest.raises(PrecommitError),
+            ModifiablePrecommit.load(io.StringIO(config)) as precommit,
+        ):
+            precommit.update_single_hook_repo(_expected_ty_repo())
+
+        result = precommit.dumps()
+        assert "id: check-foo" in result
+        assert "entry: ty check" in result
+        assert result.count("id: ty") == 1
+
+    def preserves_sibling_hooks_in_matching_local_repo():
+        config = dedent("""
+            repos:
+              - repo: local
+                hooks:
+                  - id: check-foo
+                    name: check-foo
+                    entry: check-foo
+                    language: system
+                  - id: ty
+                    name: ty
+                    entry: ty
+                    language: system
+        """).lstrip()
+
+        with (
+            pytest.raises(PrecommitError),
+            ModifiablePrecommit.load(io.StringIO(config)) as precommit,
+        ):
+            precommit.update_single_hook_repo(_expected_ty_repo())
+
+        result = precommit.dumps()
+        assert "id: check-foo" in result
+        assert "entry: ty check" in result
+        assert result.count("repo: local") == 1


### PR DESCRIPTION
Closes https://github.com/ComPWA/policy/issues/624

## 🐛 Bug fixes

- Local pre-commit hooks (`repo: local`) are now updated **by hook ID** instead of being skipped. `update_single_hook_precommit_repo` locates the matching `local` repo by the expected hook's `id`, updates that hook in place, and leaves unrelated `local` repos and sibling hooks within the same repo untouched.

## ⚠️ Interface changes

The `--keep-local-precommit` escape hatch is no longer needed now that local hooks are updated correctly by ID, so it has been removed:

| Old name                                     | New name |
| -------------------------------------------- | -------- |
| `--keep-local-precommit` CLI flag            | removed  |
| `keep-local-precommit` `pyproject` key       | removed  |
| `Arguments.keep_local_precommit`             | removed  |
| `ty.main(..., keep_precommit, ...)` argument | removed  |

## Squash commit messages

```text
* BREAK: remove `--keep-local-precommit` option
```