### PR TITLE
FIX: make `migrate` work without `pyproject.toml`

### DIFF
--- a/src/compwa_policy/cli/migrate.py
+++ b/src/compwa_policy/cli/migrate.py
@@ -140,10 +140,9 @@ def migrate(
 
 
 def _assert_inputs_exist(config_file: Path) -> None:
-    for path in (config_file, CONFIG_PATH.pyproject):
-        if not path.exists():
-            rich.print(f"[red]No such file:[/red] {path}")
-            raise typer.Exit(code=1)
+    if not config_file.exists():
+        rich.print(f"[red]No such file:[/red] {config_file}")
+        raise typer.Exit(code=1)
 
 
 def _build_validated_policy(args: list[str]) -> dict[str, Any]:
@@ -243,10 +242,14 @@ def _render(policy: dict[str, Any]) -> str:
 
 
 def _write_pyproject(policy: dict[str, Any]) -> None:
-    pyproject = ModifiablePyproject.load()
+    pyproject = ModifiablePyproject.load(
+        CONFIG_PATH.pyproject if CONFIG_PATH.pyproject.exists() else ""
+    )
     try:
         with pyproject:
             _apply(pyproject, policy)
+            if not CONFIG_PATH.pyproject.exists():
+                pyproject.dump(CONFIG_PATH.pyproject)
             pyproject.changelog.append(f"imported args of the '{_HOOK_ID}' hook")
     except PrecommitError:
         pass

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -275,6 +275,25 @@ def describe_migrate():
                 "args must be preserved"
             )
 
+        def relocates_without_pyproject(
+            tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+        ) -> None:
+            monkeypatch.chdir(tmp_path)
+            config = tmp_path / ".pre-commit-config.yaml"
+            config.write_text(_CONFIG_WITH_NOTEBOOK_HOOK)
+
+            migrate(config_file=config, dry_run=False)
+
+            repos = {
+                repo["repo"]: repo
+                for repo in yaml.safe_load(config.read_text())["repos"]
+            }
+            policy_hooks = repos["https://github.com/ComPWA/policy"]["hooks"]
+            nbhooks = repos["https://github.com/ComPWA/nbhooks"]["hooks"]
+            assert {h["id"] for h in policy_hooks} == {"check-dev-files"}
+            assert {h["id"] for h in nbhooks} == {"set-nb-cells"}
+            assert not (tmp_path / "pyproject.toml").exists()
+
         def dry_run_does_not_modify(tmp_path: Path) -> None:
             (tmp_path / "pyproject.toml").write_text('[project]\nname = "x"\n')
             config = tmp_path / ".pre-commit-config.yaml"
@@ -292,15 +311,29 @@ def describe_migrate():
             migrate(config_file=tmp_path / "does-not-exist.yaml")
         assert exc.value.exit_code == 1
 
-    def exits_on_missing_pyproject(
+    def migrates_args_into_new_pyproject(
         tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         monkeypatch.chdir(tmp_path)
         config = tmp_path / ".pre-commit-config.yaml"
-        config.write_text("repos: []\n")
-        with pytest.raises(typer.Exit) as exc:
-            migrate(config_file=config)
-        assert exc.value.exit_code == 1
+        config.write_text(
+            dedent("""
+            repos:
+              - repo: https://github.com/ComPWA/policy
+                rev: 0.1.0
+                hooks:
+                  - id: check-dev-files
+                    args: [--no-pypi, --repo-name=demo]
+            """).lstrip()
+        )
+
+        migrate(config_file=config)
+
+        pyproject = (tmp_path / "pyproject.toml").read_text()
+        assert "no-pypi = true" in pyproject
+        assert 'repo-name = "demo"' in pyproject
+        hooks = yaml.safe_load(config.read_text())["repos"][0]["hooks"]
+        assert "args" not in hooks[0], "args must be stripped after migration"
 
     def exits_when_no_hook_found(
         tmp_path: Path, monkeypatch: pytest.MonkeyPatch


### PR DESCRIPTION
Closes #635