### PR TITLE
FIX: unquote `repo-title` in `policy migrate`

### DIFF
--- a/src/compwa_policy/cli/migrate.py
+++ b/src/compwa_policy/cli/migrate.py
@@ -14,6 +14,7 @@ entry, since those hooks were extracted into a separate repository.
 from __future__ import annotations
 
 import contextlib
+import shlex
 from pathlib import Path
 from typing import TYPE_CHECKING, Annotated, Any, get_origin
 
@@ -210,6 +211,7 @@ def _build_policy(args: list[str]) -> dict[str, Any]:
     environment_variables: dict[str, str] = {}
     for arg in args:
         flag, separator, raw_value = arg.partition("=")
+        raw_value = _unquote_cli_value(raw_value)
         if flag in {"--python", "--no-python"}:
             policy["python"] = flag == "--python"
             continue
@@ -234,6 +236,22 @@ def _build_policy(args: list[str]) -> dict[str, Any]:
     if environment_variables:
         policy.setdefault("setup", {})["env"] = environment_variables
     return policy
+
+
+def _unquote_cli_value(value: str) -> str:
+    """Strip shell quotes from a single option value carried through YAML.
+
+    In a shell, ``--repo-title="ComPWA demos"`` arrives as ``--repo-title=ComPWA
+    demos``. In a pre-commit YAML ``args`` list, the quote characters are part of the
+    scalar, so migration has to remove them explicitly.
+    """
+    try:
+        values = shlex.split(value)
+    except ValueError:
+        return value
+    if len(values) == 1:
+        return values[0]
+    return value
 
 
 def _render(policy: dict[str, Any]) -> str:

--- a/tests/cli/test_migrate.py
+++ b/tests/cli/test_migrate.py
@@ -66,3 +66,16 @@ def describe_migrate():
         pyproject = (tmp_path / "pyproject.toml").read_text()
         assert 'repo-name = "demo"' in pyproject
         assert "[tool.compwa.policy]\nrepo-name" in pyproject
+
+    def strips_shell_quotes_from_migrated_arg_values(
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture,
+    ):
+        _write_repo(tmp_path, ['--repo-title="ComPWA demos"'])
+        monkeypatch.chdir(tmp_path)
+        migrate(Path(".pre-commit-config.yaml"))
+        capsys.readouterr()
+        pyproject = (tmp_path / "pyproject.toml").read_text()
+        assert 'repo-title = "ComPWA demos"' in pyproject
+        assert R'repo-title = "\"ComPWA demos\""' not in pyproject


### PR DESCRIPTION
Closes #644

## 🐛 Bug fixes

- Strip shell quotes from option values when migrating pre-commit `args` to `[tool.compwa.policy]`. In a shell, `--repo-title="ComPWA demos"` reaches the program as `--repo-title=ComPWA demos`, but inside a pre-commit YAML `args` list the quote characters are part of the scalar. `policy migrate` now removes them via `shlex`, so `repo-title = "ComPWA demos"` is written instead of a doubly-quoted `repo-title = "\"ComPWA demos\""`.