### PR TITLE
ENH: manage file resources through `Session`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ pyvenv*/
 uv.lock
 
 # Settings
+.agents/
 .claude/
 .codex/
 .idea/

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -33,6 +33,7 @@ api_target_substitutions: dict[str, str | tuple[str, str]] = {
     "Sequence": "typing.Sequence",
     "T": "typing.TypeVar",
     "Table": "tomlkit.items.Table",
+    "Token": "contextvars.Token",
     "TOMLDocument": "tomlkit.TOMLDocument",
     "ty.TypeChecker": ("obj", "compwa_policy.python.ty.TypeChecker"),
     "TypeChecker": ("obj", "compwa_policy.python.ty.TypeChecker"),
@@ -115,6 +116,7 @@ myst_enable_extensions = [
 ]
 nitpick_ignore = [
     ("py:class", "CommentedMap"),
+    ("py:class", "compwa_policy.utilities.vscode._ModifiableJsonResource"),
     ("py:class", "ProjectURLs"),
 ]
 nitpick_ignore_regex = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -290,10 +290,10 @@ ref = "test"
 help = "Run all continuous integration (CI) tasks locally"
 ignore_fail = "return_non_zero"
 sequence = [
+    "style",
     "cov",
     "doc",
     "linkcheck",
-    "style",
     "test-all",
 ]
 

--- a/src/compwa_policy/cli/_checks.py
+++ b/src/compwa_policy/cli/_checks.py
@@ -98,7 +98,7 @@ def _run(args: Arguments, groups: frozenset[Group]) -> int:
     try:
         with Session.load() as session:
             run_checks(session, args, ctx, groups=groups)
-            changes = session.collect_changes()
+            changes = session.flush()
     except PolicyError as exception:
         print("\n".join(exception.args))  # noqa: T201
         return 1

--- a/src/compwa_policy/env/conda.py
+++ b/src/compwa_policy/env/conda.py
@@ -9,7 +9,6 @@ from ruamel.yaml.scalarstring import PlainScalarString
 
 from compwa_policy.utilities import CONFIG_PATH, remove_lines
 from compwa_policy.utilities.pyproject import (
-    Pyproject,
     PythonVersion,
     get_constraints_file,
     has_pyproject_package_name,
@@ -29,24 +28,24 @@ def main(
     package_manager: PackageManagerChoice,
 ) -> None:
     if package_manager == "conda":
-        session.changelog += update_conda_environment(python_version, session=session)
+        session.changelog += update_conda_environment(session, python_version)
     else:
-        session.changelog += _remove_conda_configuration(session=session)
+        session.changelog += _remove_conda_configuration(session)
 
 
 def update_conda_environment(
-    python_version: PythonVersion,
-    *,
     session: Session,
+    /,
+    python_version: PythonVersion,
 ) -> Changelog:
-    if not has_pyproject_package_name(session=session):
+    if not has_pyproject_package_name(session):
         return []
     yaml = create_prettier_round_trip_yaml()
     updated = False
     if CONFIG_PATH.conda.exists():
         conda_env: CommentedMap = yaml.load(CONFIG_PATH.conda)
     else:
-        conda_env = __create_conda_environment(python_version, session=session)
+        conda_env = __create_conda_environment(session, python_version)
         updated = True
     if "dependencies" not in conda_env:
         conda_env["dependencies"] = CommentedSeq()
@@ -61,11 +60,12 @@ def update_conda_environment(
 
 
 def __create_conda_environment(
-    python_version: PythonVersion,
-    *,
     session: Session,
+    /,
+    python_version: PythonVersion,
 ) -> CommentedMap:
-    package_name = Pyproject.load(session=session).get_package_name()
+    pyproject = session.pyproject
+    package_name = pyproject.get_package_name() if pyproject is not None else None
     return CommentedMap({
         "name": str(package_name) if package_name is not None else None,
         "channels": ["defaults"],
@@ -120,14 +120,12 @@ def __get_pip_dependencies(dependencies: CommentedSeq) -> CommentedSeq | None:
     return None
 
 
-def _remove_conda_configuration(*, session: Session) -> Changelog:
+def _remove_conda_configuration(session: Session, /) -> Changelog:
     changes: Changelog = []
     changes += __remove_environment_yml()
     # cspell:ignore condaenv
-    changes += remove_lines(CONFIG_PATH.gitignore, r".*condaenv.*", session=session)
-    changes += remove_lines(
-        CONFIG_PATH.gitignore, r".*environment\.yml.*", session=session
-    )
+    changes += remove_lines(session, CONFIG_PATH.gitignore, r".*condaenv.*")
+    changes += remove_lines(session, CONFIG_PATH.gitignore, r".*environment\.yml.*")
     return changes
 
 

--- a/src/compwa_policy/env/conda.py
+++ b/src/compwa_policy/env/conda.py
@@ -37,7 +37,7 @@ def main(
 def update_conda_environment(
     python_version: PythonVersion,
     *,
-    session: Session | None = None,
+    session: Session,
 ) -> Changelog:
     if not has_pyproject_package_name(session=session):
         return []
@@ -63,7 +63,7 @@ def update_conda_environment(
 def __create_conda_environment(
     python_version: PythonVersion,
     *,
-    session: Session | None = None,
+    session: Session,
 ) -> CommentedMap:
     package_name = Pyproject.load(session=session).get_package_name()
     return CommentedMap({
@@ -120,7 +120,7 @@ def __get_pip_dependencies(dependencies: CommentedSeq) -> CommentedSeq | None:
     return None
 
 
-def _remove_conda_configuration(*, session: Session | None = None) -> Changelog:
+def _remove_conda_configuration(*, session: Session) -> Changelog:
     changes: Changelog = []
     changes += __remove_environment_yml()
     # cspell:ignore condaenv

--- a/src/compwa_policy/env/conda.py
+++ b/src/compwa_policy/env/conda.py
@@ -29,20 +29,24 @@ def main(
     package_manager: PackageManagerChoice,
 ) -> None:
     if package_manager == "conda":
-        session.changelog += update_conda_environment(python_version)
+        session.changelog += update_conda_environment(python_version, session=session)
     else:
-        session.changelog += _remove_conda_configuration()
+        session.changelog += _remove_conda_configuration(session=session)
 
 
-def update_conda_environment(python_version: PythonVersion) -> Changelog:
-    if not has_pyproject_package_name():
+def update_conda_environment(
+    python_version: PythonVersion,
+    *,
+    session: Session | None = None,
+) -> Changelog:
+    if not has_pyproject_package_name(session=session):
         return []
     yaml = create_prettier_round_trip_yaml()
     updated = False
     if CONFIG_PATH.conda.exists():
         conda_env: CommentedMap = yaml.load(CONFIG_PATH.conda)
     else:
-        conda_env = __create_conda_environment(python_version)
+        conda_env = __create_conda_environment(python_version, session=session)
         updated = True
     if "dependencies" not in conda_env:
         conda_env["dependencies"] = CommentedSeq()
@@ -56,9 +60,14 @@ def update_conda_environment(python_version: PythonVersion) -> Changelog:
     return []
 
 
-def __create_conda_environment(python_version: PythonVersion) -> CommentedMap:
+def __create_conda_environment(
+    python_version: PythonVersion,
+    *,
+    session: Session | None = None,
+) -> CommentedMap:
+    package_name = Pyproject.load(session=session).get_package_name()
     return CommentedMap({
-        "name": Pyproject.load().get_package_name(),
+        "name": str(package_name) if package_name is not None else None,
         "channels": ["defaults"],
         "dependencies": [
             f"python=={python_version}.*",
@@ -111,12 +120,14 @@ def __get_pip_dependencies(dependencies: CommentedSeq) -> CommentedSeq | None:
     return None
 
 
-def _remove_conda_configuration() -> Changelog:
+def _remove_conda_configuration(*, session: Session | None = None) -> Changelog:
     changes: Changelog = []
     changes += __remove_environment_yml()
     # cspell:ignore condaenv
-    changes += remove_lines(CONFIG_PATH.gitignore, r".*condaenv.*")
-    changes += remove_lines(CONFIG_PATH.gitignore, r".*environment\.yml.*")
+    changes += remove_lines(CONFIG_PATH.gitignore, r".*condaenv.*", session=session)
+    changes += remove_lines(
+        CONFIG_PATH.gitignore, r".*environment\.yml.*", session=session
+    )
     return changes
 
 

--- a/src/compwa_policy/env/conda.py
+++ b/src/compwa_policy/env/conda.py
@@ -28,18 +28,18 @@ def main(
     package_manager: PackageManagerChoice,
 ) -> None:
     if package_manager == "conda":
-        session.changelog += update_conda_environment(session, python_version)
+        update_conda_environment(session, python_version)
     else:
-        session.changelog += _remove_conda_configuration(session)
+        _remove_conda_configuration(session)
 
 
 def update_conda_environment(
     session: Session,
     /,
     python_version: PythonVersion,
-) -> Changelog:
+) -> None:
     if not has_pyproject_package_name(session):
-        return []
+        return
     yaml = create_prettier_round_trip_yaml()
     updated = False
     if CONFIG_PATH.conda.exists():
@@ -55,8 +55,7 @@ def update_conda_environment(
     if updated:
         yaml.dump(conda_env, CONFIG_PATH.conda)
         msg = f"Updated Conda environment for Python {python_version}"
-        return [msg]
-    return []
+        session.changelog.append(msg)
 
 
 def __create_conda_environment(
@@ -120,13 +119,11 @@ def __get_pip_dependencies(dependencies: CommentedSeq) -> CommentedSeq | None:
     return None
 
 
-def _remove_conda_configuration(session: Session, /) -> Changelog:
-    changes: Changelog = []
-    changes += __remove_environment_yml()
+def _remove_conda_configuration(session: Session, /) -> None:
+    session.changelog += __remove_environment_yml()
     # cspell:ignore condaenv
-    changes += remove_lines(session, CONFIG_PATH.gitignore, r".*condaenv.*")
-    changes += remove_lines(session, CONFIG_PATH.gitignore, r".*environment\.yml.*")
-    return changes
+    remove_lines(session, CONFIG_PATH.gitignore, r".*condaenv.*")
+    remove_lines(session, CONFIG_PATH.gitignore, r".*environment\.yml.*")
 
 
 def __remove_environment_yml() -> Changelog:

--- a/src/compwa_policy/env/direnv.py
+++ b/src/compwa_policy/env/direnv.py
@@ -26,29 +26,29 @@ def main(
         session.changelog += __update_envrc_content(script)
         return
     if package_manager == "pixi+uv":
-        script = __get_pixi_direnv() + "\n"
+        script = __get_pixi_direnv(session=session) + "\n"
         script += __get_uv_direnv(variables) + "\n"
         session.changelog += __update_envrc_content(script)
         return
     if package_manager == "pixi":
-        script = __get_pixi_direnv() + "\n"
+        script = __get_pixi_direnv(session=session) + "\n"
         session.changelog += __update_envrc_content(script)
         return
     statements: list[tuple[str | None, str]] = [
         (".venv", "source .venv/bin/activate"),
         ("venv", "source venv/bin/activate"),
     ]
-    if has_pixi_config():
-        script = __get_pixi_direnv()
+    if has_pixi_config(session.pyproject):
+        script = __get_pixi_direnv(session=session)
         statements.append((".pixi", script))
     if CONFIG_PATH.conda.exists():
         statements.append((None, "layout anaconda"))
     session.changelog += _update_envrc(statements)
 
 
-def __get_pixi_direnv() -> str:
+def __get_pixi_direnv(*, session: Session | None = None) -> str:
     environment_flag = ""
-    dev_environment = __determine_pixi_dev_environment()
+    dev_environment = __determine_pixi_dev_environment(session=session)
     if dev_environment is not None:
         environment_flag = f" --environment {dev_environment}"
     return dedent(f"""
@@ -67,26 +67,26 @@ def __get_uv_direnv(variables: dict[str, str]) -> str:
     return script.strip()
 
 
-def __determine_pixi_dev_environment() -> str | None:
+def __determine_pixi_dev_environment(*, session: Session | None = None) -> str | None:
     search_terms = ["dev"]
     if CONFIG_PATH.pyproject.exists():
-        pyproject = Pyproject.load()
+        pyproject = Pyproject.load(session=session)
         package_name = pyproject.get_package_name()
         if package_name is not None:
             search_terms.append(package_name)
-    available_environments = __get_pixi_environment_names()
+    available_environments = __get_pixi_environment_names(session=session)
     for candidate in search_terms:
         if candidate in available_environments:
             return candidate
     return None
 
 
-def __get_pixi_environment_names() -> set[str]:
+def __get_pixi_environment_names(*, session: Session | None = None) -> set[str]:
     if CONFIG_PATH.pixi_toml.exists():
         pixi_config = rtoml.load(CONFIG_PATH.pixi_toml)
         return set(pixi_config.get("environments", set()))
     if CONFIG_PATH.pyproject.exists():
-        pyproject = Pyproject.load()
+        pyproject = Pyproject.load(session=session)
         if pyproject.has_table("tool.pixi.environments"):
             return set(pyproject.get_table("tool.pixi.environments"))
     return set()

--- a/src/compwa_policy/env/direnv.py
+++ b/src/compwa_policy/env/direnv.py
@@ -46,7 +46,7 @@ def main(
     session.changelog += _update_envrc(statements)
 
 
-def __get_pixi_direnv(*, session: Session | None = None) -> str:
+def __get_pixi_direnv(*, session: Session) -> str:
     environment_flag = ""
     dev_environment = __determine_pixi_dev_environment(session=session)
     if dev_environment is not None:
@@ -67,7 +67,7 @@ def __get_uv_direnv(variables: dict[str, str]) -> str:
     return script.strip()
 
 
-def __determine_pixi_dev_environment(*, session: Session | None = None) -> str | None:
+def __determine_pixi_dev_environment(*, session: Session) -> str | None:
     search_terms = ["dev"]
     if CONFIG_PATH.pyproject.exists():
         pyproject = Pyproject.load(session=session)
@@ -81,7 +81,7 @@ def __determine_pixi_dev_environment(*, session: Session | None = None) -> str |
     return None
 
 
-def __get_pixi_environment_names(*, session: Session | None = None) -> set[str]:
+def __get_pixi_environment_names(*, session: Session) -> set[str]:
     if CONFIG_PATH.pixi_toml.exists():
         pixi_config = rtoml.load(CONFIG_PATH.pixi_toml)
         return set(pixi_config.get("environments", set()))

--- a/src/compwa_policy/env/direnv.py
+++ b/src/compwa_policy/env/direnv.py
@@ -9,7 +9,6 @@ import rtoml
 
 from compwa_policy.env.pixi import has_pixi_config
 from compwa_policy.utilities import CONFIG_PATH
-from compwa_policy.utilities.pyproject import Pyproject
 
 if TYPE_CHECKING:
     from compwa_policy.env.conda import PackageManagerChoice
@@ -26,29 +25,29 @@ def main(
         session.changelog += __update_envrc_content(script)
         return
     if package_manager == "pixi+uv":
-        script = __get_pixi_direnv(session=session) + "\n"
+        script = __get_pixi_direnv(session) + "\n"
         script += __get_uv_direnv(variables) + "\n"
         session.changelog += __update_envrc_content(script)
         return
     if package_manager == "pixi":
-        script = __get_pixi_direnv(session=session) + "\n"
+        script = __get_pixi_direnv(session) + "\n"
         session.changelog += __update_envrc_content(script)
         return
     statements: list[tuple[str | None, str]] = [
         (".venv", "source .venv/bin/activate"),
         ("venv", "source venv/bin/activate"),
     ]
-    if has_pixi_config(session.pyproject):
-        script = __get_pixi_direnv(session=session)
+    if has_pixi_config(session):
+        script = __get_pixi_direnv(session)
         statements.append((".pixi", script))
     if CONFIG_PATH.conda.exists():
         statements.append((None, "layout anaconda"))
     session.changelog += _update_envrc(statements)
 
 
-def __get_pixi_direnv(*, session: Session) -> str:
+def __get_pixi_direnv(session: Session, /) -> str:
     environment_flag = ""
-    dev_environment = __determine_pixi_dev_environment(session=session)
+    dev_environment = __determine_pixi_dev_environment(session)
     if dev_environment is not None:
         environment_flag = f" --environment {dev_environment}"
     return dedent(f"""
@@ -67,28 +66,27 @@ def __get_uv_direnv(variables: dict[str, str]) -> str:
     return script.strip()
 
 
-def __determine_pixi_dev_environment(*, session: Session) -> str | None:
+def __determine_pixi_dev_environment(session: Session, /) -> str | None:
     search_terms = ["dev"]
-    if CONFIG_PATH.pyproject.exists():
-        pyproject = Pyproject.load(session=session)
+    pyproject = session.pyproject
+    if pyproject is not None:
         package_name = pyproject.get_package_name()
         if package_name is not None:
             search_terms.append(package_name)
-    available_environments = __get_pixi_environment_names(session=session)
+    available_environments = __get_pixi_environment_names(session)
     for candidate in search_terms:
         if candidate in available_environments:
             return candidate
     return None
 
 
-def __get_pixi_environment_names(*, session: Session) -> set[str]:
+def __get_pixi_environment_names(session: Session, /) -> set[str]:
     if CONFIG_PATH.pixi_toml.exists():
         pixi_config = rtoml.load(CONFIG_PATH.pixi_toml)
         return set(pixi_config.get("environments", set()))
-    if CONFIG_PATH.pyproject.exists():
-        pyproject = Pyproject.load(session=session)
-        if pyproject.has_table("tool.pixi.environments"):
-            return set(pyproject.get_table("tool.pixi.environments"))
+    pyproject = session.pyproject
+    if pyproject is not None and pyproject.has_table("tool.pixi.environments"):
+        return set(pyproject.get_table("tool.pixi.environments"))
     return set()
 
 

--- a/src/compwa_policy/env/pixi/__init__.py
+++ b/src/compwa_policy/env/pixi/__init__.py
@@ -7,7 +7,6 @@ from typing import TYPE_CHECKING
 from compwa_policy.env.pixi._helpers import has_pixi_config
 from compwa_policy.env.pixi._remove import remove_pixi_configuration
 from compwa_policy.env.pixi._update import update_pixi_configuration
-from compwa_policy.utilities.pyproject import ModifiablePixi
 
 if TYPE_CHECKING:
     from compwa_policy.env.conda import PackageManagerChoice
@@ -31,11 +30,7 @@ def main(
             is_python_package,
             dev_python_version,
             package_manager,
-            session.pyproject,
-            session.get(ModifiablePixi) if package_manager == "pixi+uv" else None,
             session=session,
         )
     else:
-        session.changelog += remove_pixi_configuration(
-            session.pyproject, session=session
-        )
+        session.changelog += remove_pixi_configuration(session=session)

--- a/src/compwa_policy/env/pixi/__init__.py
+++ b/src/compwa_policy/env/pixi/__init__.py
@@ -33,6 +33,9 @@ def main(
             package_manager,
             session.pyproject,
             session.get(ModifiablePixi) if package_manager == "pixi+uv" else None,
+            session=session,
         )
     else:
-        session.changelog += remove_pixi_configuration(session.pyproject)
+        session.changelog += remove_pixi_configuration(
+            session.pyproject, session=session
+        )

--- a/src/compwa_policy/env/pixi/__init__.py
+++ b/src/compwa_policy/env/pixi/__init__.py
@@ -27,10 +27,10 @@ def main(
 ) -> None:
     if "pixi" in package_manager:
         session.changelog += update_pixi_configuration(
+            session,
             is_python_package,
             dev_python_version,
             package_manager,
-            session=session,
         )
     else:
-        session.changelog += remove_pixi_configuration(session=session)
+        session.changelog += remove_pixi_configuration(session)

--- a/src/compwa_policy/env/pixi/__init__.py
+++ b/src/compwa_policy/env/pixi/__init__.py
@@ -26,11 +26,11 @@ def main(
     dev_python_version: PythonVersion,
 ) -> None:
     if "pixi" in package_manager:
-        session.changelog += update_pixi_configuration(
+        update_pixi_configuration(
             session,
             is_python_package,
             dev_python_version,
             package_manager,
         )
     else:
-        session.changelog += remove_pixi_configuration(session)
+        remove_pixi_configuration(session)

--- a/src/compwa_policy/env/pixi/__init__.py
+++ b/src/compwa_policy/env/pixi/__init__.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 from compwa_policy.env.pixi._helpers import has_pixi_config
 from compwa_policy.env.pixi._remove import remove_pixi_configuration
 from compwa_policy.env.pixi._update import update_pixi_configuration
+from compwa_policy.utilities.pyproject import ModifiablePixi
 
 if TYPE_CHECKING:
     from compwa_policy.env.conda import PackageManagerChoice
@@ -31,6 +32,7 @@ def main(
             dev_python_version,
             package_manager,
             session.pyproject,
+            session.get(ModifiablePixi) if package_manager == "pixi+uv" else None,
         )
     else:
         session.changelog += remove_pixi_configuration(session.pyproject)

--- a/src/compwa_policy/env/pixi/_helpers.py
+++ b/src/compwa_policy/env/pixi/_helpers.py
@@ -1,13 +1,17 @@
 from __future__ import annotations
 
-from compwa_policy.utilities import CONFIG_PATH
+from typing import TYPE_CHECKING
+
 from compwa_policy.utilities.match import git_ls_files
-from compwa_policy.utilities.pyproject import Pyproject
+
+if TYPE_CHECKING:
+    from compwa_policy.utilities.session import Session
 
 
-def has_pixi_config(pyproject: Pyproject | None = None) -> bool:
+def has_pixi_config(session: Session, /) -> bool:
     if git_ls_files("pixi.lock", "pixi.toml"):
         return True
+    pyproject = session.pyproject
     if pyproject is not None:
         return pyproject.has_table("tool.pixi")
-    return CONFIG_PATH.pyproject.exists() and Pyproject.load().has_table("tool.pixi")
+    return False

--- a/src/compwa_policy/env/pixi/_remove.py
+++ b/src/compwa_policy/env/pixi/_remove.py
@@ -3,17 +3,12 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from compwa_policy.utilities import CONFIG_PATH, remove_configs, remove_lines, vscode
-from compwa_policy.utilities.pyproject import ModifiablePyproject
 
 if TYPE_CHECKING:
     from compwa_policy.utilities.session import Changelog, Session
 
 
-def remove_pixi_configuration(
-    pyproject: ModifiablePyproject | None = None,
-    *,
-    session: Session,
-) -> Changelog:
+def remove_pixi_configuration(*, session: Session) -> Changelog:
     changes = remove_lines(CONFIG_PATH.gitattributes, "pixi", session=session)
     changes += remove_lines(CONFIG_PATH.gitignore, ".*pixi.*", session=session)
     changes += remove_configs(
@@ -23,11 +18,13 @@ def remove_pixi_configuration(
     changes += vscode.remove_settings(
         {"files.associations": ["**/pixi.lock", "pixi.lock"]}, session=session
     )
-    if pyproject is None and CONFIG_PATH.pyproject.exists():
-        with ModifiablePyproject.load() as config:
-            remove_pixi_configuration(config, session=session)
-            changes += list(config.changelog)
-    elif pyproject is not None and pyproject.has_table("tool.pixi"):
+    if CONFIG_PATH.pyproject.exists():
+        pyproject = session.pyproject
+    else:
+        return changes
+    if pyproject is None:
+        return changes
+    if pyproject.has_table("tool.pixi"):
         del pyproject._document["tool"]["pixi"]  # noqa: SLF001
         pyproject.changelog.append("Removed Pixi configuration table")
     return changes

--- a/src/compwa_policy/env/pixi/_remove.py
+++ b/src/compwa_policy/env/pixi/_remove.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
 def remove_pixi_configuration(
     pyproject: ModifiablePyproject | None = None,
     *,
-    session: Session | None = None,
+    session: Session,
 ) -> Changelog:
     changes = remove_lines(CONFIG_PATH.gitattributes, "pixi", session=session)
     changes += remove_lines(CONFIG_PATH.gitignore, ".*pixi.*", session=session)
@@ -25,7 +25,7 @@ def remove_pixi_configuration(
     )
     if pyproject is None and CONFIG_PATH.pyproject.exists():
         with ModifiablePyproject.load() as config:
-            remove_pixi_configuration(config)
+            remove_pixi_configuration(config, session=session)
             changes += list(config.changelog)
     elif pyproject is not None and pyproject.has_table("tool.pixi"):
         del pyproject._document["tool"]["pixi"]  # noqa: SLF001

--- a/src/compwa_policy/env/pixi/_remove.py
+++ b/src/compwa_policy/env/pixi/_remove.py
@@ -3,10 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from compwa_policy.utilities import CONFIG_PATH, remove_lines, vscode
-from compwa_policy.utilities.pyproject import (
-    ModifiablePyproject,
-    use_modifiable_pyproject,
-)
+from compwa_policy.utilities.pyproject import ModifiablePyproject
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -24,12 +21,13 @@ def remove_pixi_configuration(
     changes += vscode.remove_settings({
         "files.associations": ["**/pixi.lock", "pixi.lock"]
     })
-    with use_modifiable_pyproject(pyproject) as (config, include_changelog):
-        if config is not None and config.has_table("tool.pixi"):
-            del config._document["tool"]["pixi"]  # noqa: SLF001
-            config.changelog.append("Removed Pixi configuration table")
-            if include_changelog:
-                changes += list(config.changelog)
+    if pyproject is None and CONFIG_PATH.pyproject.exists():
+        with ModifiablePyproject.load() as config:
+            remove_pixi_configuration(config)
+            changes += list(config.changelog)
+    elif pyproject is not None and pyproject.has_table("tool.pixi"):
+        del pyproject._document["tool"]["pixi"]  # noqa: SLF001
+        pyproject.changelog.append("Removed Pixi configuration table")
     return changes
 
 

--- a/src/compwa_policy/env/pixi/_remove.py
+++ b/src/compwa_policy/env/pixi/_remove.py
@@ -2,12 +2,10 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from compwa_policy.utilities import CONFIG_PATH, remove_lines, vscode
+from compwa_policy.utilities import CONFIG_PATH, remove_configs, remove_lines, vscode
 from compwa_policy.utilities.pyproject import ModifiablePyproject
 
 if TYPE_CHECKING:
-    from pathlib import Path
-
     from compwa_policy.utilities.session import Changelog
 
 
@@ -16,8 +14,7 @@ def remove_pixi_configuration(
 ) -> Changelog:
     changes = remove_lines(CONFIG_PATH.gitattributes, "pixi")
     changes += remove_lines(CONFIG_PATH.gitignore, ".*pixi.*")
-    changes += _remove_file(CONFIG_PATH.pixi_lock)
-    changes += _remove_file(CONFIG_PATH.pixi_toml)
+    changes += remove_configs([str(CONFIG_PATH.pixi_lock), str(CONFIG_PATH.pixi_toml)])
     changes += vscode.remove_settings({
         "files.associations": ["**/pixi.lock", "pixi.lock"]
     })
@@ -29,10 +26,3 @@ def remove_pixi_configuration(
         del pyproject._document["tool"]["pixi"]  # noqa: SLF001
         pyproject.changelog.append("Removed Pixi configuration table")
     return changes
-
-
-def _remove_file(path: Path) -> Changelog:
-    if not path.exists():
-        return []
-    path.unlink(missing_ok=True)
-    return [f"Removed redundant file {path!r}"]

--- a/src/compwa_policy/env/pixi/_remove.py
+++ b/src/compwa_policy/env/pixi/_remove.py
@@ -6,18 +6,23 @@ from compwa_policy.utilities import CONFIG_PATH, remove_configs, remove_lines, v
 from compwa_policy.utilities.pyproject import ModifiablePyproject
 
 if TYPE_CHECKING:
-    from compwa_policy.utilities.session import Changelog
+    from compwa_policy.utilities.session import Changelog, Session
 
 
 def remove_pixi_configuration(
     pyproject: ModifiablePyproject | None = None,
+    *,
+    session: Session | None = None,
 ) -> Changelog:
-    changes = remove_lines(CONFIG_PATH.gitattributes, "pixi")
-    changes += remove_lines(CONFIG_PATH.gitignore, ".*pixi.*")
-    changes += remove_configs([str(CONFIG_PATH.pixi_lock), str(CONFIG_PATH.pixi_toml)])
-    changes += vscode.remove_settings({
-        "files.associations": ["**/pixi.lock", "pixi.lock"]
-    })
+    changes = remove_lines(CONFIG_PATH.gitattributes, "pixi", session=session)
+    changes += remove_lines(CONFIG_PATH.gitignore, ".*pixi.*", session=session)
+    changes += remove_configs(
+        [str(CONFIG_PATH.pixi_lock), str(CONFIG_PATH.pixi_toml)],
+        session=session,
+    )
+    changes += vscode.remove_settings(
+        {"files.associations": ["**/pixi.lock", "pixi.lock"]}, session=session
+    )
     if pyproject is None and CONFIG_PATH.pyproject.exists():
         with ModifiablePyproject.load() as config:
             remove_pixi_configuration(config)

--- a/src/compwa_policy/env/pixi/_remove.py
+++ b/src/compwa_policy/env/pixi/_remove.py
@@ -5,26 +5,25 @@ from typing import TYPE_CHECKING
 from compwa_policy.utilities import CONFIG_PATH, remove_configs, remove_lines, vscode
 
 if TYPE_CHECKING:
-    from compwa_policy.utilities.session import Changelog, Session
+    from compwa_policy.utilities.session import Session
 
 
-def remove_pixi_configuration(session: Session, /) -> Changelog:
-    changes = remove_lines(session, CONFIG_PATH.gitattributes, "pixi")
-    changes += remove_lines(session, CONFIG_PATH.gitignore, ".*pixi.*")
-    changes += remove_configs(
+def remove_pixi_configuration(session: Session, /) -> None:
+    remove_lines(session, CONFIG_PATH.gitattributes, "pixi")
+    remove_lines(session, CONFIG_PATH.gitignore, ".*pixi.*")
+    remove_configs(
         session,
         [str(CONFIG_PATH.pixi_lock), str(CONFIG_PATH.pixi_toml)],
     )
-    changes += vscode.remove_settings(
+    vscode.remove_settings(
         session, {"files.associations": ["**/pixi.lock", "pixi.lock"]}
     )
     if CONFIG_PATH.pyproject.exists():
         pyproject = session.pyproject
     else:
-        return changes
+        return
     if pyproject is None:
-        return changes
+        return
     if pyproject.has_table("tool.pixi"):
         del pyproject._document["tool"]["pixi"]  # noqa: SLF001
         pyproject.changelog.append("Removed Pixi configuration table")
-    return changes

--- a/src/compwa_policy/env/pixi/_remove.py
+++ b/src/compwa_policy/env/pixi/_remove.py
@@ -8,15 +8,15 @@ if TYPE_CHECKING:
     from compwa_policy.utilities.session import Changelog, Session
 
 
-def remove_pixi_configuration(*, session: Session) -> Changelog:
-    changes = remove_lines(CONFIG_PATH.gitattributes, "pixi", session=session)
-    changes += remove_lines(CONFIG_PATH.gitignore, ".*pixi.*", session=session)
+def remove_pixi_configuration(session: Session, /) -> Changelog:
+    changes = remove_lines(session, CONFIG_PATH.gitattributes, "pixi")
+    changes += remove_lines(session, CONFIG_PATH.gitignore, ".*pixi.*")
     changes += remove_configs(
+        session,
         [str(CONFIG_PATH.pixi_lock), str(CONFIG_PATH.pixi_toml)],
-        session=session,
     )
     changes += vscode.remove_settings(
-        {"files.associations": ["**/pixi.lock", "pixi.lock"]}, session=session
+        session, {"files.associations": ["**/pixi.lock", "pixi.lock"]}
     )
     if CONFIG_PATH.pyproject.exists():
         pyproject = session.pyproject

--- a/src/compwa_policy/env/pixi/_update.py
+++ b/src/compwa_policy/env/pixi/_update.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
 
     from compwa_policy.env.conda import PackageManagerChoice
     from compwa_policy.utilities.pyproject.getters import PythonVersion
-    from compwa_policy.utilities.session import Changelog, Session
+    from compwa_policy.utilities.session import Session
 
 
 def update_pixi_configuration(
@@ -31,14 +31,13 @@ def update_pixi_configuration(
     is_python_package: bool,
     dev_python_version: PythonVersion,
     package_manager: PackageManagerChoice,
-) -> Changelog:
+) -> None:
     if "pixi" not in package_manager:
-        return []
+        return
     config = __get_pixi_config(session, package_manager)
-    extra: Changelog = []
     if config is None:
-        return extra
-    extra += add_badge(
+        return
+    add_badge(
         session,
         "[![Pixi Badge](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/prefix-dev/pixi/main/assets/badge/v0.json)](https://pixi.sh)",
     )
@@ -56,14 +55,13 @@ def update_pixi_configuration(
         _update_docnb_and_doclive(config, "tasks")
         _update_docnb_and_doclive(config, "feature.dev.tasks")
     _clean_up_task_env(config)
-    extra += vscode.update_settings(
+    vscode.update_settings(
         session,
         {"files.associations": {"**/pixi.lock": "yaml"}},
     )
     if has_pixi_config(session):
-        config.changelog.extend(__update_gitattributes(session))
-        config.changelog.extend(__update_gitignore(session))
-    return extra
+        __update_gitattributes(session)
+        __update_gitignore(session)
 
 
 def __get_pixi_config(
@@ -254,20 +252,18 @@ def _set_dev_python_version(
         config.changelog.append(msg)
 
 
-def __update_gitattributes(session: Session, /) -> Changelog:
+def __update_gitattributes(session: Session, /) -> None:
     expected_line = "pixi.lock linguist-language=YAML linguist-generated=true"
     if append_safe(session, expected_line, CONFIG_PATH.gitattributes):
-        return [
+        session.changelog += [
             f"Added linguist definition for pixi.lock under {CONFIG_PATH.gitattributes}"
         ]
-    return []
 
 
-def __update_gitignore(session: Session, /) -> Changelog:
+def __update_gitignore(session: Session, /) -> None:
     ignore_path = ".pixi/"
     if append_safe(session, ignore_path, CONFIG_PATH.gitignore):
-        return [f"Added {ignore_path} under {CONFIG_PATH.gitignore}"]
-    return []
+        session.changelog.append(f"Added {ignore_path} under {CONFIG_PATH.gitignore}")
 
 
 def _update_dev_environment(config: ModifiablePyproject) -> None:

--- a/src/compwa_policy/env/pixi/_update.py
+++ b/src/compwa_policy/env/pixi/_update.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from contextlib import nullcontext
 from typing import TYPE_CHECKING, Any
 
 import yaml
@@ -8,7 +7,6 @@ import yaml
 from compwa_policy.env.pixi._helpers import has_pixi_config
 from compwa_policy.utilities import CONFIG_PATH, append_safe, vscode
 from compwa_policy.utilities.pyproject import (
-    ModifiablePixi,
     ModifiablePyproject,
     Pyproject,
     complies_with_subset,
@@ -31,54 +29,43 @@ def update_pixi_configuration(
     is_python_package: bool,
     dev_python_version: PythonVersion,
     package_manager: PackageManagerChoice,
-    pyproject: ModifiablePyproject | None = None,
-    pixi: ModifiablePixi | None = None,
     *,
     session: Session,
 ) -> Changelog:
     if "pixi" not in package_manager:
         return []
-    session_owned = False
     if package_manager == "pixi":
-        if pyproject is None:
-            config_context = ModifiablePyproject.load(CONFIG_PATH.pyproject)
-        else:
-            config_context = nullcontext(pyproject)
-            session_owned = True
-    elif pixi is None:
-        config_context = ModifiablePixi.load()
+        config = session.pyproject
     else:
-        config_context = nullcontext(pixi)
-        session_owned = True
+        config = session.pixi
     extra: Changelog = []
-    with config_context as config:
-        extra += add_badge(
-            "[![Pixi Badge](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/prefix-dev/pixi/main/assets/badge/v0.json)](https://pixi.sh)",
-            session=session,
-        )
-        _rename_workspace_table(config)
-        _define_minimal_project(config, session=session)
-        _import_conda_dependencies(config)
-        _import_conda_environment(config)
-        if package_manager == "pixi+uv":
-            _define_combined_ci_job(config)
-        else:
-            if is_python_package:
-                _install_package_editable(config)
-            _set_dev_python_version(config, dev_python_version)
-            _update_dev_environment(config)
-            _update_docnb_and_doclive(config, "tasks")
-            _update_docnb_and_doclive(config, "feature.dev.tasks")
-        _clean_up_task_env(config)
-        extra += vscode.update_settings(
-            {"files.associations": {"**/pixi.lock": "yaml"}},
-            session=session,
-        )
-        if has_pixi_config(config):
-            config.changelog.extend(__update_gitattributes(session=session))
-            config.changelog.extend(__update_gitignore(session=session))
-        if not session_owned:
-            return list(config.changelog) + extra
+    if config is None:
+        return extra
+    extra += add_badge(
+        "[![Pixi Badge](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/prefix-dev/pixi/main/assets/badge/v0.json)](https://pixi.sh)",
+        session=session,
+    )
+    _rename_workspace_table(config)
+    _define_minimal_project(config, session=session)
+    _import_conda_dependencies(config)
+    _import_conda_environment(config)
+    if package_manager == "pixi+uv":
+        _define_combined_ci_job(config)
+    else:
+        if is_python_package:
+            _install_package_editable(config)
+        _set_dev_python_version(config, dev_python_version)
+        _update_dev_environment(config)
+        _update_docnb_and_doclive(config, "tasks")
+        _update_docnb_and_doclive(config, "feature.dev.tasks")
+    _clean_up_task_env(config)
+    extra += vscode.update_settings(
+        {"files.associations": {"**/pixi.lock": "yaml"}},
+        session=session,
+    )
+    if has_pixi_config(config):
+        config.changelog.extend(__update_gitattributes(session=session))
+        config.changelog.extend(__update_gitignore(session=session))
     return extra
 
 

--- a/src/compwa_policy/env/pixi/_update.py
+++ b/src/compwa_policy/env/pixi/_update.py
@@ -26,27 +26,24 @@ if TYPE_CHECKING:
 
 
 def update_pixi_configuration(
+    session: Session,
+    /,
     is_python_package: bool,
     dev_python_version: PythonVersion,
     package_manager: PackageManagerChoice,
-    *,
-    session: Session,
 ) -> Changelog:
     if "pixi" not in package_manager:
         return []
-    if package_manager == "pixi":
-        config = session.pyproject
-    else:
-        config = session.pixi
+    config = __get_pixi_config(session, package_manager)
     extra: Changelog = []
     if config is None:
         return extra
     extra += add_badge(
+        session,
         "[![Pixi Badge](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/prefix-dev/pixi/main/assets/badge/v0.json)](https://pixi.sh)",
-        session=session,
     )
     _rename_workspace_table(config)
-    _define_minimal_project(config, session=session)
+    _define_minimal_project(session, package_manager)
     _import_conda_dependencies(config)
     _import_conda_environment(config)
     if package_manager == "pixi+uv":
@@ -60,13 +57,22 @@ def update_pixi_configuration(
         _update_docnb_and_doclive(config, "feature.dev.tasks")
     _clean_up_task_env(config)
     extra += vscode.update_settings(
+        session,
         {"files.associations": {"**/pixi.lock": "yaml"}},
-        session=session,
     )
-    if has_pixi_config(config):
-        config.changelog.extend(__update_gitattributes(session=session))
-        config.changelog.extend(__update_gitignore(session=session))
+    if has_pixi_config(session):
+        config.changelog.extend(__update_gitattributes(session))
+        config.changelog.extend(__update_gitignore(session))
     return extra
+
+
+def __get_pixi_config(
+    session: Session,
+    package_manager: PackageManagerChoice,
+) -> ModifiablePyproject | None:
+    if package_manager == "pixi":
+        return session.pyproject
+    return session.pixi
 
 
 def _define_combined_ci_job(config: ModifiablePyproject) -> None:
@@ -106,22 +112,24 @@ def _rename_workspace_table(config: ModifiablePyproject) -> None:
 
 
 def _define_minimal_project(
-    config: ModifiablePyproject,
-    *,
     session: Session,
+    package_manager: PackageManagerChoice,
+    /,
 ) -> None:
     """Create a minimal Pixi project definition if it does not exist."""
+    config = __get_pixi_config(session, package_manager)
+    if config is None:
+        return
     table_name = "workspace"
     settings = __get_table(config, table_name, create=True)
     minimal_settings: dict[str, Any] = dict(
         channels=["conda-forge"],
         platforms=["linux-64"],
     )
-    if config._source == CONFIG_PATH.pixi_toml and CONFIG_PATH.pyproject.exists():  # noqa: SLF001
-        pyproject = Pyproject.load(session=session)
-        package_name = pyproject.get_package_name()
-        if package_name is not None:
-            minimal_settings["name"] = package_name
+    if config._source == CONFIG_PATH.pixi_toml:  # noqa: SLF001
+        pyproject = session.pyproject
+        if pyproject is not None:
+            minimal_settings["name"] = pyproject.get_package_name()
     if not complies_with_subset(settings, minimal_settings, exact_value_match=False):
         settings.update(minimal_settings)
         msg = "Defined minimal Pixi project settings"
@@ -246,18 +254,18 @@ def _set_dev_python_version(
         config.changelog.append(msg)
 
 
-def __update_gitattributes(*, session: Session) -> Changelog:
+def __update_gitattributes(session: Session, /) -> Changelog:
     expected_line = "pixi.lock linguist-language=YAML linguist-generated=true"
-    if append_safe(expected_line, CONFIG_PATH.gitattributes, session=session):
+    if append_safe(session, expected_line, CONFIG_PATH.gitattributes):
         return [
             f"Added linguist definition for pixi.lock under {CONFIG_PATH.gitattributes}"
         ]
     return []
 
 
-def __update_gitignore(*, session: Session) -> Changelog:
+def __update_gitignore(session: Session, /) -> Changelog:
     ignore_path = ".pixi/"
-    if append_safe(ignore_path, CONFIG_PATH.gitignore, session=session):
+    if append_safe(session, ignore_path, CONFIG_PATH.gitignore):
         return [f"Added {ignore_path} under {CONFIG_PATH.gitignore}"]
     return []
 

--- a/src/compwa_policy/env/pixi/_update.py
+++ b/src/compwa_policy/env/pixi/_update.py
@@ -34,13 +34,13 @@ def update_pixi_configuration(
 ) -> Changelog:
     if "pixi" not in package_manager:
         return []
-    include_changelog = True
+    session_owned = False
     if package_manager == "pixi":
         if pyproject is None:
             config_context = ModifiablePyproject.load(CONFIG_PATH.pyproject)
         else:
             config_context = nullcontext(pyproject)
-            include_changelog = False
+            session_owned = True
     else:
         CONFIG_PATH.pixi_toml.touch()
         config_context = ModifiablePyproject.load(CONFIG_PATH.pixi_toml)
@@ -69,7 +69,7 @@ def update_pixi_configuration(
         if has_pixi_config(config):
             config.changelog.extend(__update_gitattributes())
             config.changelog.extend(__update_gitignore())
-        if include_changelog:
+        if not session_owned:
             return list(config.changelog) + extra
     return extra
 

--- a/src/compwa_policy/env/pixi/_update.py
+++ b/src/compwa_policy/env/pixi/_update.py
@@ -8,6 +8,7 @@ import yaml
 from compwa_policy.env.pixi._helpers import has_pixi_config
 from compwa_policy.utilities import CONFIG_PATH, append_safe, vscode
 from compwa_policy.utilities.pyproject import (
+    ModifiablePixi,
     ModifiablePyproject,
     Pyproject,
     complies_with_subset,
@@ -31,6 +32,7 @@ def update_pixi_configuration(
     dev_python_version: PythonVersion,
     package_manager: PackageManagerChoice,
     pyproject: ModifiablePyproject | None = None,
+    pixi: ModifiablePixi | None = None,
 ) -> Changelog:
     if "pixi" not in package_manager:
         return []
@@ -41,9 +43,11 @@ def update_pixi_configuration(
         else:
             config_context = nullcontext(pyproject)
             session_owned = True
+    elif pixi is None:
+        config_context = ModifiablePixi.load()
     else:
-        CONFIG_PATH.pixi_toml.touch()
-        config_context = ModifiablePyproject.load(CONFIG_PATH.pixi_toml)
+        config_context = nullcontext(pixi)
+        session_owned = True
     extra: Changelog = []
     with config_context as config:
         extra += add_badge(

--- a/src/compwa_policy/env/pixi/_update.py
+++ b/src/compwa_policy/env/pixi/_update.py
@@ -34,7 +34,7 @@ def update_pixi_configuration(
     pyproject: ModifiablePyproject | None = None,
     pixi: ModifiablePixi | None = None,
     *,
-    session: Session | None = None,
+    session: Session,
 ) -> Changelog:
     if "pixi" not in package_manager:
         return []
@@ -121,7 +121,7 @@ def _rename_workspace_table(config: ModifiablePyproject) -> None:
 def _define_minimal_project(
     config: ModifiablePyproject,
     *,
-    session: Session | None = None,
+    session: Session,
 ) -> None:
     """Create a minimal Pixi project definition if it does not exist."""
     table_name = "workspace"
@@ -259,7 +259,7 @@ def _set_dev_python_version(
         config.changelog.append(msg)
 
 
-def __update_gitattributes(*, session: Session | None = None) -> Changelog:
+def __update_gitattributes(*, session: Session) -> Changelog:
     expected_line = "pixi.lock linguist-language=YAML linguist-generated=true"
     if append_safe(expected_line, CONFIG_PATH.gitattributes, session=session):
         return [
@@ -268,7 +268,7 @@ def __update_gitattributes(*, session: Session | None = None) -> Changelog:
     return []
 
 
-def __update_gitignore(*, session: Session | None = None) -> Changelog:
+def __update_gitignore(*, session: Session) -> Changelog:
     ignore_path = ".pixi/"
     if append_safe(ignore_path, CONFIG_PATH.gitignore, session=session):
         return [f"Added {ignore_path} under {CONFIG_PATH.gitignore}"]

--- a/src/compwa_policy/env/pixi/_update.py
+++ b/src/compwa_policy/env/pixi/_update.py
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
 
     from compwa_policy.env.conda import PackageManagerChoice
     from compwa_policy.utilities.pyproject.getters import PythonVersion
-    from compwa_policy.utilities.session import Changelog
+    from compwa_policy.utilities.session import Changelog, Session
 
 
 def update_pixi_configuration(
@@ -33,6 +33,8 @@ def update_pixi_configuration(
     package_manager: PackageManagerChoice,
     pyproject: ModifiablePyproject | None = None,
     pixi: ModifiablePixi | None = None,
+    *,
+    session: Session | None = None,
 ) -> Changelog:
     if "pixi" not in package_manager:
         return []
@@ -52,9 +54,10 @@ def update_pixi_configuration(
     with config_context as config:
         extra += add_badge(
             "[![Pixi Badge](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/prefix-dev/pixi/main/assets/badge/v0.json)](https://pixi.sh)",
+            session=session,
         )
         _rename_workspace_table(config)
-        _define_minimal_project(config)
+        _define_minimal_project(config, session=session)
         _import_conda_dependencies(config)
         _import_conda_environment(config)
         if package_manager == "pixi+uv":
@@ -69,10 +72,11 @@ def update_pixi_configuration(
         _clean_up_task_env(config)
         extra += vscode.update_settings(
             {"files.associations": {"**/pixi.lock": "yaml"}},
+            session=session,
         )
         if has_pixi_config(config):
-            config.changelog.extend(__update_gitattributes())
-            config.changelog.extend(__update_gitignore())
+            config.changelog.extend(__update_gitattributes(session=session))
+            config.changelog.extend(__update_gitignore(session=session))
         if not session_owned:
             return list(config.changelog) + extra
     return extra
@@ -114,7 +118,11 @@ def _rename_workspace_table(config: ModifiablePyproject) -> None:
     config.changelog.append(msg)
 
 
-def _define_minimal_project(config: ModifiablePyproject) -> None:
+def _define_minimal_project(
+    config: ModifiablePyproject,
+    *,
+    session: Session | None = None,
+) -> None:
     """Create a minimal Pixi project definition if it does not exist."""
     table_name = "workspace"
     settings = __get_table(config, table_name, create=True)
@@ -123,7 +131,7 @@ def _define_minimal_project(config: ModifiablePyproject) -> None:
         platforms=["linux-64"],
     )
     if config._source == CONFIG_PATH.pixi_toml and CONFIG_PATH.pyproject.exists():  # noqa: SLF001
-        pyproject = Pyproject.load()
+        pyproject = Pyproject.load(session=session)
         package_name = pyproject.get_package_name()
         if package_name is not None:
             minimal_settings["name"] = package_name
@@ -251,18 +259,18 @@ def _set_dev_python_version(
         config.changelog.append(msg)
 
 
-def __update_gitattributes() -> Changelog:
+def __update_gitattributes(*, session: Session | None = None) -> Changelog:
     expected_line = "pixi.lock linguist-language=YAML linguist-generated=true"
-    if append_safe(expected_line, CONFIG_PATH.gitattributes):
+    if append_safe(expected_line, CONFIG_PATH.gitattributes, session=session):
         return [
             f"Added linguist definition for pixi.lock under {CONFIG_PATH.gitattributes}"
         ]
     return []
 
 
-def __update_gitignore() -> Changelog:
+def __update_gitignore(*, session: Session | None = None) -> Changelog:
     ignore_path = ".pixi/"
-    if append_safe(ignore_path, CONFIG_PATH.gitignore):
+    if append_safe(ignore_path, CONFIG_PATH.gitignore, session=session):
         return [f"Added {ignore_path} under {CONFIG_PATH.gitignore}"]
     return []
 

--- a/src/compwa_policy/env/uv.py
+++ b/src/compwa_policy/env/uv.py
@@ -12,11 +12,7 @@ from jinja2 import Environment, FileSystemLoader
 from compwa_policy.utilities import COMPWA_POLICY_DIR, CONFIG_PATH, readme, vscode
 from compwa_policy.utilities.match import is_committed
 from compwa_policy.utilities.precommit.struct import Hook, Repo
-from compwa_policy.utilities.pyproject import (
-    ModifiablePyproject,
-    Pyproject,
-    use_modifiable_pyproject,
-)
+from compwa_policy.utilities.pyproject import ModifiablePyproject, Pyproject
 from compwa_policy.utilities.pyproject.getters import has_sub_table
 
 if TYPE_CHECKING:
@@ -82,19 +78,18 @@ def _remove_pip_constraint_files() -> Changelog:
 
 
 def _remove_uv_configuration(pyproject: ModifiablePyproject | None = None) -> Changelog:
-    with use_modifiable_pyproject(pyproject) as (config, include_changelog):
-        if config is None:
+    if pyproject is None:
+        if not CONFIG_PATH.pyproject.exists():
             return []
-        readonly_pyproject = config._document  # noqa: SLF001
-        if "tool" not in readonly_pyproject:
-            return []
-        if "uv" not in readonly_pyproject["tool"]:
-            return []
-        tool_table = config.get_table("tool")
-        tool_table.pop("uv")
-        config.changelog.append("Removed uv configuration from pyproject.toml.")
-        if include_changelog:
+        with ModifiablePyproject.load() as config:
+            _remove_uv_configuration(config)
             return list(config.changelog)
+    readonly_pyproject = pyproject._document  # noqa: SLF001
+    if "tool" not in readonly_pyproject or "uv" not in readonly_pyproject["tool"]:
+        return []
+    tool_table = pyproject.get_table("tool")
+    tool_table.pop("uv")
+    pyproject.changelog.append("Removed uv configuration from pyproject.toml.")
     return []
 
 

--- a/src/compwa_policy/env/uv.py
+++ b/src/compwa_policy/env/uv.py
@@ -130,7 +130,7 @@ def _update_editor_config() -> Changelog:
 def _update_python_version_file(
     dev_python_version: PythonVersion,
     *,
-    session: Session | None = None,
+    session: Session,
 ) -> Changelog:
     if not CONFIG_PATH.pyproject.exists():
         return []
@@ -173,7 +173,7 @@ def _update_contributing_file(
     organization: str,
     repo_name: str,
     *,
-    session: Session | None = None,
+    session: Session,
 ) -> Changelog:
     contributing_file = Path("CONTRIBUTING.md")
     if not contributing_file.exists():
@@ -200,7 +200,7 @@ def _update_contributing_file(
     return []
 
 
-def __get_runner_instructions(*, session: Session | None = None) -> str:
+def __get_runner_instructions(*, session: Session) -> str:
     poe_instructions = dedent("""
     [Poe the Poet](https://poethepoet.natn.io) is used as a task runner. Install it globally (within your home folder) with `uv`:
 

--- a/src/compwa_policy/env/uv.py
+++ b/src/compwa_policy/env/uv.py
@@ -32,23 +32,21 @@ def main(  # noqa: PLR0917
 ) -> None:
     precommit_config = session.precommit
     if "uv" in package_manager:
-        session.changelog += readme.add_badge(
+        readme.add_badge(
             session,
             "[![uv](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/uv/main/assets/badge/v0.json)](https://github.com/astral-sh/uv)",
         )
         session.changelog += _update_editor_config()
-        session.changelog += _update_python_version_file(session, dev_python_version)
+        _update_python_version_file(session, dev_python_version)
         _update_uv_lock_hook(precommit_config)
         if not keep_contributing_md:
-            session.changelog += _update_contributing_file(
-                session, organization, repo_name
-            )
+            _update_contributing_file(session, organization, repo_name)
         session.changelog += _remove_pip_constraint_files()
-        session.changelog += vscode.remove_settings(
+        vscode.remove_settings(
             session,
             {"files.associations": ["**/.constraints/py*.txt"]},
         )
-        session.changelog += vscode.remove_settings(
+        vscode.remove_settings(
             session,
             {
                 "search.exclude": [
@@ -58,16 +56,14 @@ def main(  # noqa: PLR0917
             },
         )
     else:
-        session.changelog += _remove_uv_configuration(session.pyproject)
+        _remove_uv_configuration(session.pyproject)
         session.changelog += _remove_uv_lock()
         precommit_config.remove_hook("uv-lock")
-        session.changelog += readme.remove_badge(
+        readme.remove_badge(
             session,
             r"\[\!\[[^\[]+\]\(https://img\.shields\.io/[^\)]+/uv/main/assets/badge/[^\)]+\)\]\(https://github\.com/astral-sh/uv\)",
         )
-        session.changelog += vscode.remove_settings(
-            session, {"search.exclude": ["uv.lock", "**/uv.lock"]}
-        )
+        vscode.remove_settings(session, {"search.exclude": ["uv.lock", "**/uv.lock"]})
 
 
 def _remove_pip_constraint_files() -> Changelog:
@@ -83,16 +79,15 @@ def _remove_pip_constraint_files() -> Changelog:
     return [msg]
 
 
-def _remove_uv_configuration(pyproject: ModifiablePyproject | None) -> Changelog:
+def _remove_uv_configuration(pyproject: ModifiablePyproject | None) -> None:
     if pyproject is None:
-        return []
+        return
     readonly_pyproject = pyproject._document  # noqa: SLF001
     if "tool" not in readonly_pyproject or "uv" not in readonly_pyproject["tool"]:
-        return []
+        return
     tool_table = pyproject.get_table("tool")
     tool_table.pop("uv")
     pyproject.changelog.append("Removed uv configuration from pyproject.toml.")
-    return []
 
 
 def _remove_uv_lock() -> Changelog:
@@ -125,10 +120,10 @@ def _update_python_version_file(
     session: Session,
     /,
     dev_python_version: PythonVersion,
-) -> Changelog:
+) -> None:
     pyproject = session.pyproject
     if pyproject is None:
-        return []
+        return
     python_version_file = Path(".python-version")
     if pyproject.has_table("project"):
         requires_python = pyproject.get_table("project").get("requires-python", "")
@@ -136,19 +131,20 @@ def _update_python_version_file(
             if python_version_file.exists():
                 python_version_file.unlink()
                 msg = f"Removed {python_version_file} file because requires-python already pins the Python version"
-                return [msg]
-            return []
+                session.changelog.append(msg)
+                return
+            return
 
     existing_python_version = ""
     if python_version_file.exists():
         with open(python_version_file) as stream:
             existing_python_version = stream.read().strip()
     if existing_python_version == dev_python_version:
-        return []
+        return
     with open(".python-version", "w") as stream:
         stream.write(dev_python_version + "\n")
     msg = f"Updated {python_version_file} to {dev_python_version}"
-    return [msg]
+    session.changelog.append(msg)
 
 
 def _update_uv_lock_hook(precommit: ModifiablePrecommit) -> None:
@@ -168,10 +164,10 @@ def _update_contributing_file(
     /,
     organization: str,
     repo_name: str,
-) -> Changelog:
+) -> None:
     contributing_file = Path("CONTRIBUTING.md")
     if not contributing_file.exists():
-        return []
+        return
     template_dir = COMPWA_POLICY_DIR / ".template"
     env = Environment(
         autoescape=True,
@@ -190,8 +186,7 @@ def _update_contributing_file(
     if expected_content != existing_content:
         contributing_file.write_text(expected_content)
         msg = f"Updated {contributing_file} to latest template"
-        return [msg]
-    return []
+        session.changelog.append(msg)
 
 
 def __get_runner_instructions(session: Session, /) -> str:

--- a/src/compwa_policy/env/uv.py
+++ b/src/compwa_policy/env/uv.py
@@ -34,15 +34,21 @@ def main(  # noqa: PLR0917
     if "uv" in package_manager:
         session.changelog += readme.add_badge(
             "[![uv](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/uv/main/assets/badge/v0.json)](https://github.com/astral-sh/uv)",
+            session=session,
         )
         session.changelog += _update_editor_config()
-        session.changelog += _update_python_version_file(dev_python_version)
+        session.changelog += _update_python_version_file(
+            dev_python_version, session=session
+        )
         _update_uv_lock_hook(precommit_config)
         if not keep_contributing_md:
-            session.changelog += _update_contributing_file(organization, repo_name)
+            session.changelog += _update_contributing_file(
+                organization, repo_name, session=session
+            )
         session.changelog += _remove_pip_constraint_files()
         session.changelog += vscode.remove_settings(
             {"files.associations": ["**/.constraints/py*.txt"]},
+            session=session,
         )
         session.changelog += vscode.remove_settings(
             {
@@ -51,6 +57,7 @@ def main(  # noqa: PLR0917
                     ".constraints/*.txt",
                 ]
             },
+            session=session,
         )
     else:
         session.changelog += _remove_uv_configuration(session.pyproject)
@@ -58,10 +65,11 @@ def main(  # noqa: PLR0917
         precommit_config.remove_hook("uv-lock")
         session.changelog += readme.remove_badge(
             r"\[\!\[[^\[]+\]\(https://img\.shields\.io/[^\)]+/uv/main/assets/badge/[^\)]+\)\]\(https://github\.com/astral-sh/uv\)",
+            session=session,
         )
-        session.changelog += vscode.remove_settings({
-            "search.exclude": ["uv.lock", "**/uv.lock"]
-        })
+        session.changelog += vscode.remove_settings(
+            {"search.exclude": ["uv.lock", "**/uv.lock"]}, session=session
+        )
 
 
 def _remove_pip_constraint_files() -> Changelog:
@@ -119,10 +127,14 @@ def _update_editor_config() -> Changelog:
     return [f"Updated {CONFIG_PATH.editorconfig} for uv.lock"]
 
 
-def _update_python_version_file(dev_python_version: PythonVersion) -> Changelog:
+def _update_python_version_file(
+    dev_python_version: PythonVersion,
+    *,
+    session: Session | None = None,
+) -> Changelog:
     if not CONFIG_PATH.pyproject.exists():
         return []
-    pyproject = Pyproject.load()
+    pyproject = Pyproject.load(session=session)
     python_version_file = Path(".python-version")
     if pyproject.has_table("project"):
         requires_python = pyproject.get_table("project").get("requires-python", "")
@@ -157,7 +169,12 @@ def _update_uv_lock_hook(precommit: ModifiablePrecommit) -> None:
         precommit.remove_hook("uv-lock")
 
 
-def _update_contributing_file(organization: str, repo_name: str) -> Changelog:
+def _update_contributing_file(
+    organization: str,
+    repo_name: str,
+    *,
+    session: Session | None = None,
+) -> Changelog:
     contributing_file = Path("CONTRIBUTING.md")
     if not contributing_file.exists():
         return []
@@ -170,7 +187,7 @@ def _update_contributing_file(organization: str, repo_name: str) -> Changelog:
     context = {
         "ORGANIZATION": organization,
         "REPO_NAME": repo_name,
-        "RUNNER": __get_runner_instructions().strip(),
+        "RUNNER": __get_runner_instructions(session=session).strip(),
     }
     expected_content = template.render(context).strip() + "\n"
     existing_content = ""
@@ -183,7 +200,7 @@ def _update_contributing_file(organization: str, repo_name: str) -> Changelog:
     return []
 
 
-def __get_runner_instructions() -> str:
+def __get_runner_instructions(*, session: Session | None = None) -> str:
     poe_instructions = dedent("""
     [Poe the Poet](https://poethepoet.natn.io) is used as a task runner. Install it globally (within your home folder) with `uv`:
 
@@ -217,7 +234,7 @@ def __get_runner_instructions() -> str:
     ```
     """)
     if CONFIG_PATH.pyproject.exists():
-        pyproject = Pyproject.load()
+        pyproject = Pyproject.load(session=session)
         if pyproject.has_table("tool.poe.tasks"):
             return poe_instructions
         if pyproject.has_table("tool.pixi.tasks"):

--- a/src/compwa_policy/env/uv.py
+++ b/src/compwa_policy/env/uv.py
@@ -12,12 +12,12 @@ from jinja2 import Environment, FileSystemLoader
 from compwa_policy.utilities import COMPWA_POLICY_DIR, CONFIG_PATH, readme, vscode
 from compwa_policy.utilities.match import is_committed
 from compwa_policy.utilities.precommit.struct import Hook, Repo
-from compwa_policy.utilities.pyproject import ModifiablePyproject, Pyproject
 from compwa_policy.utilities.pyproject.getters import has_sub_table
 
 if TYPE_CHECKING:
     from compwa_policy.env.conda import PackageManagerChoice
     from compwa_policy.utilities.precommit import ModifiablePrecommit
+    from compwa_policy.utilities.pyproject import ModifiablePyproject
     from compwa_policy.utilities.pyproject.getters import PythonVersion
     from compwa_policy.utilities.session import Changelog, Session
 
@@ -33,42 +33,40 @@ def main(  # noqa: PLR0917
     precommit_config = session.precommit
     if "uv" in package_manager:
         session.changelog += readme.add_badge(
+            session,
             "[![uv](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/uv/main/assets/badge/v0.json)](https://github.com/astral-sh/uv)",
-            session=session,
         )
         session.changelog += _update_editor_config()
-        session.changelog += _update_python_version_file(
-            dev_python_version, session=session
-        )
+        session.changelog += _update_python_version_file(session, dev_python_version)
         _update_uv_lock_hook(precommit_config)
         if not keep_contributing_md:
             session.changelog += _update_contributing_file(
-                organization, repo_name, session=session
+                session, organization, repo_name
             )
         session.changelog += _remove_pip_constraint_files()
         session.changelog += vscode.remove_settings(
+            session,
             {"files.associations": ["**/.constraints/py*.txt"]},
-            session=session,
         )
         session.changelog += vscode.remove_settings(
+            session,
             {
                 "search.exclude": [
                     "**/.constraints/py*.txt",
                     ".constraints/*.txt",
                 ]
             },
-            session=session,
         )
     else:
         session.changelog += _remove_uv_configuration(session.pyproject)
         session.changelog += _remove_uv_lock()
         precommit_config.remove_hook("uv-lock")
         session.changelog += readme.remove_badge(
+            session,
             r"\[\!\[[^\[]+\]\(https://img\.shields\.io/[^\)]+/uv/main/assets/badge/[^\)]+\)\]\(https://github\.com/astral-sh/uv\)",
-            session=session,
         )
         session.changelog += vscode.remove_settings(
-            {"search.exclude": ["uv.lock", "**/uv.lock"]}, session=session
+            session, {"search.exclude": ["uv.lock", "**/uv.lock"]}
         )
 
 
@@ -85,13 +83,9 @@ def _remove_pip_constraint_files() -> Changelog:
     return [msg]
 
 
-def _remove_uv_configuration(pyproject: ModifiablePyproject | None = None) -> Changelog:
+def _remove_uv_configuration(pyproject: ModifiablePyproject | None) -> Changelog:
     if pyproject is None:
-        if not CONFIG_PATH.pyproject.exists():
-            return []
-        with ModifiablePyproject.load() as config:
-            _remove_uv_configuration(config)
-            return list(config.changelog)
+        return []
     readonly_pyproject = pyproject._document  # noqa: SLF001
     if "tool" not in readonly_pyproject or "uv" not in readonly_pyproject["tool"]:
         return []
@@ -128,13 +122,13 @@ def _update_editor_config() -> Changelog:
 
 
 def _update_python_version_file(
-    dev_python_version: PythonVersion,
-    *,
     session: Session,
+    /,
+    dev_python_version: PythonVersion,
 ) -> Changelog:
-    if not CONFIG_PATH.pyproject.exists():
+    pyproject = session.pyproject
+    if pyproject is None:
         return []
-    pyproject = Pyproject.load(session=session)
     python_version_file = Path(".python-version")
     if pyproject.has_table("project"):
         requires_python = pyproject.get_table("project").get("requires-python", "")
@@ -170,10 +164,10 @@ def _update_uv_lock_hook(precommit: ModifiablePrecommit) -> None:
 
 
 def _update_contributing_file(
+    session: Session,
+    /,
     organization: str,
     repo_name: str,
-    *,
-    session: Session,
 ) -> Changelog:
     contributing_file = Path("CONTRIBUTING.md")
     if not contributing_file.exists():
@@ -187,7 +181,7 @@ def _update_contributing_file(
     context = {
         "ORGANIZATION": organization,
         "REPO_NAME": repo_name,
-        "RUNNER": __get_runner_instructions(session=session).strip(),
+        "RUNNER": __get_runner_instructions(session).strip(),
     }
     expected_content = template.render(context).strip() + "\n"
     existing_content = ""
@@ -200,7 +194,7 @@ def _update_contributing_file(
     return []
 
 
-def __get_runner_instructions(*, session: Session) -> str:
+def __get_runner_instructions(session: Session, /) -> str:
     poe_instructions = dedent("""
     [Poe the Poet](https://poethepoet.natn.io) is used as a task runner. Install it globally (within your home folder) with `uv`:
 
@@ -233,8 +227,8 @@ def __get_runner_instructions(*, session: Session) -> str:
     pixi run style
     ```
     """)
-    if CONFIG_PATH.pyproject.exists():
-        pyproject = Pyproject.load(session=session)
+    pyproject = session.pyproject
+    if pyproject is not None:
         if pyproject.has_table("tool.poe.tasks"):
             return poe_instructions
         if pyproject.has_table("tool.pixi.tasks"):

--- a/src/compwa_policy/format/cspell.py
+++ b/src/compwa_policy/format/cspell.py
@@ -35,30 +35,28 @@ with open(COMPWA_POLICY_DIR / ".template" / CONFIG_PATH.cspell) as __STREAM:
 
 def main(session: Session, no_cspell_update: bool) -> None:
     precommit = session.precommit
-    session.changelog += rename_file(
-        "cspell.json", str(CONFIG_PATH.cspell), session=session
-    )
+    session.changelog += rename_file(session, "cspell.json", str(CONFIG_PATH.cspell))
     _update_cspell_repo_url(precommit)
     has_cspell_hook = False
     if CONFIG_PATH.cspell.exists():
         has_cspell_hook = precommit.find_repo(__REPO_URL) is not None
     if not has_cspell_hook:
-        session.changelog += _remove_configuration(session=session)
+        session.changelog += _remove_configuration(session)
     else:
         _update_precommit_repo(precommit)
         if not no_cspell_update:
             session.changelog += _update_config_content()
         session.changelog += _sort_config_entries()
         session.changelog += add_badge(
+            session,
             "[![Spelling checked](https://img.shields.io/badge/cspell-checked-brightgreen.svg)](https://github.com/streetsidesoftware/cspell/tree/main/packages/cspell)",
-            session=session,
         )
         session.changelog += remove_badge(
+            session,
             r"\[\!\[[Ss]pelling.*\]\(.*cspell.*\)\]\(.*master.*cspell\)\n?",
-            session=session,
         )
         session.changelog += vscode.add_extension_recommendation(
-            __VSCODE_EXTENSION_NAME, session=session
+            session, __VSCODE_EXTENSION_NAME
         )
 
 
@@ -75,7 +73,7 @@ def _update_cspell_repo_url(precommit: ModifiablePrecommit) -> None:
         precommit.changelog.append(msg)
 
 
-def _remove_configuration(*, session: Session) -> Changelog:
+def _remove_configuration(session: Session, /) -> Changelog:
     changes: Changelog = []
     if CONFIG_PATH.cspell.exists():
         os.remove(CONFIG_PATH.cspell)
@@ -97,12 +95,10 @@ def _remove_configuration(*, session: Session) -> Changelog:
             changes.append(msg)
             return changes
     changes += remove_badge(
+        session,
         r"\[\!\[[Ss]pelling.*\]\(.*cspell.*\)\]\(.*cspell.*\)\n?",
-        session=session,
     )
-    changes += vscode.remove_extension_recommendation(
-        __VSCODE_EXTENSION_NAME, session=session
-    )
+    changes += vscode.remove_extension_recommendation(session, __VSCODE_EXTENSION_NAME)
     return changes
 
 

--- a/src/compwa_policy/format/cspell.py
+++ b/src/compwa_policy/format/cspell.py
@@ -35,29 +35,27 @@ with open(COMPWA_POLICY_DIR / ".template" / CONFIG_PATH.cspell) as __STREAM:
 
 def main(session: Session, no_cspell_update: bool) -> None:
     precommit = session.precommit
-    session.changelog += rename_file(session, "cspell.json", str(CONFIG_PATH.cspell))
+    rename_file(session, "cspell.json", str(CONFIG_PATH.cspell))
     _update_cspell_repo_url(precommit)
     has_cspell_hook = False
     if CONFIG_PATH.cspell.exists():
         has_cspell_hook = precommit.find_repo(__REPO_URL) is not None
     if not has_cspell_hook:
-        session.changelog += _remove_configuration(session)
+        _remove_configuration(session)
     else:
         _update_precommit_repo(precommit)
         if not no_cspell_update:
             session.changelog += _update_config_content()
         session.changelog += _sort_config_entries()
-        session.changelog += add_badge(
+        add_badge(
             session,
             "[![Spelling checked](https://img.shields.io/badge/cspell-checked-brightgreen.svg)](https://github.com/streetsidesoftware/cspell/tree/main/packages/cspell)",
         )
-        session.changelog += remove_badge(
+        remove_badge(
             session,
             r"\[\!\[[Ss]pelling.*\]\(.*cspell.*\)\]\(.*master.*cspell\)\n?",
         )
-        session.changelog += vscode.add_extension_recommendation(
-            session, __VSCODE_EXTENSION_NAME
-        )
+        vscode.add_extension_recommendation(session, __VSCODE_EXTENSION_NAME)
 
 
 def _update_cspell_repo_url(precommit: ModifiablePrecommit) -> None:
@@ -73,13 +71,12 @@ def _update_cspell_repo_url(precommit: ModifiablePrecommit) -> None:
         precommit.changelog.append(msg)
 
 
-def _remove_configuration(session: Session, /) -> Changelog:
-    changes: Changelog = []
+def _remove_configuration(session: Session, /) -> None:
     if CONFIG_PATH.cspell.exists():
         os.remove(CONFIG_PATH.cspell)
         msg = f'"{CONFIG_PATH.cspell}" is no longer required and has been removed'
-        changes.append(msg)
-        return changes
+        session.changelog.append(msg)
+        return
     if CONFIG_PATH.editorconfig.exists():
         with open(CONFIG_PATH.editorconfig) as stream:
             prettier_ignore_content = stream.readlines()
@@ -92,14 +89,13 @@ def _remove_configuration(session: Session, /) -> Changelog:
                 f'"{CONFIG_PATH.cspell}" in {CONFIG_PATH.editorconfig} is no longer'
                 " required and has been removed"
             )
-            changes.append(msg)
-            return changes
-    changes += remove_badge(
+            session.changelog.append(msg)
+            return
+    remove_badge(
         session,
         r"\[\!\[[Ss]pelling.*\]\(.*cspell.*\)\]\(.*cspell.*\)\n?",
     )
-    changes += vscode.remove_extension_recommendation(session, __VSCODE_EXTENSION_NAME)
-    return changes
+    vscode.remove_extension_recommendation(session, __VSCODE_EXTENSION_NAME)
 
 
 def _update_precommit_repo(precommit: ModifiablePrecommit) -> None:

--- a/src/compwa_policy/format/cspell.py
+++ b/src/compwa_policy/format/cspell.py
@@ -75,7 +75,7 @@ def _update_cspell_repo_url(precommit: ModifiablePrecommit) -> None:
         precommit.changelog.append(msg)
 
 
-def _remove_configuration(*, session: Session | None = None) -> Changelog:
+def _remove_configuration(*, session: Session) -> Changelog:
     changes: Changelog = []
     if CONFIG_PATH.cspell.exists():
         os.remove(CONFIG_PATH.cspell)

--- a/src/compwa_policy/format/cspell.py
+++ b/src/compwa_policy/format/cspell.py
@@ -35,13 +35,15 @@ with open(COMPWA_POLICY_DIR / ".template" / CONFIG_PATH.cspell) as __STREAM:
 
 def main(session: Session, no_cspell_update: bool) -> None:
     precommit = session.precommit
-    session.changelog += rename_file("cspell.json", str(CONFIG_PATH.cspell))
+    session.changelog += rename_file(
+        "cspell.json", str(CONFIG_PATH.cspell), session=session
+    )
     _update_cspell_repo_url(precommit)
     has_cspell_hook = False
     if CONFIG_PATH.cspell.exists():
         has_cspell_hook = precommit.find_repo(__REPO_URL) is not None
     if not has_cspell_hook:
-        session.changelog += _remove_configuration()
+        session.changelog += _remove_configuration(session=session)
     else:
         _update_precommit_repo(precommit)
         if not no_cspell_update:
@@ -49,12 +51,14 @@ def main(session: Session, no_cspell_update: bool) -> None:
         session.changelog += _sort_config_entries()
         session.changelog += add_badge(
             "[![Spelling checked](https://img.shields.io/badge/cspell-checked-brightgreen.svg)](https://github.com/streetsidesoftware/cspell/tree/main/packages/cspell)",
+            session=session,
         )
         session.changelog += remove_badge(
             r"\[\!\[[Ss]pelling.*\]\(.*cspell.*\)\]\(.*master.*cspell\)\n?",
+            session=session,
         )
         session.changelog += vscode.add_extension_recommendation(
-            __VSCODE_EXTENSION_NAME
+            __VSCODE_EXTENSION_NAME, session=session
         )
 
 
@@ -71,7 +75,7 @@ def _update_cspell_repo_url(precommit: ModifiablePrecommit) -> None:
         precommit.changelog.append(msg)
 
 
-def _remove_configuration() -> Changelog:
+def _remove_configuration(*, session: Session | None = None) -> Changelog:
     changes: Changelog = []
     if CONFIG_PATH.cspell.exists():
         os.remove(CONFIG_PATH.cspell)
@@ -92,8 +96,13 @@ def _remove_configuration() -> Changelog:
             )
             changes.append(msg)
             return changes
-    changes += remove_badge(r"\[\!\[[Ss]pelling.*\]\(.*cspell.*\)\]\(.*cspell.*\)\n?")
-    changes += vscode.remove_extension_recommendation(__VSCODE_EXTENSION_NAME)
+    changes += remove_badge(
+        r"\[\!\[[Ss]pelling.*\]\(.*cspell.*\)\]\(.*cspell.*\)\n?",
+        session=session,
+    )
+    changes += vscode.remove_extension_recommendation(
+        __VSCODE_EXTENSION_NAME, session=session
+    )
     return changes
 
 

--- a/src/compwa_policy/format/cspell.py
+++ b/src/compwa_policy/format/cspell.py
@@ -49,11 +49,11 @@ def main(session: Session, no_cspell_update: bool) -> None:
         session.changelog += _sort_config_entries()
         add_badge(
             session,
-            "[![Spelling checked](https://img.shields.io/badge/cspell-checked-brightgreen.svg)](https://github.com/streetsidesoftware/cspell/tree/main/packages/cspell)",
+            badge="[![Spelling checked](https://img.shields.io/badge/cspell-checked-brightgreen.svg)](https://github.com/streetsidesoftware/cspell/tree/main/packages/cspell)",
         )
         remove_badge(
             session,
-            r"\[\!\[[Ss]pelling.*\]\(.*cspell.*\)\]\(.*master.*cspell\)\n?",
+            badge_pattern=r"\[\!\[[Ss]pelling.*\]\(.*cspell.*\)\]\(.*master.*cspell\)\n?",
         )
         vscode.add_extension_recommendation(session, __VSCODE_EXTENSION_NAME)
 
@@ -91,10 +91,7 @@ def _remove_configuration(session: Session, /) -> None:
             )
             session.changelog.append(msg)
             return
-    remove_badge(
-        session,
-        r"\[\!\[[Ss]pelling.*\]\(.*cspell.*\)\]\(.*cspell.*\)\n?",
-    )
+    remove_badge(session, r"\[\!\[[Ss]pelling.*\]\(.*cspell.*\)\]\(.*cspell.*\)\n?")
     vscode.remove_extension_recommendation(session, __VSCODE_EXTENSION_NAME)
 
 

--- a/src/compwa_policy/format/precommit.py
+++ b/src/compwa_policy/format/precommit.py
@@ -8,7 +8,6 @@ from typing import TYPE_CHECKING, cast
 
 from compwa_policy.utilities.precommit.getters import find_repo
 from compwa_policy.utilities.precommit.struct import Hook, Repo
-from compwa_policy.utilities.pyproject import use_modifiable_pyproject
 from compwa_policy.utilities.yaml import create_prettier_round_trip_yaml
 
 if TYPE_CHECKING:
@@ -27,10 +26,9 @@ def main(session: Session, has_notebooks: bool) -> None:
     _update_precommit_ci_skip(precommit)
     _update_notebook_hooks(precommit, has_notebooks)
     _update_repo_urls(precommit)
-    with use_modifiable_pyproject(session.pyproject) as (config, _):
-        if config is not None:
-            config.remove_dependency("pre-commit")
-            config.remove_dependency("pre-commit-uv")
+    if session.pyproject is not None:
+        session.pyproject.remove_dependency("pre-commit")
+        session.pyproject.remove_dependency("pre-commit-uv")
 
 
 def _sort_hooks(precommit: ModifiablePrecommit) -> None:

--- a/src/compwa_policy/format/prettier.py
+++ b/src/compwa_policy/format/prettier.py
@@ -38,7 +38,7 @@ def main(session: Session) -> None:
     session.changelog += _update_prettier_ignore()
 
 
-def _remove_configuration(*, session: Session | None = None) -> Changelog:
+def _remove_configuration(*, session: Session) -> Changelog:
     old_config_files = [
         ".prettierrc.json",
         ".prettierrc.json5",

--- a/src/compwa_policy/format/prettier.py
+++ b/src/compwa_policy/format/prettier.py
@@ -28,17 +28,17 @@ __GENERATED_LOCK_FILES = [
 def main(session: Session) -> None:
     precommit = session.precommit
     if precommit.find_repo(r".*/(mirrors-)?prettier(-pre-commit)?$") is None:
-        session.changelog += _remove_configuration(session=session)
+        session.changelog += _remove_configuration(session)
         return
-    session.changelog += add_badge(__BADGE, session=session)
+    session.changelog += add_badge(session, __BADGE)
     session.changelog += vscode.add_extension_recommendation(
-        __VSCODE_EXTENSION_NAME, session=session
+        session, __VSCODE_EXTENSION_NAME
     )
     _update_prettier_hook(precommit)
     session.changelog += _update_prettier_ignore()
 
 
-def _remove_configuration(*, session: Session) -> Changelog:
+def _remove_configuration(session: Session, /) -> Changelog:
     old_config_files = [
         ".prettierrc.json",
         ".prettierrc.json5",
@@ -57,10 +57,8 @@ def _remove_configuration(*, session: Session) -> Changelog:
         msg = f"Removed redundant configuration files: {removed_paths_str}"
         return [msg]
     changes: Changelog = []
-    changes += remove_badge(__BADGE_PATTERN, session=session)
-    changes += vscode.remove_extension_recommendation(
-        __VSCODE_EXTENSION_NAME, session=session
-    )
+    changes += remove_badge(session, __BADGE_PATTERN)
+    changes += vscode.remove_extension_recommendation(session, __VSCODE_EXTENSION_NAME)
     return changes
 
 

--- a/src/compwa_policy/format/prettier.py
+++ b/src/compwa_policy/format/prettier.py
@@ -28,15 +28,17 @@ __GENERATED_LOCK_FILES = [
 def main(session: Session) -> None:
     precommit = session.precommit
     if precommit.find_repo(r".*/(mirrors-)?prettier(-pre-commit)?$") is None:
-        session.changelog += _remove_configuration()
+        session.changelog += _remove_configuration(session=session)
         return
-    session.changelog += add_badge(__BADGE)
-    session.changelog += vscode.add_extension_recommendation(__VSCODE_EXTENSION_NAME)
+    session.changelog += add_badge(__BADGE, session=session)
+    session.changelog += vscode.add_extension_recommendation(
+        __VSCODE_EXTENSION_NAME, session=session
+    )
     _update_prettier_hook(precommit)
     session.changelog += _update_prettier_ignore()
 
 
-def _remove_configuration() -> Changelog:
+def _remove_configuration(*, session: Session | None = None) -> Changelog:
     old_config_files = [
         ".prettierrc.json",
         ".prettierrc.json5",
@@ -55,8 +57,10 @@ def _remove_configuration() -> Changelog:
         msg = f"Removed redundant configuration files: {removed_paths_str}"
         return [msg]
     changes: Changelog = []
-    changes += remove_badge(__BADGE_PATTERN)
-    changes += vscode.remove_extension_recommendation(__VSCODE_EXTENSION_NAME)
+    changes += remove_badge(__BADGE_PATTERN, session=session)
+    changes += vscode.remove_extension_recommendation(
+        __VSCODE_EXTENSION_NAME, session=session
+    )
     return changes
 
 

--- a/src/compwa_policy/format/prettier.py
+++ b/src/compwa_policy/format/prettier.py
@@ -28,17 +28,15 @@ __GENERATED_LOCK_FILES = [
 def main(session: Session) -> None:
     precommit = session.precommit
     if precommit.find_repo(r".*/(mirrors-)?prettier(-pre-commit)?$") is None:
-        session.changelog += _remove_configuration(session)
+        _remove_configuration(session)
         return
-    session.changelog += add_badge(session, __BADGE)
-    session.changelog += vscode.add_extension_recommendation(
-        session, __VSCODE_EXTENSION_NAME
-    )
+    add_badge(session, __BADGE)
+    vscode.add_extension_recommendation(session, __VSCODE_EXTENSION_NAME)
     _update_prettier_hook(precommit)
     session.changelog += _update_prettier_ignore()
 
 
-def _remove_configuration(session: Session, /) -> Changelog:
+def _remove_configuration(session: Session, /) -> None:
     old_config_files = [
         ".prettierrc.json",
         ".prettierrc.json5",
@@ -55,11 +53,10 @@ def _remove_configuration(session: Session, /) -> Changelog:
     if removed_paths:
         removed_paths_str = ", ".join(removed_paths)
         msg = f"Removed redundant configuration files: {removed_paths_str}"
-        return [msg]
-    changes: Changelog = []
-    changes += remove_badge(session, __BADGE_PATTERN)
-    changes += vscode.remove_extension_recommendation(session, __VSCODE_EXTENSION_NAME)
-    return changes
+        session.changelog.append(msg)
+        return
+    remove_badge(session, __BADGE_PATTERN)
+    vscode.remove_extension_recommendation(session, __VSCODE_EXTENSION_NAME)
 
 
 def _update_prettier_hook(precommit: ModifiablePrecommit) -> None:

--- a/src/compwa_policy/format/toml.py
+++ b/src/compwa_policy/format/toml.py
@@ -12,7 +12,6 @@ import tomlkit
 from compwa_policy.utilities import COMPWA_POLICY_DIR, CONFIG_PATH, vscode
 from compwa_policy.utilities.match import filter_patterns
 from compwa_policy.utilities.precommit.struct import Hook, Repo
-from compwa_policy.utilities.pyproject import Pyproject
 from compwa_policy.utilities.pyproject.getters import has_sub_table
 from compwa_policy.utilities.toml import to_toml_array
 from compwa_policy.utilities.yaml import read_preserved_yaml
@@ -36,15 +35,15 @@ def main(session: Session) -> None:
         return
     precommit = session.precommit
     session.changelog += _rename_taplo_config()
-    session.changelog += _update_taplo_config(session=session)
+    session.changelog += _update_taplo_config(session)
     _rename_precommit_url(precommit)
     _update_precommit_repo(precommit)
-    session.changelog += _update_tomlsort_config(session=session)
+    session.changelog += _update_tomlsort_config(session)
     _update_tomlsort_hook(precommit)
-    session.changelog += _update_vscode_extensions(session=session)
+    session.changelog += _update_vscode_extensions(session)
 
 
-def _update_tomlsort_config(*, session: Session) -> Changelog:
+def _update_tomlsort_config(session: Session, /) -> Changelog:
     if not CONFIG_PATH.pyproject.exists():
         return []
     sort_first = [
@@ -106,7 +105,7 @@ def _rename_taplo_config() -> Changelog:
     return []
 
 
-def _update_taplo_config(*, session: Session) -> Changelog:
+def _update_taplo_config(session: Session, /) -> Changelog:
     template_path = COMPWA_POLICY_DIR / ".template" / CONFIG_PATH.taplo
     with open(template_path) as f:
         expected = tomlkit.load(f)
@@ -124,8 +123,8 @@ def _update_taplo_config(*, session: Session) -> Changelog:
             pixi_config = rtoml.load(stream)
         if has_sub_table(pixi_config, "tasks"):
             rules.append(__taplo_rule(CONFIG_PATH.pixi_toml, ["tasks"]))
-    if CONFIG_PATH.pyproject.exists():
-        pyproject = Pyproject.load(session=session)
+    pyproject = session.pyproject
+    if pyproject is not None:
         keys = [
             key
             for key in ["tool.pixi.tasks", "tool.poe.groups", "tool.poe.tasks"]
@@ -191,14 +190,12 @@ def _update_precommit_repo(precommit: ModifiablePrecommit) -> None:
     precommit.update_single_hook_repo(expected_hook)
 
 
-def _update_vscode_extensions(*, session: Session) -> Changelog:
+def _update_vscode_extensions(session: Session, /) -> Changelog:
     # cspell:ignore bungcip tamasfe
     changes: Changelog = []
-    changes += vscode.add_extension_recommendation(
-        "tamasfe.even-better-toml", session=session
-    )
+    changes += vscode.add_extension_recommendation(session, "tamasfe.even-better-toml")
     changes += vscode.remove_extension_recommendation(
-        "bungcip.better-toml", unwanted=True, session=session
+        session, "bungcip.better-toml", unwanted=True
     )
     return changes
 

--- a/src/compwa_policy/format/toml.py
+++ b/src/compwa_policy/format/toml.py
@@ -35,17 +35,17 @@ def main(session: Session) -> None:
         return
     precommit = session.precommit
     session.changelog += _rename_taplo_config()
-    session.changelog += _update_taplo_config(session)
+    _update_taplo_config(session)
     _rename_precommit_url(precommit)
     _update_precommit_repo(precommit)
-    session.changelog += _update_tomlsort_config(session)
+    _update_tomlsort_config(session)
     _update_tomlsort_hook(precommit)
-    session.changelog += _update_vscode_extensions(session)
+    _update_vscode_extensions(session)
 
 
-def _update_tomlsort_config(session: Session, /) -> Changelog:
+def _update_tomlsort_config(session: Session, /) -> None:
     if not CONFIG_PATH.pyproject.exists():
-        return []
+        return
     sort_first = [
         "build-system",
         "project",
@@ -55,7 +55,7 @@ def _update_tomlsort_config(session: Session, /) -> Changelog:
     ]
     pyproject = session.pyproject
     if pyproject is None:
-        return []
+        return
     sort_first = [table for table in sort_first if pyproject.has_table(table)]
     expected_config = dict(
         all=False,
@@ -69,10 +69,9 @@ def _update_tomlsort_config(session: Session, /) -> Changelog:
         expected_config.pop("sort_first")
     tool_table = pyproject.get_table("tool", create=True)
     if tool_table.get("tomlsort") == expected_config:
-        return []
+        return
     tool_table["tomlsort"] = expected_config
     pyproject.changelog.append("Updated toml-sort configuration")
-    return []
 
 
 def _update_tomlsort_hook(precommit: ModifiablePrecommit) -> None:
@@ -105,7 +104,7 @@ def _rename_taplo_config() -> Changelog:
     return []
 
 
-def _update_taplo_config(session: Session, /) -> Changelog:
+def _update_taplo_config(session: Session, /) -> None:
     template_path = COMPWA_POLICY_DIR / ".template" / CONFIG_PATH.taplo
     with open(template_path) as f:
         expected = tomlkit.load(f)
@@ -140,7 +139,8 @@ def _update_taplo_config(session: Session, /) -> Changelog:
         with open(CONFIG_PATH.taplo, "w") as stream:
             stream.write(expected_str)
         msg = f"Added {CONFIG_PATH.taplo} config for TOML formatting"
-        return [msg]
+        session.changelog.append(msg)
+        return
     with open(CONFIG_PATH.taplo) as f:
         existing = tomlkit.load(f)
     existing_str = tomlkit.dumps(existing, sort_keys=True)
@@ -148,8 +148,7 @@ def _update_taplo_config(session: Session, /) -> Changelog:
         with open(CONFIG_PATH.taplo, "w") as stream:
             stream.write(expected_str)
         msg = f"Updated {CONFIG_PATH.taplo} config file"
-        return [msg]
-    return []
+        session.changelog.append(msg)
 
 
 def __taplo_rule(toml_path: Path | str, keys: list[str]) -> dict:
@@ -190,14 +189,12 @@ def _update_precommit_repo(precommit: ModifiablePrecommit) -> None:
     precommit.update_single_hook_repo(expected_hook)
 
 
-def _update_vscode_extensions(session: Session, /) -> Changelog:
+def _update_vscode_extensions(session: Session, /) -> None:
     # cspell:ignore bungcip tamasfe
-    changes: Changelog = []
-    changes += vscode.add_extension_recommendation(session, "tamasfe.even-better-toml")
-    changes += vscode.remove_extension_recommendation(
+    vscode.add_extension_recommendation(session, "tamasfe.even-better-toml")
+    vscode.remove_extension_recommendation(
         session, "bungcip.better-toml", unwanted=True
     )
-    return changes
 
 
 def _to_regex(glob: str) -> str:

--- a/src/compwa_policy/format/toml.py
+++ b/src/compwa_policy/format/toml.py
@@ -47,7 +47,7 @@ def main(session: Session) -> None:
 def _update_tomlsort_config(
     pyproject: ModifiablePyproject | None = None,
     *,
-    session: Session | None = None,
+    session: Session,
 ) -> Changelog:
     if pyproject is None and not CONFIG_PATH.pyproject.exists():
         return []
@@ -74,7 +74,7 @@ def _update_tomlsort_config(
         if not CONFIG_PATH.pyproject.exists():
             return []
         with ModifiablePyproject.load() as config:
-            _update_tomlsort_config(config)
+            _update_tomlsort_config(config, session=session)
             return list(config.changelog)
     tool_table = pyproject.get_table("tool", create=True)
     if tool_table.get("tomlsort") == expected_config:
@@ -114,7 +114,7 @@ def _rename_taplo_config() -> Changelog:
     return []
 
 
-def _update_taplo_config(*, session: Session | None = None) -> Changelog:
+def _update_taplo_config(*, session: Session) -> Changelog:
     template_path = COMPWA_POLICY_DIR / ".template" / CONFIG_PATH.taplo
     with open(template_path) as f:
         expected = tomlkit.load(f)
@@ -199,7 +199,7 @@ def _update_precommit_repo(precommit: ModifiablePrecommit) -> None:
     precommit.update_single_hook_repo(expected_hook)
 
 
-def _update_vscode_extensions(*, session: Session | None = None) -> Changelog:
+def _update_vscode_extensions(*, session: Session) -> Changelog:
     # cspell:ignore bungcip tamasfe
     changes: Changelog = []
     changes += vscode.add_extension_recommendation(

--- a/src/compwa_policy/format/toml.py
+++ b/src/compwa_policy/format/toml.py
@@ -12,7 +12,7 @@ import tomlkit
 from compwa_policy.utilities import COMPWA_POLICY_DIR, CONFIG_PATH, vscode
 from compwa_policy.utilities.match import filter_patterns
 from compwa_policy.utilities.precommit.struct import Hook, Repo
-from compwa_policy.utilities.pyproject import ModifiablePyproject, Pyproject
+from compwa_policy.utilities.pyproject import Pyproject
 from compwa_policy.utilities.pyproject.getters import has_sub_table
 from compwa_policy.utilities.toml import to_toml_array
 from compwa_policy.utilities.yaml import read_preserved_yaml
@@ -39,17 +39,13 @@ def main(session: Session) -> None:
     session.changelog += _update_taplo_config(session=session)
     _rename_precommit_url(precommit)
     _update_precommit_repo(precommit)
-    session.changelog += _update_tomlsort_config(session.pyproject, session=session)
+    session.changelog += _update_tomlsort_config(session=session)
     _update_tomlsort_hook(precommit)
     session.changelog += _update_vscode_extensions(session=session)
 
 
-def _update_tomlsort_config(
-    pyproject: ModifiablePyproject | None = None,
-    *,
-    session: Session,
-) -> Changelog:
-    if pyproject is None and not CONFIG_PATH.pyproject.exists():
+def _update_tomlsort_config(*, session: Session) -> Changelog:
+    if not CONFIG_PATH.pyproject.exists():
         return []
     sort_first = [
         "build-system",
@@ -58,8 +54,10 @@ def _update_tomlsort_config(
         "tool.setuptools_scm",
         "tool.tox.env_run_base",
     ]
-    readonly_pyproject = pyproject or Pyproject.load(session=session)
-    sort_first = [table for table in sort_first if readonly_pyproject.has_table(table)]
+    pyproject = session.pyproject
+    if pyproject is None:
+        return []
+    sort_first = [table for table in sort_first if pyproject.has_table(table)]
     expected_config = dict(
         all=False,
         ignore_case=True,
@@ -70,12 +68,6 @@ def _update_tomlsort_config(
     )
     if not sort_first:
         expected_config.pop("sort_first")
-    if pyproject is None:
-        if not CONFIG_PATH.pyproject.exists():
-            return []
-        with ModifiablePyproject.load() as config:
-            _update_tomlsort_config(config, session=session)
-            return list(config.changelog)
     tool_table = pyproject.get_table("tool", create=True)
     if tool_table.get("tomlsort") == expected_config:
         return []

--- a/src/compwa_policy/format/toml.py
+++ b/src/compwa_policy/format/toml.py
@@ -36,15 +36,19 @@ def main(session: Session) -> None:
         return
     precommit = session.precommit
     session.changelog += _rename_taplo_config()
-    session.changelog += _update_taplo_config()
+    session.changelog += _update_taplo_config(session=session)
     _rename_precommit_url(precommit)
     _update_precommit_repo(precommit)
-    session.changelog += _update_tomlsort_config(session.pyproject)
+    session.changelog += _update_tomlsort_config(session.pyproject, session=session)
     _update_tomlsort_hook(precommit)
-    session.changelog += _update_vscode_extensions()
+    session.changelog += _update_vscode_extensions(session=session)
 
 
-def _update_tomlsort_config(pyproject: ModifiablePyproject | None = None) -> Changelog:
+def _update_tomlsort_config(
+    pyproject: ModifiablePyproject | None = None,
+    *,
+    session: Session | None = None,
+) -> Changelog:
     if pyproject is None and not CONFIG_PATH.pyproject.exists():
         return []
     sort_first = [
@@ -54,7 +58,7 @@ def _update_tomlsort_config(pyproject: ModifiablePyproject | None = None) -> Cha
         "tool.setuptools_scm",
         "tool.tox.env_run_base",
     ]
-    readonly_pyproject = pyproject or Pyproject.load()
+    readonly_pyproject = pyproject or Pyproject.load(session=session)
     sort_first = [table for table in sort_first if readonly_pyproject.has_table(table)]
     expected_config = dict(
         all=False,
@@ -110,7 +114,7 @@ def _rename_taplo_config() -> Changelog:
     return []
 
 
-def _update_taplo_config() -> Changelog:
+def _update_taplo_config(*, session: Session | None = None) -> Changelog:
     template_path = COMPWA_POLICY_DIR / ".template" / CONFIG_PATH.taplo
     with open(template_path) as f:
         expected = tomlkit.load(f)
@@ -129,7 +133,7 @@ def _update_taplo_config() -> Changelog:
         if has_sub_table(pixi_config, "tasks"):
             rules.append(__taplo_rule(CONFIG_PATH.pixi_toml, ["tasks"]))
     if CONFIG_PATH.pyproject.exists():
-        pyproject = Pyproject.load()
+        pyproject = Pyproject.load(session=session)
         keys = [
             key
             for key in ["tool.pixi.tasks", "tool.poe.groups", "tool.poe.tasks"]
@@ -195,12 +199,14 @@ def _update_precommit_repo(precommit: ModifiablePrecommit) -> None:
     precommit.update_single_hook_repo(expected_hook)
 
 
-def _update_vscode_extensions() -> Changelog:
+def _update_vscode_extensions(*, session: Session | None = None) -> Changelog:
     # cspell:ignore bungcip tamasfe
     changes: Changelog = []
-    changes += vscode.add_extension_recommendation("tamasfe.even-better-toml")
+    changes += vscode.add_extension_recommendation(
+        "tamasfe.even-better-toml", session=session
+    )
     changes += vscode.remove_extension_recommendation(
-        "bungcip.better-toml", unwanted=True
+        "bungcip.better-toml", unwanted=True, session=session
     )
     return changes
 

--- a/src/compwa_policy/format/toml.py
+++ b/src/compwa_policy/format/toml.py
@@ -12,11 +12,7 @@ import tomlkit
 from compwa_policy.utilities import COMPWA_POLICY_DIR, CONFIG_PATH, vscode
 from compwa_policy.utilities.match import filter_patterns
 from compwa_policy.utilities.precommit.struct import Hook, Repo
-from compwa_policy.utilities.pyproject import (
-    ModifiablePyproject,
-    Pyproject,
-    use_modifiable_pyproject,
-)
+from compwa_policy.utilities.pyproject import ModifiablePyproject, Pyproject
 from compwa_policy.utilities.pyproject.getters import has_sub_table
 from compwa_policy.utilities.toml import to_toml_array
 from compwa_policy.utilities.yaml import read_preserved_yaml
@@ -70,16 +66,17 @@ def _update_tomlsort_config(pyproject: ModifiablePyproject | None = None) -> Cha
     )
     if not sort_first:
         expected_config.pop("sort_first")
-    with use_modifiable_pyproject(pyproject) as (config, include_changelog):
-        if config is None:
+    if pyproject is None:
+        if not CONFIG_PATH.pyproject.exists():
             return []
-        tool_table = config.get_table("tool", create=True)
-        if tool_table.get("tomlsort") == expected_config:
-            return []
-        tool_table["tomlsort"] = expected_config
-        config.changelog.append("Updated toml-sort configuration")
-        if include_changelog:
+        with ModifiablePyproject.load() as config:
+            _update_tomlsort_config(config)
             return list(config.changelog)
+    tool_table = pyproject.get_table("tool", create=True)
+    if tool_table.get("tomlsort") == expected_config:
+        return []
+    tool_table["tomlsort"] = expected_config
+    pyproject.changelog.append("Updated toml-sort configuration")
     return []
 
 

--- a/src/compwa_policy/github/release_drafter.py
+++ b/src/compwa_policy/github/release_drafter.py
@@ -30,7 +30,7 @@ def main(
                 f"Removed {', '.join(str(p) for p in paths_to_remove)}"
             )
         return
-    session.changelog += update_file(session, CONFIG_PATH.release_drafter_workflow)
+    update_file(session, CONFIG_PATH.release_drafter_workflow)
     session.changelog += _update_draft(repo_name, repo_title, organization)
 
 

--- a/src/compwa_policy/github/release_drafter.py
+++ b/src/compwa_policy/github/release_drafter.py
@@ -30,9 +30,7 @@ def main(
                 f"Removed {', '.join(str(p) for p in paths_to_remove)}"
             )
         return
-    session.changelog += update_file(
-        CONFIG_PATH.release_drafter_workflow, session=session
-    )
+    session.changelog += update_file(session, CONFIG_PATH.release_drafter_workflow)
     session.changelog += _update_draft(repo_name, repo_title, organization)
 
 

--- a/src/compwa_policy/github/release_drafter.py
+++ b/src/compwa_policy/github/release_drafter.py
@@ -30,7 +30,9 @@ def main(
                 f"Removed {', '.join(str(p) for p in paths_to_remove)}"
             )
         return
-    session.changelog += update_file(CONFIG_PATH.release_drafter_workflow)
+    session.changelog += update_file(
+        CONFIG_PATH.release_drafter_workflow, session=session
+    )
     session.changelog += _update_draft(repo_name, repo_title, organization)
 
 

--- a/src/compwa_policy/github/upgrade_lock.py
+++ b/src/compwa_policy/github/upgrade_lock.py
@@ -17,7 +17,7 @@ from compwa_policy.utilities.match import filter_patterns
 from compwa_policy.utilities.yaml import create_prettier_round_trip_yaml
 
 if TYPE_CHECKING:
-    from compwa_policy.utilities.precommit import ModifiablePrecommit, Precommit
+    from compwa_policy.utilities.precommit import ModifiablePrecommit
     from compwa_policy.utilities.session import Changelog, Session
 
 Frequency = Literal[
@@ -39,7 +39,7 @@ def main(session: Session, frequency: Frequency, keep_workflow: set[str]) -> Non
     _update_precommit_schedule(precommit, frequency)
     session.changelog += _remove_script("pin_requirements.py")
     session.changelog += _remove_script("upgrade.sh")
-    session.changelog += _update_lock_workflow(precommit, frequency, keep_workflow)
+    _update_lock_workflow(session, frequency, keep_workflow)
 
 
 def _remove_script(script_name: str) -> Changelog:
@@ -52,9 +52,11 @@ def _remove_script(script_name: str) -> Changelog:
 
 
 def _update_lock_workflow(
-    precommit: Precommit, frequency: Frequency, keep_workflow: set[str]
-) -> Changelog:
-    def overwrite_workflow(workflow_file: str) -> Changelog:
+    session: Session, /, frequency: Frequency, keep_workflow: set[str]
+) -> None:
+    precommit = session.precommit
+
+    def overwrite_workflow(workflow_file: str) -> None:
         expected_workflow_path = (
             COMPWA_POLICY_DIR / CONFIG_PATH.github_workflow_dir / workflow_file
         )
@@ -78,23 +80,21 @@ def _update_lock_workflow(
             expected_data["on"]["schedule"][0]["cron"] = _to_cron_schedule(frequency)
         workflow_path = CONFIG_PATH.github_workflow_dir / workflow_file
         if not workflow_path.exists():
-            return update_workflow(yaml, expected_data, workflow_path)
+            session.changelog += update_workflow(yaml, expected_data, workflow_path)
+            return
         existing_data = yaml.load(workflow_path)
         if existing_data != expected_data:
-            return update_workflow(yaml, expected_data, workflow_path)
-        return []
+            session.changelog += update_workflow(yaml, expected_data, workflow_path)
 
-    changes: Changelog = []
     if "lock.yml" not in keep_workflow:
-        changes += overwrite_workflow("lock.yml")
+        overwrite_workflow("lock.yml")
     for workflow in (
         "requirements.yml",
         "requirements-cron.yml",
         "requirements-pr.yml",
     ):
         if workflow not in keep_workflow:
-            changes += remove_workflow(workflow)
-    return changes
+            session.changelog += remove_workflow(workflow)
 
 
 def _to_cron_schedule(frequency: Frequency) -> str:

--- a/src/compwa_policy/github/workflows.py
+++ b/src/compwa_policy/github/workflows.py
@@ -52,7 +52,7 @@ def main(
         session.changelog += remove_workflow("cd.yml")
     else:
         session.changelog += _update_cd_workflow(
-            no_milestones, no_pypi, no_version_branches
+            no_milestones, no_pypi, no_version_branches, session=session
         )
     session.changelog += _update_ci_workflow(
         session.precommit,
@@ -64,14 +64,19 @@ def main(
         python_version,
         single_threaded,
         skip_tests,
+        session=session,
     )
     if not keep_pr_linting:
         session.changelog += _update_pr_linting()
-    session.changelog += _recommend_vscode_extension()
+    session.changelog += _recommend_vscode_extension(session=session)
 
 
 def _update_cd_workflow(  # noqa: C901
-    no_milestones: bool, no_pypi: bool, no_version_branches: bool
+    no_milestones: bool,
+    no_pypi: bool,
+    no_version_branches: bool,
+    *,
+    session: Session | None = None,
 ) -> Changelog:
     def update() -> Changelog:  # noqa: C901
         yaml = create_prettier_round_trip_yaml()
@@ -80,7 +85,7 @@ def _update_cd_workflow(  # noqa: C901
         banned_jobs = set()
         if no_milestones:
             banned_jobs.add("milestone")
-        if no_pypi or not has_pyproject_package_name():
+        if no_pypi or not has_pyproject_package_name(session=session):
             banned_jobs.add("package-name")
             banned_jobs.add("pypi")
         if no_version_branches:
@@ -132,6 +137,8 @@ def _update_ci_workflow(  # noqa: PLR0917
     python_version: PythonVersion,
     single_threaded: bool,
     skip_tests: list[str],
+    *,
+    session: Session | None = None,
 ) -> Changelog:
     def update() -> Changelog:
         yaml, expected_data = _get_ci_workflow(
@@ -165,7 +172,7 @@ def _update_ci_workflow(  # noqa: PLR0917
         changes += remove_workflow("ci-style.yml")
         changes += remove_workflow("ci-tests.yml")
         changes += remove_workflow("linkcheck.yml")
-    changes += _copy_workflow_file("clean-caches.yml")
+    changes += _copy_workflow_file("clean-caches.yml", session=session)
     changes += remove_workflow("clean-cache.yml")
     return changes
 
@@ -290,7 +297,11 @@ def __get_coverage_python_version() -> PythonVersion:
     return DEFAULT_DEV_PYTHON_VERSION
 
 
-def _copy_workflow_file(filename: str) -> Changelog:
+def _copy_workflow_file(
+    filename: str,
+    *,
+    session: Session | None = None,
+) -> Changelog:
     expected_workflow_path = (
         COMPWA_POLICY_DIR / CONFIG_PATH.github_workflow_dir / filename
     )
@@ -301,14 +312,14 @@ def _copy_workflow_file(filename: str) -> Changelog:
 
     workflow_path = f"{CONFIG_PATH.github_workflow_dir}/{filename}"
     if not os.path.exists(workflow_path):
-        write(expected_content, target=workflow_path)
+        write(expected_content, target=workflow_path, session=session)
         msg = f"Created {workflow_path} workflow"
         return [msg]
 
     with open(workflow_path) as stream:
         existing_content = stream.read()
     if existing_content != expected_content:
-        write(expected_content, target=workflow_path)
+        write(expected_content, target=workflow_path, session=session)
         msg = f"Updated {workflow_path} workflow"
         return [msg]
     return []
@@ -328,21 +339,23 @@ def __remove_constraint_pinning(content: str) -> str:
     )
 
 
-def _recommend_vscode_extension() -> Changelog:
+def _recommend_vscode_extension(*, session: Session | None = None) -> Changelog:
     if not CONFIG_PATH.github_workflow_dir.exists():
         return []
     # cspell:ignore cschleiden
     changes: Changelog = []
     changes += vscode.remove_extension_recommendation(
-        "cschleiden.vscode-github-actions"
+        "cschleiden.vscode-github-actions", session=session
     )
-    changes += vscode.add_extension_recommendation("github.vscode-github-actions")
+    changes += vscode.add_extension_recommendation(
+        "github.vscode-github-actions", session=session
+    )
     ci_workflow = CONFIG_PATH.github_workflow_dir / "ci.yml"
     if ci_workflow.exists():
         action_settings = {
             "github-actions.workflows.pinned.workflows": [str(ci_workflow)],
         }
-        changes += vscode.update_settings(action_settings)
+        changes += vscode.update_settings(action_settings, session=session)
     return changes
 
 

--- a/src/compwa_policy/github/workflows.py
+++ b/src/compwa_policy/github/workflows.py
@@ -51,10 +51,8 @@ def main(
     if no_cd:
         session.changelog += remove_workflow("cd.yml")
     else:
-        session.changelog += _update_cd_workflow(
-            session, no_milestones, no_pypi, no_version_branches
-        )
-    session.changelog += _update_ci_workflow(
+        _update_cd_workflow(session, no_milestones, no_pypi, no_version_branches)
+    _update_ci_workflow(
         session,
         allow_deprecated,
         doc_apt_packages,
@@ -67,7 +65,7 @@ def main(
     )
     if not keep_pr_linting:
         session.changelog += _update_pr_linting()
-    session.changelog += _recommend_vscode_extension(session)
+    _recommend_vscode_extension(session)
 
 
 def _update_cd_workflow(  # noqa: C901
@@ -76,7 +74,7 @@ def _update_cd_workflow(  # noqa: C901
     no_milestones: bool,
     no_pypi: bool,
     no_version_branches: bool,
-) -> Changelog:
+) -> None:
     def update() -> Changelog:  # noqa: C901
         yaml = create_prettier_round_trip_yaml()
         workflow_path = CONFIG_PATH.github_workflow_dir / "cd.yml"
@@ -108,10 +106,8 @@ def _update_cd_workflow(  # noqa: C901
             return update_workflow(yaml, expected_data, workflow_path)
         return []
 
-    changes: Changelog = []
-    changes += update()
-    changes += remove_workflow("milestone.yml")
-    return changes
+    session.changelog += update()
+    session.changelog += remove_workflow("milestone.yml")
 
 
 def _update_pr_linting() -> Changelog:
@@ -137,7 +133,7 @@ def _update_ci_workflow(  # noqa: PLR0917
     python_version: PythonVersion,
     single_threaded: bool,
     skip_tests: list[str],
-) -> Changelog:
+) -> None:
     def update() -> Changelog:
         precommit = session.precommit
         yaml, expected_data = _get_ci_workflow(
@@ -164,16 +160,14 @@ def _update_ci_workflow(  # noqa: PLR0917
                 return update_workflow(yaml, expected_data, workflow_path)
         return []
 
-    changes: Changelog = []
-    changes += update()
+    session.changelog += update()
     if not allow_deprecated:
-        changes += remove_workflow("ci-docs.yml")
-        changes += remove_workflow("ci-style.yml")
-        changes += remove_workflow("ci-tests.yml")
-        changes += remove_workflow("linkcheck.yml")
-    changes += _copy_workflow_file(session, "clean-caches.yml")
-    changes += remove_workflow("clean-cache.yml")
-    return changes
+        session.changelog += remove_workflow("ci-docs.yml")
+        session.changelog += remove_workflow("ci-style.yml")
+        session.changelog += remove_workflow("ci-tests.yml")
+        session.changelog += remove_workflow("linkcheck.yml")
+    _copy_workflow_file(session, "clean-caches.yml")
+    session.changelog += remove_workflow("clean-cache.yml")
 
 
 def _get_ci_workflow(  # noqa: PLR0917
@@ -296,7 +290,7 @@ def __get_coverage_python_version() -> PythonVersion:
     return DEFAULT_DEV_PYTHON_VERSION
 
 
-def _copy_workflow_file(session: Session, /, filename: str) -> Changelog:
+def _copy_workflow_file(session: Session, /, filename: str) -> None:
     expected_workflow_path = (
         COMPWA_POLICY_DIR / CONFIG_PATH.github_workflow_dir / filename
     )
@@ -309,15 +303,15 @@ def _copy_workflow_file(session: Session, /, filename: str) -> Changelog:
     if not os.path.exists(workflow_path):
         write(expected_content, target=workflow_path, session=session)
         msg = f"Created {workflow_path} workflow"
-        return [msg]
+        session.changelog.append(msg)
+        return
 
     with open(workflow_path) as stream:
         existing_content = stream.read()
     if existing_content != expected_content:
         write(expected_content, target=workflow_path, session=session)
         msg = f"Updated {workflow_path} workflow"
-        return [msg]
-    return []
+        session.changelog.append(msg)
 
 
 def __remove_constraint_pinning(content: str) -> str:
@@ -334,24 +328,18 @@ def __remove_constraint_pinning(content: str) -> str:
     )
 
 
-def _recommend_vscode_extension(session: Session, /) -> Changelog:
+def _recommend_vscode_extension(session: Session, /) -> None:
     if not CONFIG_PATH.github_workflow_dir.exists():
-        return []
+        return
     # cspell:ignore cschleiden
-    changes: Changelog = []
-    changes += vscode.remove_extension_recommendation(
-        session, "cschleiden.vscode-github-actions"
-    )
-    changes += vscode.add_extension_recommendation(
-        session, "github.vscode-github-actions"
-    )
+    vscode.remove_extension_recommendation(session, "cschleiden.vscode-github-actions")
+    vscode.add_extension_recommendation(session, "github.vscode-github-actions")
     ci_workflow = CONFIG_PATH.github_workflow_dir / "ci.yml"
     if ci_workflow.exists():
         action_settings = {
             "github-actions.workflows.pinned.workflows": [str(ci_workflow)],
         }
-        changes += vscode.update_settings(session, action_settings)
-    return changes
+        vscode.update_settings(session, action_settings)
 
 
 def remove_workflow(filename: str) -> Changelog:

--- a/src/compwa_policy/github/workflows.py
+++ b/src/compwa_policy/github/workflows.py
@@ -76,7 +76,7 @@ def _update_cd_workflow(  # noqa: C901
     no_pypi: bool,
     no_version_branches: bool,
     *,
-    session: Session | None = None,
+    session: Session,
 ) -> Changelog:
     def update() -> Changelog:  # noqa: C901
         yaml = create_prettier_round_trip_yaml()
@@ -138,7 +138,7 @@ def _update_ci_workflow(  # noqa: PLR0917
     single_threaded: bool,
     skip_tests: list[str],
     *,
-    session: Session | None = None,
+    session: Session,
 ) -> Changelog:
     def update() -> Changelog:
         yaml, expected_data = _get_ci_workflow(
@@ -300,7 +300,7 @@ def __get_coverage_python_version() -> PythonVersion:
 def _copy_workflow_file(
     filename: str,
     *,
-    session: Session | None = None,
+    session: Session,
 ) -> Changelog:
     expected_workflow_path = (
         COMPWA_POLICY_DIR / CONFIG_PATH.github_workflow_dir / filename
@@ -339,7 +339,7 @@ def __remove_constraint_pinning(content: str) -> str:
     )
 
 
-def _recommend_vscode_extension(*, session: Session | None = None) -> Changelog:
+def _recommend_vscode_extension(*, session: Session) -> Changelog:
     if not CONFIG_PATH.github_workflow_dir.exists():
         return []
     # cspell:ignore cschleiden

--- a/src/compwa_policy/github/workflows.py
+++ b/src/compwa_policy/github/workflows.py
@@ -52,10 +52,10 @@ def main(
         session.changelog += remove_workflow("cd.yml")
     else:
         session.changelog += _update_cd_workflow(
-            no_milestones, no_pypi, no_version_branches, session=session
+            session, no_milestones, no_pypi, no_version_branches
         )
     session.changelog += _update_ci_workflow(
-        session.precommit,
+        session,
         allow_deprecated,
         doc_apt_packages,
         environment_variables,
@@ -64,19 +64,18 @@ def main(
         python_version,
         single_threaded,
         skip_tests,
-        session=session,
     )
     if not keep_pr_linting:
         session.changelog += _update_pr_linting()
-    session.changelog += _recommend_vscode_extension(session=session)
+    session.changelog += _recommend_vscode_extension(session)
 
 
 def _update_cd_workflow(  # noqa: C901
+    session: Session,
+    /,
     no_milestones: bool,
     no_pypi: bool,
     no_version_branches: bool,
-    *,
-    session: Session,
 ) -> Changelog:
     def update() -> Changelog:  # noqa: C901
         yaml = create_prettier_round_trip_yaml()
@@ -85,7 +84,7 @@ def _update_cd_workflow(  # noqa: C901
         banned_jobs = set()
         if no_milestones:
             banned_jobs.add("milestone")
-        if no_pypi or not has_pyproject_package_name(session=session):
+        if no_pypi or not has_pyproject_package_name(session):
             banned_jobs.add("package-name")
             banned_jobs.add("pypi")
         if no_version_branches:
@@ -128,7 +127,8 @@ def _update_pr_linting() -> Changelog:
 
 
 def _update_ci_workflow(  # noqa: PLR0917
-    precommit: Precommit,
+    session: Session,
+    /,
     allow_deprecated: bool,
     doc_apt_packages: list[str],
     environment_variables: dict[str, str],
@@ -137,10 +137,9 @@ def _update_ci_workflow(  # noqa: PLR0917
     python_version: PythonVersion,
     single_threaded: bool,
     skip_tests: list[str],
-    *,
-    session: Session,
 ) -> Changelog:
     def update() -> Changelog:
+        precommit = session.precommit
         yaml, expected_data = _get_ci_workflow(
             COMPWA_POLICY_DIR / CONFIG_PATH.github_workflow_dir / "ci.yml",
             precommit,
@@ -172,7 +171,7 @@ def _update_ci_workflow(  # noqa: PLR0917
         changes += remove_workflow("ci-style.yml")
         changes += remove_workflow("ci-tests.yml")
         changes += remove_workflow("linkcheck.yml")
-    changes += _copy_workflow_file("clean-caches.yml", session=session)
+    changes += _copy_workflow_file(session, "clean-caches.yml")
     changes += remove_workflow("clean-cache.yml")
     return changes
 
@@ -297,11 +296,7 @@ def __get_coverage_python_version() -> PythonVersion:
     return DEFAULT_DEV_PYTHON_VERSION
 
 
-def _copy_workflow_file(
-    filename: str,
-    *,
-    session: Session,
-) -> Changelog:
+def _copy_workflow_file(session: Session, /, filename: str) -> Changelog:
     expected_workflow_path = (
         COMPWA_POLICY_DIR / CONFIG_PATH.github_workflow_dir / filename
     )
@@ -339,23 +334,23 @@ def __remove_constraint_pinning(content: str) -> str:
     )
 
 
-def _recommend_vscode_extension(*, session: Session) -> Changelog:
+def _recommend_vscode_extension(session: Session, /) -> Changelog:
     if not CONFIG_PATH.github_workflow_dir.exists():
         return []
     # cspell:ignore cschleiden
     changes: Changelog = []
     changes += vscode.remove_extension_recommendation(
-        "cschleiden.vscode-github-actions", session=session
+        session, "cschleiden.vscode-github-actions"
     )
     changes += vscode.add_extension_recommendation(
-        "github.vscode-github-actions", session=session
+        session, "github.vscode-github-actions"
     )
     ci_workflow = CONFIG_PATH.github_workflow_dir / "ci.yml"
     if ci_workflow.exists():
         action_settings = {
             "github-actions.workflows.pinned.workflows": [str(ci_workflow)],
         }
-        changes += vscode.update_settings(action_settings, session=session)
+        changes += vscode.update_settings(session, action_settings)
     return changes
 
 

--- a/src/compwa_policy/nb/binder.py
+++ b/src/compwa_policy/nb/binder.py
@@ -11,7 +11,6 @@ from textwrap import dedent
 from typing import TYPE_CHECKING, Any
 
 from compwa_policy.utilities import CONFIG_PATH
-from compwa_policy.utilities.pyproject import Pyproject
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
@@ -29,7 +28,7 @@ def main(
     apt_packages: list[str],
 ) -> None:
     session.changelog += _update_apt_txt(apt_packages)
-    session.changelog += _update_post_build(package_manager, session=session)
+    session.changelog += _update_post_build(session, package_manager)
     session.changelog += _make_executable(CONFIG_PATH.binder / "postBuild")
     session.changelog += _update_runtime_txt(python_version)
 
@@ -50,14 +49,14 @@ def _update_apt_txt(apt_packages: list[str]) -> Changelog:
 
 
 def _update_post_build(
-    package_manager: PackageManagerChoice,
-    *,
     session: Session,
+    /,
+    package_manager: PackageManagerChoice,
 ) -> Changelog:
     if package_manager == "pixi+uv":
-        expected_content = __get_post_builder_for_pixi_with_uv(session=session)
+        expected_content = __get_post_builder_for_pixi_with_uv(session)
     elif package_manager == "uv":
-        expected_content = __get_post_builder_for_uv(session=session)
+        expected_content = __get_post_builder_for_uv(session)
     else:
         msg = f"Package manager {package_manager} is not supported."
         raise NotImplementedError(msg)
@@ -67,10 +66,7 @@ def _update_post_build(
     )
 
 
-def __get_post_builder_for_pixi_with_uv(
-    *,
-    session: Session,
-) -> str:
+def __get_post_builder_for_pixi_with_uv(session: Session, /) -> str:
     expected_content = dedent("""
         #!/bin/bash
         set -ex
@@ -82,7 +78,7 @@ def __get_post_builder_for_pixi_with_uv(
           pixi global install $pixi_packages
         fi
     """).strip()
-    activation = ___get_pixi_activation()
+    activation = ___get_pixi_activation(session)
     if activation.environment:
         for key, value in activation.environment.items():
             expected_content += f'\nexport {key}="{value}"'
@@ -91,7 +87,7 @@ def __get_post_builder_for_pixi_with_uv(
             expected_content += "\nbash " + script
     expected_content += "\npixi clean cache --yes\n"
     expected_content += "\nuv export \\"
-    for groups in __get_notebook_groups(session=session):
+    for groups in __get_notebook_groups(session):
         expected_content += f"\n  --group {groups} \\"
     expected_content += dedent(R"""
           --no-dev \
@@ -110,10 +106,10 @@ class PixiActivation:
     environment: dict[str, str] | None = None
 
 
-def ___get_pixi_activation() -> PixiActivation:
+def ___get_pixi_activation(session: Session, /) -> PixiActivation:
     if not CONFIG_PATH.pixi_toml.exists():
         return PixiActivation()
-    pixi = Pyproject.load(CONFIG_PATH.pixi_toml)
+    pixi = session.pixi
     if not pixi.has_table("activation"):
         return PixiActivation()
     activation = pixi.get_table("activation")
@@ -123,7 +119,7 @@ def ___get_pixi_activation() -> PixiActivation:
     )
 
 
-def __get_post_builder_for_uv(*, session: Session) -> str:
+def __get_post_builder_for_uv(session: Session, /) -> str:
     expected_content = dedent("""
         #!/bin/bash
         set -ex
@@ -131,7 +127,7 @@ def __get_post_builder_for_uv(*, session: Session) -> str:
         source $HOME/.cargo/env
     """).strip()
     expected_content += "\nuv export \\"
-    for group in __get_notebook_groups(session=session):
+    for group in __get_notebook_groups(session):
         expected_content += f"\n  --group {group} \\"
     expected_content += dedent(R"""
           --no-dev \
@@ -145,20 +141,16 @@ def __get_post_builder_for_uv(*, session: Session) -> str:
     return expected_content
 
 
-def __get_notebook_groups(*, session: Session) -> list[str]:
-    dependency_groups = ___safe_get_table("dependency-groups", session=session)
+def __get_notebook_groups(session: Session, /) -> list[str]:
+    dependency_groups = ___safe_get_table(session, "dependency-groups")
     allowed_groups = {"jupyter", "notebooks"}
     return sorted(allowed_groups & set(dependency_groups))
 
 
-def ___safe_get_table(
-    dotted_header: str,
-    *,
-    session: Session,
-) -> Mapping[str, Any]:
-    if not CONFIG_PATH.pyproject.exists():
+def ___safe_get_table(session: Session, /, dotted_header: str) -> Mapping[str, Any]:
+    pyproject = session.pyproject
+    if pyproject is None:
         return {}
-    pyproject = Pyproject.load(session=session)
     if not pyproject.has_table(dotted_header):
         return {}
     return pyproject.get_table(dotted_header)

--- a/src/compwa_policy/nb/binder.py
+++ b/src/compwa_policy/nb/binder.py
@@ -29,7 +29,7 @@ def main(
     apt_packages: list[str],
 ) -> None:
     session.changelog += _update_apt_txt(apt_packages)
-    session.changelog += _update_post_build(package_manager)
+    session.changelog += _update_post_build(package_manager, session=session)
     session.changelog += _make_executable(CONFIG_PATH.binder / "postBuild")
     session.changelog += _update_runtime_txt(python_version)
 
@@ -49,11 +49,15 @@ def _update_apt_txt(apt_packages: list[str]) -> Changelog:
     )
 
 
-def _update_post_build(package_manager: PackageManagerChoice) -> Changelog:
+def _update_post_build(
+    package_manager: PackageManagerChoice,
+    *,
+    session: Session | None = None,
+) -> Changelog:
     if package_manager == "pixi+uv":
-        expected_content = __get_post_builder_for_pixi_with_uv()
+        expected_content = __get_post_builder_for_pixi_with_uv(session=session)
     elif package_manager == "uv":
-        expected_content = __get_post_builder_for_uv()
+        expected_content = __get_post_builder_for_uv(session=session)
     else:
         msg = f"Package manager {package_manager} is not supported."
         raise NotImplementedError(msg)
@@ -63,7 +67,10 @@ def _update_post_build(package_manager: PackageManagerChoice) -> Changelog:
     )
 
 
-def __get_post_builder_for_pixi_with_uv() -> str:
+def __get_post_builder_for_pixi_with_uv(
+    *,
+    session: Session | None = None,
+) -> str:
     expected_content = dedent("""
         #!/bin/bash
         set -ex
@@ -84,7 +91,7 @@ def __get_post_builder_for_pixi_with_uv() -> str:
             expected_content += "\nbash " + script
     expected_content += "\npixi clean cache --yes\n"
     expected_content += "\nuv export \\"
-    for groups in __get_notebook_groups():
+    for groups in __get_notebook_groups(session=session):
         expected_content += f"\n  --group {groups} \\"
     expected_content += dedent(R"""
           --no-dev \
@@ -116,7 +123,7 @@ def ___get_pixi_activation() -> PixiActivation:
     )
 
 
-def __get_post_builder_for_uv() -> str:
+def __get_post_builder_for_uv(*, session: Session | None = None) -> str:
     expected_content = dedent("""
         #!/bin/bash
         set -ex
@@ -124,7 +131,7 @@ def __get_post_builder_for_uv() -> str:
         source $HOME/.cargo/env
     """).strip()
     expected_content += "\nuv export \\"
-    for group in __get_notebook_groups():
+    for group in __get_notebook_groups(session=session):
         expected_content += f"\n  --group {group} \\"
     expected_content += dedent(R"""
           --no-dev \
@@ -138,16 +145,20 @@ def __get_post_builder_for_uv() -> str:
     return expected_content
 
 
-def __get_notebook_groups() -> list[str]:
-    dependency_groups = ___safe_get_table("dependency-groups")
+def __get_notebook_groups(*, session: Session | None = None) -> list[str]:
+    dependency_groups = ___safe_get_table("dependency-groups", session=session)
     allowed_groups = {"jupyter", "notebooks"}
     return sorted(allowed_groups & set(dependency_groups))
 
 
-def ___safe_get_table(dotted_header: str) -> Mapping[str, Any]:
+def ___safe_get_table(
+    dotted_header: str,
+    *,
+    session: Session | None = None,
+) -> Mapping[str, Any]:
     if not CONFIG_PATH.pyproject.exists():
         return {}
-    pyproject = Pyproject.load()
+    pyproject = Pyproject.load(session=session)
     if not pyproject.has_table(dotted_header):
         return {}
     return pyproject.get_table(dotted_header)

--- a/src/compwa_policy/nb/binder.py
+++ b/src/compwa_policy/nb/binder.py
@@ -28,7 +28,7 @@ def main(
     apt_packages: list[str],
 ) -> None:
     session.changelog += _update_apt_txt(apt_packages)
-    session.changelog += _update_post_build(session, package_manager)
+    _update_post_build(session, package_manager)
     session.changelog += _make_executable(CONFIG_PATH.binder / "postBuild")
     session.changelog += _update_runtime_txt(python_version)
 
@@ -52,7 +52,7 @@ def _update_post_build(
     session: Session,
     /,
     package_manager: PackageManagerChoice,
-) -> Changelog:
+) -> None:
     if package_manager == "pixi+uv":
         expected_content = __get_post_builder_for_pixi_with_uv(session)
     elif package_manager == "uv":
@@ -60,8 +60,8 @@ def _update_post_build(
     else:
         msg = f"Package manager {package_manager} is not supported."
         raise NotImplementedError(msg)
-    return __update_file(
-        expected_content.strip() + "\n",
+    session.changelog += __update_file(
+        expected_content=expected_content.strip() + "\n",
         path=CONFIG_PATH.binder / "postBuild",
     )
 

--- a/src/compwa_policy/nb/binder.py
+++ b/src/compwa_policy/nb/binder.py
@@ -52,7 +52,7 @@ def _update_apt_txt(apt_packages: list[str]) -> Changelog:
 def _update_post_build(
     package_manager: PackageManagerChoice,
     *,
-    session: Session | None = None,
+    session: Session,
 ) -> Changelog:
     if package_manager == "pixi+uv":
         expected_content = __get_post_builder_for_pixi_with_uv(session=session)
@@ -69,7 +69,7 @@ def _update_post_build(
 
 def __get_post_builder_for_pixi_with_uv(
     *,
-    session: Session | None = None,
+    session: Session,
 ) -> str:
     expected_content = dedent("""
         #!/bin/bash
@@ -123,7 +123,7 @@ def ___get_pixi_activation() -> PixiActivation:
     )
 
 
-def __get_post_builder_for_uv(*, session: Session | None = None) -> str:
+def __get_post_builder_for_uv(*, session: Session) -> str:
     expected_content = dedent("""
         #!/bin/bash
         set -ex
@@ -145,7 +145,7 @@ def __get_post_builder_for_uv(*, session: Session | None = None) -> str:
     return expected_content
 
 
-def __get_notebook_groups(*, session: Session | None = None) -> list[str]:
+def __get_notebook_groups(*, session: Session) -> list[str]:
     dependency_groups = ___safe_get_table("dependency-groups", session=session)
     allowed_groups = {"jupyter", "notebooks"}
     return sorted(allowed_groups & set(dependency_groups))
@@ -154,7 +154,7 @@ def __get_notebook_groups(*, session: Session | None = None) -> list[str]:
 def ___safe_get_table(
     dotted_header: str,
     *,
-    session: Session | None = None,
+    session: Session,
 ) -> Mapping[str, Any]:
     if not CONFIG_PATH.pyproject.exists():
         return {}

--- a/src/compwa_policy/nb/jupyter.py
+++ b/src/compwa_policy/nb/jupyter.py
@@ -7,32 +7,28 @@ from typing import TYPE_CHECKING
 from compwa_policy.utilities import vscode
 
 if TYPE_CHECKING:
-    from compwa_policy.utilities.session import Changelog, Session
+    from compwa_policy.utilities.session import Session
 
 
 def main(session: Session, no_ruff: bool) -> None:
-    session.changelog += _update_dev_requirements(session, no_ruff)
+    _update_dev_requirements(session, no_ruff)
     # cspell:ignore toolsai
-    session.changelog += vscode.add_extension_recommendation(
-        session, "ms-toolsai.jupyter"
-    )
-    session.changelog += vscode.add_extension_recommendation(
-        session, "ms-toolsai.vscode-jupyter-cell-tags"
-    )
-    session.changelog += vscode.remove_extension_recommendation(
+    vscode.add_extension_recommendation(session, "ms-toolsai.jupyter")
+    vscode.add_extension_recommendation(session, "ms-toolsai.vscode-jupyter-cell-tags")
+    vscode.remove_extension_recommendation(
         session,
         "ms-toolsai.vscode-jupyter-slideshow",
         unwanted=True,
     )
 
 
-def _update_dev_requirements(session: Session, /, no_ruff: bool) -> Changelog:
+def _update_dev_requirements(session: Session, /, no_ruff: bool) -> None:
     pyproject = session.pyproject
     if pyproject is None:
-        return []
+        return
     supported_python_versions = pyproject.get_supported_python_versions()
     if "3.6" in supported_python_versions:
-        return []
+        return
     packages = {
         "jupyterlab",
         "jupyterlab-git",
@@ -60,4 +56,3 @@ def _update_dev_requirements(session: Session, /, no_ruff: bool) -> Changelog:
         packages.add("jupyter-ruff")
     for package in sorted(packages):
         pyproject.add_dependency(package, dependency_group=["jupyter", "dev"])
-    return []

--- a/src/compwa_policy/nb/jupyter.py
+++ b/src/compwa_policy/nb/jupyter.py
@@ -4,17 +4,14 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from compwa_policy.utilities import CONFIG_PATH, vscode
-from compwa_policy.utilities.pyproject import ModifiablePyproject
+from compwa_policy.utilities import vscode
 
 if TYPE_CHECKING:
     from compwa_policy.utilities.session import Changelog, Session
 
 
 def main(session: Session, no_ruff: bool) -> None:
-    session.changelog += _update_dev_requirements(
-        no_ruff, session.pyproject, session=session
-    )
+    session.changelog += _update_dev_requirements(no_ruff, session=session)
     # cspell:ignore toolsai
     session.changelog += vscode.add_extension_recommendation(
         "ms-toolsai.jupyter", session=session
@@ -31,16 +28,12 @@ def main(session: Session, no_ruff: bool) -> None:
 
 def _update_dev_requirements(
     no_ruff: bool,
-    pyproject: ModifiablePyproject | None = None,
     *,
     session: Session,
 ) -> Changelog:
+    pyproject = session.pyproject
     if pyproject is None:
-        if not CONFIG_PATH.pyproject.exists():
-            return []
-        with ModifiablePyproject.load() as config:
-            _update_dev_requirements(no_ruff, config, session=session)
-            return list(config.changelog)
+        return []
     supported_python_versions = pyproject.get_supported_python_versions()
     if "3.6" in supported_python_versions:
         return []

--- a/src/compwa_policy/nb/jupyter.py
+++ b/src/compwa_policy/nb/jupyter.py
@@ -33,13 +33,13 @@ def _update_dev_requirements(
     no_ruff: bool,
     pyproject: ModifiablePyproject | None = None,
     *,
-    session: Session | None = None,
+    session: Session,
 ) -> Changelog:
     if pyproject is None:
         if not CONFIG_PATH.pyproject.exists():
             return []
         with ModifiablePyproject.load() as config:
-            _update_dev_requirements(no_ruff, config)
+            _update_dev_requirements(no_ruff, config, session=session)
             return list(config.changelog)
     supported_python_versions = pyproject.get_supported_python_versions()
     if "3.6" in supported_python_versions:

--- a/src/compwa_policy/nb/jupyter.py
+++ b/src/compwa_policy/nb/jupyter.py
@@ -11,26 +11,22 @@ if TYPE_CHECKING:
 
 
 def main(session: Session, no_ruff: bool) -> None:
-    session.changelog += _update_dev_requirements(no_ruff, session=session)
+    session.changelog += _update_dev_requirements(session, no_ruff)
     # cspell:ignore toolsai
     session.changelog += vscode.add_extension_recommendation(
-        "ms-toolsai.jupyter", session=session
+        session, "ms-toolsai.jupyter"
     )
     session.changelog += vscode.add_extension_recommendation(
-        "ms-toolsai.vscode-jupyter-cell-tags", session=session
+        session, "ms-toolsai.vscode-jupyter-cell-tags"
     )
     session.changelog += vscode.remove_extension_recommendation(
+        session,
         "ms-toolsai.vscode-jupyter-slideshow",
         unwanted=True,
-        session=session,
     )
 
 
-def _update_dev_requirements(
-    no_ruff: bool,
-    *,
-    session: Session,
-) -> Changelog:
+def _update_dev_requirements(session: Session, /, no_ruff: bool) -> Changelog:
     pyproject = session.pyproject
     if pyproject is None:
         return []
@@ -45,7 +41,7 @@ def _update_dev_requirements(
         "python-lsp-server",
     }
     # cspell:ignore executablebookproject
-    recommended_vscode_extensions = vscode.get_recommended_extensions(session=session)
+    recommended_vscode_extensions = vscode.get_recommended_extensions(session)
     if "executablebookproject.myst-highlight" in recommended_vscode_extensions:
         packages.add("jupyterlab-myst")
     else:

--- a/src/compwa_policy/nb/jupyter.py
+++ b/src/compwa_policy/nb/jupyter.py
@@ -4,11 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from compwa_policy.utilities import vscode
-from compwa_policy.utilities.pyproject import (
-    ModifiablePyproject,
-    use_modifiable_pyproject,
-)
+from compwa_policy.utilities import CONFIG_PATH, vscode
+from compwa_policy.utilities.pyproject import ModifiablePyproject
 
 if TYPE_CHECKING:
     from compwa_policy.utilities.session import Changelog, Session
@@ -31,39 +28,40 @@ def _update_dev_requirements(
     no_ruff: bool,
     pyproject: ModifiablePyproject | None = None,
 ) -> Changelog:
-    with use_modifiable_pyproject(pyproject) as (config, include_changelog):
-        if config is None:
+    if pyproject is None:
+        if not CONFIG_PATH.pyproject.exists():
             return []
-        supported_python_versions = config.get_supported_python_versions()
-        if "3.6" in supported_python_versions:
-            return []
-        packages = {
-            "jupyterlab",
-            "jupyterlab-git",
-            "jupyterlab-lsp",
-            "jupyterlab-quickopen",  # cspell:ignore quickopen
-            "python-lsp-server",
-        }
-        # cspell:ignore executablebookproject
-        recommended_vscode_extensions = vscode.get_recommended_extensions()
-        if "executablebookproject.myst-highlight" in recommended_vscode_extensions:
-            packages.add("jupyterlab-myst")
-        else:
-            config.remove_dependency("jupyterlab-myst")
-        if "quarto.quarto" in recommended_vscode_extensions:
-            packages.add("jupyterlab-quarto")
-        else:
-            config.remove_dependency("jupyterlab-quarto")
-        config.remove_dependency("python-lsp-server[rope]")
-        if not no_ruff:
-            config.remove_dependency(
-                "black", ignored_sections=["doc", "notebooks", "test"]
-            )
-            config.remove_dependency("isort")
-            config.remove_dependency("jupyterlab-code-formatter")
-            packages.add("jupyter-ruff")
-        for package in sorted(packages):
-            config.add_dependency(package, dependency_group=["jupyter", "dev"])
-        if include_changelog:
+        with ModifiablePyproject.load() as config:
+            _update_dev_requirements(no_ruff, config)
             return list(config.changelog)
+    supported_python_versions = pyproject.get_supported_python_versions()
+    if "3.6" in supported_python_versions:
+        return []
+    packages = {
+        "jupyterlab",
+        "jupyterlab-git",
+        "jupyterlab-lsp",
+        "jupyterlab-quickopen",  # cspell:ignore quickopen
+        "python-lsp-server",
+    }
+    # cspell:ignore executablebookproject
+    recommended_vscode_extensions = vscode.get_recommended_extensions()
+    if "executablebookproject.myst-highlight" in recommended_vscode_extensions:
+        packages.add("jupyterlab-myst")
+    else:
+        pyproject.remove_dependency("jupyterlab-myst")
+    if "quarto.quarto" in recommended_vscode_extensions:
+        packages.add("jupyterlab-quarto")
+    else:
+        pyproject.remove_dependency("jupyterlab-quarto")
+    pyproject.remove_dependency("python-lsp-server[rope]")
+    if not no_ruff:
+        pyproject.remove_dependency(
+            "black", ignored_sections=["doc", "notebooks", "test"]
+        )
+        pyproject.remove_dependency("isort")
+        pyproject.remove_dependency("jupyterlab-code-formatter")
+        packages.add("jupyter-ruff")
+    for package in sorted(packages):
+        pyproject.add_dependency(package, dependency_group=["jupyter", "dev"])
     return []

--- a/src/compwa_policy/nb/jupyter.py
+++ b/src/compwa_policy/nb/jupyter.py
@@ -12,21 +12,28 @@ if TYPE_CHECKING:
 
 
 def main(session: Session, no_ruff: bool) -> None:
-    session.changelog += _update_dev_requirements(no_ruff, session.pyproject)
+    session.changelog += _update_dev_requirements(
+        no_ruff, session.pyproject, session=session
+    )
     # cspell:ignore toolsai
-    session.changelog += vscode.add_extension_recommendation("ms-toolsai.jupyter")
     session.changelog += vscode.add_extension_recommendation(
-        "ms-toolsai.vscode-jupyter-cell-tags"
+        "ms-toolsai.jupyter", session=session
+    )
+    session.changelog += vscode.add_extension_recommendation(
+        "ms-toolsai.vscode-jupyter-cell-tags", session=session
     )
     session.changelog += vscode.remove_extension_recommendation(
         "ms-toolsai.vscode-jupyter-slideshow",
         unwanted=True,
+        session=session,
     )
 
 
 def _update_dev_requirements(
     no_ruff: bool,
     pyproject: ModifiablePyproject | None = None,
+    *,
+    session: Session | None = None,
 ) -> Changelog:
     if pyproject is None:
         if not CONFIG_PATH.pyproject.exists():
@@ -45,7 +52,7 @@ def _update_dev_requirements(
         "python-lsp-server",
     }
     # cspell:ignore executablebookproject
-    recommended_vscode_extensions = vscode.get_recommended_extensions()
+    recommended_vscode_extensions = vscode.get_recommended_extensions(session=session)
     if "executablebookproject.myst-highlight" in recommended_vscode_extensions:
         packages.add("jupyterlab-myst")
     else:

--- a/src/compwa_policy/python/black.py
+++ b/src/compwa_policy/python/black.py
@@ -22,24 +22,16 @@ def main(session: Session, has_notebooks: bool) -> None:
         return
     _remove_outdated_settings(config)
     _update_black_settings(config)
-    precommit.remove_hook(
-        hook_id="black",
-        repo_url="https://github.com/psf/black",
-    )
-    precommit.remove_hook(
-        hook_id="black-jupyter",
-        repo_url="https://github.com/psf/black",
-    )
+    precommit.remove_hook("black", repo_url="https://github.com/psf/black")
+    precommit.remove_hook("black-jupyter", repo_url="https://github.com/psf/black")
     _update_precommit_repo(precommit, has_notebooks)
-    vscode.add_extension_recommendation(
-        session, extension_name="ms-python.black-formatter"
-    )
+    vscode.add_extension_recommendation(session, "ms-python.black-formatter")
     vscode.update_settings(
-        session, new_settings={"black-formatter.importStrategy": "fromEnvironment"}
+        session, {"black-formatter.importStrategy": "fromEnvironment"}
     )
     vscode.update_settings(
         session,
-        new_settings={
+        {
             "[python]": {
                 "editor.defaultFormatter": "ms-python.black-formatter",
                 "editor.rulers": [88],

--- a/src/compwa_policy/python/black.py
+++ b/src/compwa_policy/python/black.py
@@ -32,19 +32,19 @@ def main(session: Session, has_notebooks: bool) -> None:
     )
     _update_precommit_repo(precommit, has_notebooks)
     session.changelog += vscode.add_extension_recommendation(
-        "ms-python.black-formatter", session=session
+        session, "ms-python.black-formatter"
     )
     session.changelog += vscode.update_settings(
-        {"black-formatter.importStrategy": "fromEnvironment"}, session=session
+        session, {"black-formatter.importStrategy": "fromEnvironment"}
     )
     session.changelog += vscode.update_settings(
+        session,
         {
             "[python]": {
                 "editor.defaultFormatter": "ms-python.black-formatter",
                 "editor.rulers": [88],
             },
         },
-        session=session,
     )
     precommit.remove_hook("nbqa-black")
 

--- a/src/compwa_policy/python/black.py
+++ b/src/compwa_policy/python/black.py
@@ -32,14 +32,14 @@ def main(session: Session, has_notebooks: bool) -> None:
     )
     _update_precommit_repo(precommit, has_notebooks)
     session.changelog += vscode.add_extension_recommendation(
-        session, "ms-python.black-formatter"
+        session, extension_name="ms-python.black-formatter"
     )
     session.changelog += vscode.update_settings(
-        session, {"black-formatter.importStrategy": "fromEnvironment"}
+        session, new_settings={"black-formatter.importStrategy": "fromEnvironment"}
     )
     session.changelog += vscode.update_settings(
         session,
-        {
+        new_settings={
             "[python]": {
                 "editor.defaultFormatter": "ms-python.black-formatter",
                 "editor.rulers": [88],

--- a/src/compwa_policy/python/black.py
+++ b/src/compwa_policy/python/black.py
@@ -32,17 +32,20 @@ def main(session: Session, has_notebooks: bool) -> None:
     )
     _update_precommit_repo(precommit, has_notebooks)
     session.changelog += vscode.add_extension_recommendation(
-        "ms-python.black-formatter"
+        "ms-python.black-formatter", session=session
     )
-    session.changelog += vscode.update_settings({
-        "black-formatter.importStrategy": "fromEnvironment"
-    })
-    session.changelog += vscode.update_settings({
-        "[python]": {
-            "editor.defaultFormatter": "ms-python.black-formatter",
-            "editor.rulers": [88],
+    session.changelog += vscode.update_settings(
+        {"black-formatter.importStrategy": "fromEnvironment"}, session=session
+    )
+    session.changelog += vscode.update_settings(
+        {
+            "[python]": {
+                "editor.defaultFormatter": "ms-python.black-formatter",
+                "editor.rulers": [88],
+            },
         },
-    })
+        session=session,
+    )
     precommit.remove_hook("nbqa-black")
 
 

--- a/src/compwa_policy/python/black.py
+++ b/src/compwa_policy/python/black.py
@@ -6,11 +6,7 @@ from typing import TYPE_CHECKING, Any
 
 from compwa_policy.utilities import vscode
 from compwa_policy.utilities.precommit.struct import Hook, Repo
-from compwa_policy.utilities.pyproject import (
-    ModifiablePyproject,
-    complies_with_subset,
-    use_modifiable_pyproject,
-)
+from compwa_policy.utilities.pyproject import ModifiablePyproject, complies_with_subset
 from compwa_policy.utilities.toml import to_toml_array
 from compwa_policy.utilities.yaml import read_preserved_yaml
 
@@ -21,33 +17,33 @@ if TYPE_CHECKING:
 
 def main(session: Session, has_notebooks: bool) -> None:
     precommit = session.precommit
-    with use_modifiable_pyproject(session.pyproject) as (config, _):
-        if config is None:
-            return
-        _remove_outdated_settings(config)
-        _update_black_settings(config)
-        precommit.remove_hook(
-            hook_id="black",
-            repo_url="https://github.com/psf/black",
-        )
-        precommit.remove_hook(
-            hook_id="black-jupyter",
-            repo_url="https://github.com/psf/black",
-        )
-        _update_precommit_repo(precommit, has_notebooks)
-        session.changelog += vscode.add_extension_recommendation(
-            "ms-python.black-formatter"
-        )
-        session.changelog += vscode.update_settings({
-            "black-formatter.importStrategy": "fromEnvironment"
-        })
-        session.changelog += vscode.update_settings({
-            "[python]": {
-                "editor.defaultFormatter": "ms-python.black-formatter",
-                "editor.rulers": [88],
-            },
-        })
-        precommit.remove_hook("nbqa-black")
+    config = session.pyproject
+    if config is None:
+        return
+    _remove_outdated_settings(config)
+    _update_black_settings(config)
+    precommit.remove_hook(
+        hook_id="black",
+        repo_url="https://github.com/psf/black",
+    )
+    precommit.remove_hook(
+        hook_id="black-jupyter",
+        repo_url="https://github.com/psf/black",
+    )
+    _update_precommit_repo(precommit, has_notebooks)
+    session.changelog += vscode.add_extension_recommendation(
+        "ms-python.black-formatter"
+    )
+    session.changelog += vscode.update_settings({
+        "black-formatter.importStrategy": "fromEnvironment"
+    })
+    session.changelog += vscode.update_settings({
+        "[python]": {
+            "editor.defaultFormatter": "ms-python.black-formatter",
+            "editor.rulers": [88],
+        },
+    })
+    precommit.remove_hook("nbqa-black")
 
 
 def _remove_outdated_settings(pyproject: ModifiablePyproject) -> None:

--- a/src/compwa_policy/python/black.py
+++ b/src/compwa_policy/python/black.py
@@ -31,13 +31,13 @@ def main(session: Session, has_notebooks: bool) -> None:
         repo_url="https://github.com/psf/black",
     )
     _update_precommit_repo(precommit, has_notebooks)
-    session.changelog += vscode.add_extension_recommendation(
+    vscode.add_extension_recommendation(
         session, extension_name="ms-python.black-formatter"
     )
-    session.changelog += vscode.update_settings(
+    vscode.update_settings(
         session, new_settings={"black-formatter.importStrategy": "fromEnvironment"}
     )
-    session.changelog += vscode.update_settings(
+    vscode.update_settings(
         session,
         new_settings={
             "[python]": {

--- a/src/compwa_policy/python/mypy.py
+++ b/src/compwa_policy/python/mypy.py
@@ -11,34 +11,31 @@ from ruamel.yaml.comments import CommentedSeq
 
 from compwa_policy.utilities import CONFIG_PATH, remove_lines, vscode
 from compwa_policy.utilities.precommit.struct import Hook, Repo
-from compwa_policy.utilities.pyproject import (
-    ModifiablePyproject,
-    use_modifiable_pyproject,
-)
 from compwa_policy.utilities.readme import add_badge, remove_badge
 
 if TYPE_CHECKING:
     from compwa_policy.utilities.precommit import ModifiablePrecommit
+    from compwa_policy.utilities.pyproject import ModifiablePyproject
     from compwa_policy.utilities.session import Changelog, Session
 
 
 def main(session: Session, active: bool) -> None:
     precommit = session.precommit
     session.changelog += _update_vscode_settings(active)
-    with use_modifiable_pyproject(session.pyproject) as (config, _):
-        if config is None:
-            return
-        if active:
-            config.add_dependency("mypy", dependency_group=["style", "dev"])
-            _merge_mypy_into_pyproject(config)
-            _update_precommit_config(precommit)
-            session.changelog += remove_badge(r"http://(www\.)?mypy\-lang\.org/")
-            session.changelog += add_badge(
-                "[![Type-checked with mypy](https://mypy-lang.org/static/mypy_badge.svg)](https://mypy.readthedocs.io)",
-            )
-        else:
-            session.changelog += _remove_mypy(precommit, config)
-            session.changelog += remove_lines(CONFIG_PATH.gitignore, ".*mypy.*")
+    config = session.pyproject
+    if config is None:
+        return
+    if active:
+        config.add_dependency("mypy", dependency_group=["style", "dev"])
+        _merge_mypy_into_pyproject(config)
+        _update_precommit_config(precommit)
+        session.changelog += remove_badge(r"http://(www\.)?mypy\-lang\.org/")
+        session.changelog += add_badge(
+            "[![Type-checked with mypy](https://mypy-lang.org/static/mypy_badge.svg)](https://mypy.readthedocs.io)",
+        )
+    else:
+        session.changelog += _remove_mypy(precommit, config)
+        session.changelog += remove_lines(CONFIG_PATH.gitignore, ".*mypy.*")
 
 
 def _merge_mypy_into_pyproject(pyproject: ModifiablePyproject) -> None:

--- a/src/compwa_policy/python/mypy.py
+++ b/src/compwa_policy/python/mypy.py
@@ -16,11 +16,11 @@ from compwa_policy.utilities.readme import add_badge, remove_badge
 if TYPE_CHECKING:
     from compwa_policy.utilities.precommit import ModifiablePrecommit
     from compwa_policy.utilities.pyproject import ModifiablePyproject
-    from compwa_policy.utilities.session import Changelog, Session
+    from compwa_policy.utilities.session import Session
 
 
 def main(session: Session, active: bool) -> None:
-    session.changelog += _update_vscode_settings(session, active)
+    _update_vscode_settings(session, active)
     config = session.pyproject
     if config is None:
         return
@@ -28,14 +28,14 @@ def main(session: Session, active: bool) -> None:
         config.add_dependency("mypy", dependency_group=["style", "dev"])
         _merge_mypy_into_pyproject(config)
         _update_precommit_config(session.precommit)
-        session.changelog += remove_badge(session, r"http://(www\.)?mypy\-lang\.org/")
-        session.changelog += add_badge(
+        remove_badge(session, r"http://(www\.)?mypy\-lang\.org/")
+        add_badge(
             session,
             badge="[![Type-checked with mypy](https://mypy-lang.org/static/mypy_badge.svg)](https://mypy.readthedocs.io)",
         )
     else:
-        session.changelog += _remove_mypy(session)
-        session.changelog += remove_lines(session, CONFIG_PATH.gitignore, ".*mypy.*")
+        _remove_mypy(session)
+        remove_lines(session, CONFIG_PATH.gitignore, ".*mypy.*")
 
 
 def _merge_mypy_into_pyproject(pyproject: ModifiablePyproject) -> None:
@@ -53,17 +53,17 @@ def _merge_mypy_into_pyproject(pyproject: ModifiablePyproject) -> None:
     pyproject.changelog.append(msg)
 
 
-def _remove_mypy(session: Session, /) -> Changelog:
+def _remove_mypy(session: Session, /) -> None:
     precommit = session.precommit
     pyproject = session.pyproject
     if pyproject is None:
-        return []
+        return
     if pyproject.has_table("tool.mypy"):
         del pyproject._document["tool"]["mypy"]  # noqa: SLF001
         pyproject.changelog.append("Removed mypy configuration table")
     pyproject.remove_dependency("mypy")
     precommit.remove_hook("mypy")
-    return remove_badge(
+    remove_badge(
         session,
         badge_pattern=r"\[\!\[.*[Mm]ypy.*\]\(.*mypy.*\)\]\(.*mypy.*\)\n?",
     )
@@ -84,10 +84,9 @@ def _update_precommit_config(precommit: ModifiablePrecommit) -> None:
     precommit.update_single_hook_repo(expected_repo)
 
 
-def _update_vscode_settings(session: Session, /, mypy: bool) -> Changelog:
-    changes: Changelog = []
+def _update_vscode_settings(session: Session, /, mypy: bool) -> None:
     if mypy:
-        changes += vscode.add_extension_recommendation(
+        vscode.add_extension_recommendation(
             session, extension_name="ms-python.mypy-type-checker"
         )
         settings = {
@@ -95,15 +94,14 @@ def _update_vscode_settings(session: Session, /, mypy: bool) -> Changelog:
                 f"--config-file=${{workspaceFolder}}/{CONFIG_PATH.pyproject}"
             ],
         }
-        changes += vscode.update_settings(session, settings)
+        vscode.update_settings(session, settings)
     else:
-        changes += vscode.remove_extension_recommendation(
+        vscode.remove_extension_recommendation(
             session,
             "ms-python.mypy-type-checker",
             unwanted=True,
         )
-        changes += vscode.remove_settings(
+        vscode.remove_settings(
             session,
             ["mypy-type-checker.args", "mypy-type-checker.importStrategy"],
         )
-    return changes

--- a/src/compwa_policy/python/mypy.py
+++ b/src/compwa_policy/python/mypy.py
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
 
 
 def main(session: Session, active: bool) -> None:
-    session.changelog += _update_vscode_settings(active, session=session)
+    session.changelog += _update_vscode_settings(session, active)
     config = session.pyproject
     if config is None:
         return
@@ -28,18 +28,14 @@ def main(session: Session, active: bool) -> None:
         config.add_dependency("mypy", dependency_group=["style", "dev"])
         _merge_mypy_into_pyproject(config)
         _update_precommit_config(session.precommit)
-        session.changelog += remove_badge(
-            r"http://(www\.)?mypy\-lang\.org/", session=session
-        )
+        session.changelog += remove_badge(session, r"http://(www\.)?mypy\-lang\.org/")
         session.changelog += add_badge(
+            session,
             "[![Type-checked with mypy](https://mypy-lang.org/static/mypy_badge.svg)](https://mypy.readthedocs.io)",
-            session=session,
         )
     else:
-        session.changelog += _remove_mypy(session=session)
-        session.changelog += remove_lines(
-            CONFIG_PATH.gitignore, ".*mypy.*", session=session
-        )
+        session.changelog += _remove_mypy(session)
+        session.changelog += remove_lines(session, CONFIG_PATH.gitignore, ".*mypy.*")
 
 
 def _merge_mypy_into_pyproject(pyproject: ModifiablePyproject) -> None:
@@ -57,7 +53,7 @@ def _merge_mypy_into_pyproject(pyproject: ModifiablePyproject) -> None:
     pyproject.changelog.append(msg)
 
 
-def _remove_mypy(*, session: Session) -> Changelog:
+def _remove_mypy(session: Session, /) -> Changelog:
     precommit = session.precommit
     pyproject = session.pyproject
     if pyproject is None:
@@ -68,8 +64,8 @@ def _remove_mypy(*, session: Session) -> Changelog:
     pyproject.remove_dependency("mypy")
     precommit.remove_hook("mypy")
     return remove_badge(
+        session,
         r"\[\!\[.*[Mm]ypy.*\]\(.*mypy.*\)\]\(.*mypy.*\)\n?",
-        session=session,
     )
 
 
@@ -88,30 +84,26 @@ def _update_precommit_config(precommit: ModifiablePrecommit) -> None:
     precommit.update_single_hook_repo(expected_repo)
 
 
-def _update_vscode_settings(
-    mypy: bool,
-    *,
-    session: Session,
-) -> Changelog:
+def _update_vscode_settings(session: Session, /, mypy: bool) -> Changelog:
     changes: Changelog = []
     if mypy:
         changes += vscode.add_extension_recommendation(
-            "ms-python.mypy-type-checker", session=session
+            session, "ms-python.mypy-type-checker"
         )
         settings = {
             "mypy-type-checker.args": [
                 f"--config-file=${{workspaceFolder}}/{CONFIG_PATH.pyproject}"
             ],
         }
-        changes += vscode.update_settings(settings, session=session)
+        changes += vscode.update_settings(session, settings)
     else:
         changes += vscode.remove_extension_recommendation(
+            session,
             "ms-python.mypy-type-checker",
             unwanted=True,
-            session=session,
         )
         changes += vscode.remove_settings(
+            session,
             ["mypy-type-checker.args", "mypy-type-checker.importStrategy"],
-            session=session,
         )
     return changes

--- a/src/compwa_policy/python/mypy.py
+++ b/src/compwa_policy/python/mypy.py
@@ -31,7 +31,7 @@ def main(session: Session, active: bool) -> None:
         session.changelog += remove_badge(session, r"http://(www\.)?mypy\-lang\.org/")
         session.changelog += add_badge(
             session,
-            "[![Type-checked with mypy](https://mypy-lang.org/static/mypy_badge.svg)](https://mypy.readthedocs.io)",
+            badge="[![Type-checked with mypy](https://mypy-lang.org/static/mypy_badge.svg)](https://mypy.readthedocs.io)",
         )
     else:
         session.changelog += _remove_mypy(session)
@@ -65,7 +65,7 @@ def _remove_mypy(session: Session, /) -> Changelog:
     precommit.remove_hook("mypy")
     return remove_badge(
         session,
-        r"\[\!\[.*[Mm]ypy.*\]\(.*mypy.*\)\]\(.*mypy.*\)\n?",
+        badge_pattern=r"\[\!\[.*[Mm]ypy.*\]\(.*mypy.*\)\]\(.*mypy.*\)\n?",
     )
 
 
@@ -88,7 +88,7 @@ def _update_vscode_settings(session: Session, /, mypy: bool) -> Changelog:
     changes: Changelog = []
     if mypy:
         changes += vscode.add_extension_recommendation(
-            session, "ms-python.mypy-type-checker"
+            session, extension_name="ms-python.mypy-type-checker"
         )
         settings = {
             "mypy-type-checker.args": [

--- a/src/compwa_policy/python/mypy.py
+++ b/src/compwa_policy/python/mypy.py
@@ -62,7 +62,7 @@ def _remove_mypy(
     precommit: ModifiablePrecommit,
     pyproject: ModifiablePyproject,
     *,
-    session: Session | None = None,
+    session: Session,
 ) -> Changelog:
     if pyproject.has_table("tool.mypy"):
         del pyproject._document["tool"]["mypy"]  # noqa: SLF001
@@ -93,7 +93,7 @@ def _update_precommit_config(precommit: ModifiablePrecommit) -> None:
 def _update_vscode_settings(
     mypy: bool,
     *,
-    session: Session | None = None,
+    session: Session,
 ) -> Changelog:
     changes: Changelog = []
     if mypy:

--- a/src/compwa_policy/python/mypy.py
+++ b/src/compwa_policy/python/mypy.py
@@ -20,7 +20,6 @@ if TYPE_CHECKING:
 
 
 def main(session: Session, active: bool) -> None:
-    precommit = session.precommit
     session.changelog += _update_vscode_settings(active, session=session)
     config = session.pyproject
     if config is None:
@@ -28,7 +27,7 @@ def main(session: Session, active: bool) -> None:
     if active:
         config.add_dependency("mypy", dependency_group=["style", "dev"])
         _merge_mypy_into_pyproject(config)
-        _update_precommit_config(precommit)
+        _update_precommit_config(session.precommit)
         session.changelog += remove_badge(
             r"http://(www\.)?mypy\-lang\.org/", session=session
         )
@@ -37,7 +36,7 @@ def main(session: Session, active: bool) -> None:
             session=session,
         )
     else:
-        session.changelog += _remove_mypy(precommit, config, session=session)
+        session.changelog += _remove_mypy(session=session)
         session.changelog += remove_lines(
             CONFIG_PATH.gitignore, ".*mypy.*", session=session
         )
@@ -58,12 +57,11 @@ def _merge_mypy_into_pyproject(pyproject: ModifiablePyproject) -> None:
     pyproject.changelog.append(msg)
 
 
-def _remove_mypy(
-    precommit: ModifiablePrecommit,
-    pyproject: ModifiablePyproject,
-    *,
-    session: Session,
-) -> Changelog:
+def _remove_mypy(*, session: Session) -> Changelog:
+    precommit = session.precommit
+    pyproject = session.pyproject
+    if pyproject is None:
+        return []
     if pyproject.has_table("tool.mypy"):
         del pyproject._document["tool"]["mypy"]  # noqa: SLF001
         pyproject.changelog.append("Removed mypy configuration table")

--- a/src/compwa_policy/python/mypy.py
+++ b/src/compwa_policy/python/mypy.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
 
 def main(session: Session, active: bool) -> None:
     precommit = session.precommit
-    session.changelog += _update_vscode_settings(active)
+    session.changelog += _update_vscode_settings(active, session=session)
     config = session.pyproject
     if config is None:
         return
@@ -29,13 +29,18 @@ def main(session: Session, active: bool) -> None:
         config.add_dependency("mypy", dependency_group=["style", "dev"])
         _merge_mypy_into_pyproject(config)
         _update_precommit_config(precommit)
-        session.changelog += remove_badge(r"http://(www\.)?mypy\-lang\.org/")
+        session.changelog += remove_badge(
+            r"http://(www\.)?mypy\-lang\.org/", session=session
+        )
         session.changelog += add_badge(
             "[![Type-checked with mypy](https://mypy-lang.org/static/mypy_badge.svg)](https://mypy.readthedocs.io)",
+            session=session,
         )
     else:
-        session.changelog += _remove_mypy(precommit, config)
-        session.changelog += remove_lines(CONFIG_PATH.gitignore, ".*mypy.*")
+        session.changelog += _remove_mypy(precommit, config, session=session)
+        session.changelog += remove_lines(
+            CONFIG_PATH.gitignore, ".*mypy.*", session=session
+        )
 
 
 def _merge_mypy_into_pyproject(pyproject: ModifiablePyproject) -> None:
@@ -54,14 +59,20 @@ def _merge_mypy_into_pyproject(pyproject: ModifiablePyproject) -> None:
 
 
 def _remove_mypy(
-    precommit: ModifiablePrecommit, pyproject: ModifiablePyproject
+    precommit: ModifiablePrecommit,
+    pyproject: ModifiablePyproject,
+    *,
+    session: Session | None = None,
 ) -> Changelog:
     if pyproject.has_table("tool.mypy"):
         del pyproject._document["tool"]["mypy"]  # noqa: SLF001
         pyproject.changelog.append("Removed mypy configuration table")
     pyproject.remove_dependency("mypy")
     precommit.remove_hook("mypy")
-    return remove_badge(r"\[\!\[.*[Mm]ypy.*\]\(.*mypy.*\)\]\(.*mypy.*\)\n?")
+    return remove_badge(
+        r"\[\!\[.*[Mm]ypy.*\]\(.*mypy.*\)\]\(.*mypy.*\)\n?",
+        session=session,
+    )
 
 
 def _update_precommit_config(precommit: ModifiablePrecommit) -> None:
@@ -79,22 +90,30 @@ def _update_precommit_config(precommit: ModifiablePrecommit) -> None:
     precommit.update_single_hook_repo(expected_repo)
 
 
-def _update_vscode_settings(mypy: bool) -> Changelog:
+def _update_vscode_settings(
+    mypy: bool,
+    *,
+    session: Session | None = None,
+) -> Changelog:
     changes: Changelog = []
     if mypy:
-        changes += vscode.add_extension_recommendation("ms-python.mypy-type-checker")
+        changes += vscode.add_extension_recommendation(
+            "ms-python.mypy-type-checker", session=session
+        )
         settings = {
             "mypy-type-checker.args": [
                 f"--config-file=${{workspaceFolder}}/{CONFIG_PATH.pyproject}"
             ],
         }
-        changes += vscode.update_settings(settings)
+        changes += vscode.update_settings(settings, session=session)
     else:
         changes += vscode.remove_extension_recommendation(
             "ms-python.mypy-type-checker",
             unwanted=True,
+            session=session,
         )
         changes += vscode.remove_settings(
             ["mypy-type-checker.args", "mypy-type-checker.importStrategy"],
+            session=session,
         )
     return changes

--- a/src/compwa_policy/python/pyproject.py
+++ b/src/compwa_policy/python/pyproject.py
@@ -6,10 +6,6 @@ import os
 import re
 from typing import TYPE_CHECKING
 
-from compwa_policy.utilities.pyproject import (
-    ModifiablePyproject,
-    use_modifiable_pyproject,
-)
 from compwa_policy.utilities.pyproject.getters import (
     _get_allowed_versions,
     _get_requires_python,
@@ -18,18 +14,19 @@ from compwa_policy.utilities.toml import to_toml_array
 
 if TYPE_CHECKING:
     from compwa_policy.config import PythonVersion
+    from compwa_policy.utilities.pyproject import ModifiablePyproject
     from compwa_policy.utilities.session import Session
 
 
 def main(session: Session, excluded_python_versions: set[PythonVersion]) -> None:
-    with use_modifiable_pyproject(session.pyproject) as (config, _):
-        if config is None:
-            return
-        _update_pypi_link_names(config)
-        _convert_to_dependency_groups(config)
-        _rename_sty_to_style(config)
-        _update_requires_python(config)
-        _update_python_version_classifiers(config, excluded_python_versions)
+    config = session.pyproject
+    if config is None:
+        return
+    _update_pypi_link_names(config)
+    _convert_to_dependency_groups(config)
+    _rename_sty_to_style(config)
+    _update_requires_python(config)
+    _update_python_version_classifiers(config, excluded_python_versions)
 
 
 def _update_pypi_link_names(pyproject: ModifiablePyproject) -> None:

--- a/src/compwa_policy/python/pyright.py
+++ b/src/compwa_policy/python/pyright.py
@@ -14,11 +14,11 @@ from compwa_policy.utilities.toml import to_toml_array
 
 if TYPE_CHECKING:
     from compwa_policy.utilities.precommit import ModifiablePrecommit
-    from compwa_policy.utilities.session import Changelog, Session
+    from compwa_policy.utilities.session import Session
 
 
 def main(session: Session, active: bool) -> None:
-    session.changelog += _update_vscode_settings(session, active)
+    _update_vscode_settings(session, active)
     config = session.pyproject
     if config is None:
         return
@@ -28,7 +28,7 @@ def main(session: Session, active: bool) -> None:
         _remove_excludes(config)
         _update_settings(config)
     else:
-        session.changelog += _remove_pyright(session)
+        _remove_pyright(session)
 
 
 def _merge_config_into_pyproject(
@@ -91,13 +91,10 @@ def _update_settings(pyproject: ModifiablePyproject) -> None:
         pyproject.changelog.append(msg)
 
 
-def _update_vscode_settings(session: Session, /, active: bool) -> Changelog:
-    changes: Changelog = []
+def _update_vscode_settings(session: Session, /, active: bool) -> None:
     if active:
-        changes += vscode.add_extension_recommendation(
-            session, "ms-python.vscode-pylance"
-        )
-        changes += vscode.update_settings(
+        vscode.add_extension_recommendation(session, "ms-python.vscode-pylance")
+        vscode.update_settings(
             session,
             {
                 "python.analysis.autoImportCompletions": False,
@@ -105,26 +102,25 @@ def _update_vscode_settings(session: Session, /, active: bool) -> Changelog:
             },
         )
     else:
-        changes += vscode.remove_settings(
+        vscode.remove_settings(
             session,
             [
                 "python.analysis.autoImportCompletions",
                 "python.analysis.inlayHints.pytestParameters",
             ],
         )
-        changes += vscode.remove_extension_recommendation(
+        vscode.remove_extension_recommendation(
             session,
             "ms-python.vscode-pylance",
             unwanted=True,
         )
-    return changes
 
 
-def _remove_pyright(session: Session, /) -> Changelog:
+def _remove_pyright(session: Session, /) -> None:
     precommit = session.precommit
     pyproject = session.pyproject
     if pyproject is None:
-        return []
+        return
     pyright_config = Path("pyrightconfig.json")
     if pyright_config.exists():
         os.remove(pyright_config)
@@ -136,4 +132,4 @@ def _remove_pyright(session: Session, /) -> Changelog:
         pyproject.changelog.append(msg)
     pyproject.remove_dependency("pyright")
     precommit.remove_hook("pyright")
-    return remove_lines(session, CONFIG_PATH.gitignore, ".*pyrightconfig.json")
+    remove_lines(session, CONFIG_PATH.gitignore, ".*pyrightconfig.json")

--- a/src/compwa_policy/python/pyright.py
+++ b/src/compwa_policy/python/pyright.py
@@ -18,18 +18,17 @@ if TYPE_CHECKING:
 
 
 def main(session: Session, active: bool) -> None:
-    precommit = session.precommit
     session.changelog += _update_vscode_settings(active, session=session)
     config = session.pyproject
     if config is None:
         return
     if active:
         _merge_config_into_pyproject(config)
-        _update_precommit(precommit)
+        _update_precommit(session.precommit)
         _remove_excludes(config)
         _update_settings(config)
     else:
-        session.changelog += _remove_pyright(precommit, config, session=session)
+        session.changelog += _remove_pyright(session=session)
 
 
 def _merge_config_into_pyproject(
@@ -125,12 +124,11 @@ def _update_vscode_settings(
     return changes
 
 
-def _remove_pyright(
-    precommit: ModifiablePrecommit,
-    pyproject: ModifiablePyproject,
-    *,
-    session: Session,
-) -> Changelog:
+def _remove_pyright(*, session: Session) -> Changelog:
+    precommit = session.precommit
+    pyproject = session.pyproject
+    if pyproject is None:
+        return []
     pyright_config = Path("pyrightconfig.json")
     if pyright_config.exists():
         os.remove(pyright_config)

--- a/src/compwa_policy/python/pyright.py
+++ b/src/compwa_policy/python/pyright.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
 
 
 def main(session: Session, active: bool) -> None:
-    session.changelog += _update_vscode_settings(active, session=session)
+    session.changelog += _update_vscode_settings(session, active)
     config = session.pyproject
     if config is None:
         return
@@ -28,7 +28,7 @@ def main(session: Session, active: bool) -> None:
         _remove_excludes(config)
         _update_settings(config)
     else:
-        session.changelog += _remove_pyright(session=session)
+        session.changelog += _remove_pyright(session)
 
 
 def _merge_config_into_pyproject(
@@ -91,40 +91,36 @@ def _update_settings(pyproject: ModifiablePyproject) -> None:
         pyproject.changelog.append(msg)
 
 
-def _update_vscode_settings(
-    active: bool,
-    *,
-    session: Session,
-) -> Changelog:
+def _update_vscode_settings(session: Session, /, active: bool) -> Changelog:
     changes: Changelog = []
     if active:
         changes += vscode.add_extension_recommendation(
-            "ms-python.vscode-pylance", session=session
+            session, "ms-python.vscode-pylance"
         )
         changes += vscode.update_settings(
+            session,
             {
                 "python.analysis.autoImportCompletions": False,
                 "python.analysis.inlayHints.pytestParameters": True,
             },
-            session=session,
         )
     else:
         changes += vscode.remove_settings(
+            session,
             [
                 "python.analysis.autoImportCompletions",
                 "python.analysis.inlayHints.pytestParameters",
             ],
-            session=session,
         )
         changes += vscode.remove_extension_recommendation(
+            session,
             "ms-python.vscode-pylance",
             unwanted=True,
-            session=session,
         )
     return changes
 
 
-def _remove_pyright(*, session: Session) -> Changelog:
+def _remove_pyright(session: Session, /) -> Changelog:
     precommit = session.precommit
     pyproject = session.pyproject
     if pyproject is None:
@@ -140,4 +136,4 @@ def _remove_pyright(*, session: Session) -> Changelog:
         pyproject.changelog.append(msg)
     pyproject.remove_dependency("pyright")
     precommit.remove_hook("pyright")
-    return remove_lines(CONFIG_PATH.gitignore, ".*pyrightconfig.json", session=session)
+    return remove_lines(session, CONFIG_PATH.gitignore, ".*pyrightconfig.json")

--- a/src/compwa_policy/python/pyright.py
+++ b/src/compwa_policy/python/pyright.py
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
 
 def main(session: Session, active: bool) -> None:
     precommit = session.precommit
-    session.changelog += _update_vscode_settings(active)
+    session.changelog += _update_vscode_settings(active, session=session)
     config = session.pyproject
     if config is None:
         return
@@ -29,7 +29,7 @@ def main(session: Session, active: bool) -> None:
         _remove_excludes(config)
         _update_settings(config)
     else:
-        session.changelog += _remove_pyright(precommit, config)
+        session.changelog += _remove_pyright(precommit, config, session=session)
 
 
 def _merge_config_into_pyproject(
@@ -92,22 +92,35 @@ def _update_settings(pyproject: ModifiablePyproject) -> None:
         pyproject.changelog.append(msg)
 
 
-def _update_vscode_settings(active: bool) -> Changelog:
+def _update_vscode_settings(
+    active: bool,
+    *,
+    session: Session | None = None,
+) -> Changelog:
     changes: Changelog = []
     if active:
-        changes += vscode.add_extension_recommendation("ms-python.vscode-pylance")
-        changes += vscode.update_settings({
-            "python.analysis.autoImportCompletions": False,
-            "python.analysis.inlayHints.pytestParameters": True,
-        })
+        changes += vscode.add_extension_recommendation(
+            "ms-python.vscode-pylance", session=session
+        )
+        changes += vscode.update_settings(
+            {
+                "python.analysis.autoImportCompletions": False,
+                "python.analysis.inlayHints.pytestParameters": True,
+            },
+            session=session,
+        )
     else:
-        changes += vscode.remove_settings([
-            "python.analysis.autoImportCompletions",
-            "python.analysis.inlayHints.pytestParameters",
-        ])
+        changes += vscode.remove_settings(
+            [
+                "python.analysis.autoImportCompletions",
+                "python.analysis.inlayHints.pytestParameters",
+            ],
+            session=session,
+        )
         changes += vscode.remove_extension_recommendation(
             "ms-python.vscode-pylance",
             unwanted=True,
+            session=session,
         )
     return changes
 
@@ -115,6 +128,8 @@ def _update_vscode_settings(active: bool) -> Changelog:
 def _remove_pyright(
     precommit: ModifiablePrecommit,
     pyproject: ModifiablePyproject,
+    *,
+    session: Session | None = None,
 ) -> Changelog:
     pyright_config = Path("pyrightconfig.json")
     if pyright_config.exists():
@@ -127,4 +142,4 @@ def _remove_pyright(
         pyproject.changelog.append(msg)
     pyproject.remove_dependency("pyright")
     precommit.remove_hook("pyright")
-    return remove_lines(CONFIG_PATH.gitignore, ".*pyrightconfig.json")
+    return remove_lines(CONFIG_PATH.gitignore, ".*pyrightconfig.json", session=session)

--- a/src/compwa_policy/python/pyright.py
+++ b/src/compwa_policy/python/pyright.py
@@ -9,11 +9,7 @@ from typing import TYPE_CHECKING
 
 from compwa_policy.utilities import CONFIG_PATH, remove_lines, vscode
 from compwa_policy.utilities.precommit.struct import Hook, Repo
-from compwa_policy.utilities.pyproject import (
-    ModifiablePyproject,
-    complies_with_subset,
-    use_modifiable_pyproject,
-)
+from compwa_policy.utilities.pyproject import ModifiablePyproject, complies_with_subset
 from compwa_policy.utilities.toml import to_toml_array
 
 if TYPE_CHECKING:
@@ -24,16 +20,16 @@ if TYPE_CHECKING:
 def main(session: Session, active: bool) -> None:
     precommit = session.precommit
     session.changelog += _update_vscode_settings(active)
-    with use_modifiable_pyproject(session.pyproject) as (config, _):
-        if config is None:
-            return
-        if active:
-            _merge_config_into_pyproject(config)
-            _update_precommit(precommit)
-            _remove_excludes(config)
-            _update_settings(config)
-        else:
-            session.changelog += _remove_pyright(precommit, config)
+    config = session.pyproject
+    if config is None:
+        return
+    if active:
+        _merge_config_into_pyproject(config)
+        _update_precommit(precommit)
+        _remove_excludes(config)
+        _update_settings(config)
+    else:
+        session.changelog += _remove_pyright(precommit, config)
 
 
 def _merge_config_into_pyproject(

--- a/src/compwa_policy/python/pyright.py
+++ b/src/compwa_policy/python/pyright.py
@@ -95,7 +95,7 @@ def _update_settings(pyproject: ModifiablePyproject) -> None:
 def _update_vscode_settings(
     active: bool,
     *,
-    session: Session | None = None,
+    session: Session,
 ) -> Changelog:
     changes: Changelog = []
     if active:
@@ -129,7 +129,7 @@ def _remove_pyright(
     precommit: ModifiablePrecommit,
     pyproject: ModifiablePyproject,
     *,
-    session: Session | None = None,
+    session: Session,
 ) -> Changelog:
     pyright_config = Path("pyrightconfig.json")
     if pyright_config.exists():

--- a/src/compwa_policy/python/pytest.py
+++ b/src/compwa_policy/python/pytest.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
 
     from tomlkit.items import Array
 
-    from compwa_policy.utilities.session import Changelog, Session
+    from compwa_policy.utilities.session import Session
 
 
 def main(
@@ -35,9 +35,7 @@ def main(
     _deny_ini_options(config)
     _update_codecov_settings(config, branch_coverage)
     _update_settings(config)
-    session.changelog += _update_vscode_settings(
-        session, coverage_gutters, single_threaded
-    )
+    _update_vscode_settings(session, coverage_gutters, single_threaded)
     if single_threaded:
         config.remove_dependency("pytest-xdist")
     else:
@@ -172,39 +170,38 @@ def _update_vscode_settings(
     /,
     coverage_gutters: bool,
     single_threaded: bool,
-) -> Changelog:
-    changes: Changelog = []
+) -> None:
     # cspell:ignore ryanluker
     if coverage_gutters:
-        changes += vscode.add_extension_recommendation(
+        vscode.add_extension_recommendation(
             session,
             "ryanluker.vscode-coverage-gutters",
         )
     else:
-        changes += vscode.remove_extension_recommendation(
+        vscode.remove_extension_recommendation(
             session,
             extension_name="ryanluker.vscode-coverage-gutters",
             unwanted=True,
         )
-    changes += vscode.update_settings(
+    vscode.update_settings(
         session,
         {
             "testing.coverageToolbarEnabled": True,
             "testing.showCoverageInExplorer": True,
         },
     )
-    changes += vscode.remove_settings(
+    vscode.remove_settings(
         session, {"python.testing.pytestArgs": ["--color=no", "--no-cov"]}
     )
     pyproject = session.pyproject
     package_name = pyproject.get_package_name() if pyproject is not None else None
     if package_name is not None:
         module_name = package_name.replace("-", "_")
-        changes += vscode.remove_settings(
+        vscode.remove_settings(
             session, {"python.testing.pytestArgs": [f"--cov={module_name}"]}
         )
     if single_threaded:
-        changes += vscode.remove_settings(
+        vscode.remove_settings(
             session,
             {
                 "python.testing.pytestArgs": [
@@ -216,10 +213,10 @@ def _update_vscode_settings(
             },
         )
     else:
-        changes += vscode.update_settings(
+        vscode.update_settings(
             session, {"python.testing.pytestArgs": ["--numprocesses=auto"]}
         )
-        changes += vscode.remove_settings(
+        vscode.remove_settings(
             session,
             {
                 "python.testing.pytestArgs": [
@@ -230,7 +227,7 @@ def _update_vscode_settings(
             },
         )
     if not coverage_gutters:
-        changes += vscode.remove_settings(
+        vscode.remove_settings(
             session,
             [
                 "coverage-gutters.coverageFileNames",
@@ -239,4 +236,3 @@ def _update_vscode_settings(
                 "coverage-gutters.showLineCoverage",
             ],
         )
-    return changes

--- a/src/compwa_policy/python/pytest.py
+++ b/src/compwa_policy/python/pytest.py
@@ -41,7 +41,7 @@ def main(
     _update_codecov_settings(config, branch_coverage)
     _update_settings(config)
     session.changelog += _update_vscode_settings(
-        config, coverage_gutters, single_threaded
+        config, coverage_gutters, single_threaded, session=session
     )
     if single_threaded:
         config.remove_dependency("pytest-xdist")
@@ -173,57 +173,75 @@ def __update_settings(config: MutableMapping, **expected: Any) -> bool:
 
 
 def _update_vscode_settings(
-    pyproject: Pyproject, coverage_gutters: bool, single_threaded: bool
+    pyproject: Pyproject,
+    coverage_gutters: bool,
+    single_threaded: bool,
+    *,
+    session: Session | None = None,
 ) -> Changelog:
     changes: Changelog = []
     # cspell:ignore ryanluker
     if coverage_gutters:
         changes += vscode.add_extension_recommendation(
             "ryanluker.vscode-coverage-gutters",
+            session=session,
         )
     else:
         changes += vscode.remove_extension_recommendation(
             extension_name="ryanluker.vscode-coverage-gutters",
             unwanted=True,
+            session=session,
         )
-    changes += vscode.update_settings({
-        "testing.coverageToolbarEnabled": True,
-        "testing.showCoverageInExplorer": True,
-    })
-    changes += vscode.remove_settings({
-        "python.testing.pytestArgs": ["--color=no", "--no-cov"]
-    })
+    changes += vscode.update_settings(
+        {
+            "testing.coverageToolbarEnabled": True,
+            "testing.showCoverageInExplorer": True,
+        },
+        session=session,
+    )
+    changes += vscode.remove_settings(
+        {"python.testing.pytestArgs": ["--color=no", "--no-cov"]}, session=session
+    )
     package_name = get_package_name(pyproject._document)  # noqa: SLF001
     if package_name is not None:
         module_name = package_name.replace("-", "_")
-        changes += vscode.remove_settings({
-            "python.testing.pytestArgs": [f"--cov={module_name}"]
-        })
+        changes += vscode.remove_settings(
+            {"python.testing.pytestArgs": [f"--cov={module_name}"]}, session=session
+        )
     if single_threaded:
-        changes += vscode.remove_settings({
-            "python.testing.pytestArgs": [
-                "--numprocesses auto",
-                "--numprocesses=auto",
-                "-n auto",
-                "-nauto",  # cspell:ignore nauto
-            ]
-        })
+        changes += vscode.remove_settings(
+            {
+                "python.testing.pytestArgs": [
+                    "--numprocesses auto",
+                    "--numprocesses=auto",
+                    "-n auto",
+                    "-nauto",  # cspell:ignore nauto
+                ]
+            },
+            session=session,
+        )
     else:
-        changes += vscode.update_settings({
-            "python.testing.pytestArgs": ["--numprocesses=auto"]
-        })
-        changes += vscode.remove_settings({
-            "python.testing.pytestArgs": [
-                "--numprocesses auto",
-                "-n auto",
-                "-nauto",
-            ]
-        })
+        changes += vscode.update_settings(
+            {"python.testing.pytestArgs": ["--numprocesses=auto"]}, session=session
+        )
+        changes += vscode.remove_settings(
+            {
+                "python.testing.pytestArgs": [
+                    "--numprocesses auto",
+                    "-n auto",
+                    "-nauto",
+                ]
+            },
+            session=session,
+        )
     if not coverage_gutters:
-        changes += vscode.remove_settings([
-            "coverage-gutters.coverageFileNames",
-            "coverage-gutters.coverageReportFileName",
-            "coverage-gutters.showGutterCoverage",
-            "coverage-gutters.showLineCoverage",
-        ])
+        changes += vscode.remove_settings(
+            [
+                "coverage-gutters.coverageFileNames",
+                "coverage-gutters.coverageReportFileName",
+                "coverage-gutters.showGutterCoverage",
+                "coverage-gutters.showLineCoverage",
+            ],
+            session=session,
+        )
     return changes

--- a/src/compwa_policy/python/pytest.py
+++ b/src/compwa_policy/python/pytest.py
@@ -14,7 +14,6 @@ from compwa_policy.utilities.pyproject import (
     ModifiablePyproject,
     Pyproject,
     has_dependency,
-    use_modifiable_pyproject,
 )
 from compwa_policy.utilities.pyproject.getters import get_package_name
 from compwa_policy.utilities.toml import to_toml_array
@@ -33,23 +32,21 @@ def main(
     single_threaded: bool,
     branch_coverage: bool = True,
 ) -> None:
-    with use_modifiable_pyproject(session.pyproject) as (config, _):
-        if config is None:
-            return
-        if not has_dependency(config, "pytest"):
-            return
-        _merge_coverage_into_pyproject(config)
-        _merge_pytest_into_pyproject(config)
-        _deny_ini_options(config)
-        _update_codecov_settings(config, branch_coverage)
-        _update_settings(config)
-        session.changelog += _update_vscode_settings(
-            config, coverage_gutters, single_threaded
-        )
-        if single_threaded:
-            config.remove_dependency("pytest-xdist")
-        else:
-            config.add_dependency("pytest-xdist", ["test", "dev"])
+    config = session.pyproject
+    if config is None or not has_dependency(config, "pytest"):
+        return
+    _merge_coverage_into_pyproject(config)
+    _merge_pytest_into_pyproject(config)
+    _deny_ini_options(config)
+    _update_codecov_settings(config, branch_coverage)
+    _update_settings(config)
+    session.changelog += _update_vscode_settings(
+        config, coverage_gutters, single_threaded
+    )
+    if single_threaded:
+        config.remove_dependency("pytest-xdist")
+    else:
+        config.add_dependency("pytest-xdist", ["test", "dev"])
 
 
 def _merge_coverage_into_pyproject(pyproject: ModifiablePyproject) -> None:

--- a/src/compwa_policy/python/pytest.py
+++ b/src/compwa_policy/python/pytest.py
@@ -10,12 +10,7 @@ from ini2toml.api import Translator
 from compwa_policy.errors import PolicyError
 from compwa_policy.utilities import CONFIG_PATH, vscode
 from compwa_policy.utilities.cfg import open_config
-from compwa_policy.utilities.pyproject import (
-    ModifiablePyproject,
-    Pyproject,
-    has_dependency,
-)
-from compwa_policy.utilities.pyproject.getters import get_package_name
+from compwa_policy.utilities.pyproject import ModifiablePyproject, has_dependency
 from compwa_policy.utilities.toml import to_toml_array
 
 if TYPE_CHECKING:
@@ -41,7 +36,7 @@ def main(
     _update_codecov_settings(config, branch_coverage)
     _update_settings(config)
     session.changelog += _update_vscode_settings(
-        config, coverage_gutters, single_threaded, session=session
+        session, coverage_gutters, single_threaded
     )
     if single_threaded:
         config.remove_dependency("pytest-xdist")
@@ -173,43 +168,44 @@ def __update_settings(config: MutableMapping, **expected: Any) -> bool:
 
 
 def _update_vscode_settings(
-    pyproject: Pyproject,
+    session: Session,
+    /,
     coverage_gutters: bool,
     single_threaded: bool,
-    *,
-    session: Session,
 ) -> Changelog:
     changes: Changelog = []
     # cspell:ignore ryanluker
     if coverage_gutters:
         changes += vscode.add_extension_recommendation(
+            session,
             "ryanluker.vscode-coverage-gutters",
-            session=session,
         )
     else:
         changes += vscode.remove_extension_recommendation(
+            session,
             extension_name="ryanluker.vscode-coverage-gutters",
             unwanted=True,
-            session=session,
         )
     changes += vscode.update_settings(
+        session,
         {
             "testing.coverageToolbarEnabled": True,
             "testing.showCoverageInExplorer": True,
         },
-        session=session,
     )
     changes += vscode.remove_settings(
-        {"python.testing.pytestArgs": ["--color=no", "--no-cov"]}, session=session
+        session, {"python.testing.pytestArgs": ["--color=no", "--no-cov"]}
     )
-    package_name = get_package_name(pyproject._document)  # noqa: SLF001
+    pyproject = session.pyproject
+    package_name = pyproject.get_package_name() if pyproject is not None else None
     if package_name is not None:
         module_name = package_name.replace("-", "_")
         changes += vscode.remove_settings(
-            {"python.testing.pytestArgs": [f"--cov={module_name}"]}, session=session
+            session, {"python.testing.pytestArgs": [f"--cov={module_name}"]}
         )
     if single_threaded:
         changes += vscode.remove_settings(
+            session,
             {
                 "python.testing.pytestArgs": [
                     "--numprocesses auto",
@@ -218,13 +214,13 @@ def _update_vscode_settings(
                     "-nauto",  # cspell:ignore nauto
                 ]
             },
-            session=session,
         )
     else:
         changes += vscode.update_settings(
-            {"python.testing.pytestArgs": ["--numprocesses=auto"]}, session=session
+            session, {"python.testing.pytestArgs": ["--numprocesses=auto"]}
         )
         changes += vscode.remove_settings(
+            session,
             {
                 "python.testing.pytestArgs": [
                     "--numprocesses auto",
@@ -232,16 +228,15 @@ def _update_vscode_settings(
                     "-nauto",
                 ]
             },
-            session=session,
         )
     if not coverage_gutters:
         changes += vscode.remove_settings(
+            session,
             [
                 "coverage-gutters.coverageFileNames",
                 "coverage-gutters.coverageReportFileName",
                 "coverage-gutters.showGutterCoverage",
                 "coverage-gutters.showLineCoverage",
             ],
-            session=session,
         )
     return changes

--- a/src/compwa_policy/python/pytest.py
+++ b/src/compwa_policy/python/pytest.py
@@ -177,7 +177,7 @@ def _update_vscode_settings(
     coverage_gutters: bool,
     single_threaded: bool,
     *,
-    session: Session | None = None,
+    session: Session,
 ) -> Changelog:
     changes: Changelog = []
     # cspell:ignore ryanluker

--- a/src/compwa_policy/python/pyupgrade.py
+++ b/src/compwa_policy/python/pyupgrade.py
@@ -27,7 +27,7 @@ def main(session: Session, no_ruff: bool) -> None:
 def _update_precommit_repo(
     precommit: ModifiablePrecommit,
     *,
-    session: Session | None = None,
+    session: Session,
 ) -> None:
     expected_hook = Repo(
         repo="https://github.com/asottile/pyupgrade",
@@ -45,7 +45,7 @@ def _update_precommit_repo(
 def _update_precommit_nbqa_hook(
     precommit: ModifiablePrecommit,
     *,
-    session: Session | None = None,
+    session: Session,
 ) -> None:
     precommit.update_hook(
         repo_url="https://github.com/nbQA-dev/nbQA",
@@ -58,11 +58,13 @@ def _update_precommit_nbqa_hook(
 
 def __get_pyupgrade_version_argument(
     *,
-    session: Session | None = None,
+    session: Session,
 ) -> CommentedSeq:
     """Get the --py3x-plus argument for pyupgrade.
 
-    >>> __get_pyupgrade_version_argument()
+    >>> from compwa_policy.utilities.session import Session
+    >>> with Session() as session:
+    ...     __get_pyupgrade_version_argument(session=session)
     ['--py310-plus']
     """
     supported_python_versions = Pyproject.load(

--- a/src/compwa_policy/python/pyupgrade.py
+++ b/src/compwa_policy/python/pyupgrade.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from compwa_policy.utilities.precommit.struct import Hook, Repo
-from compwa_policy.utilities.pyproject import Pyproject
 from compwa_policy.utilities.yaml import read_preserved_yaml
 
 if TYPE_CHECKING:
@@ -18,58 +17,51 @@ if TYPE_CHECKING:
 def main(session: Session, no_ruff: bool) -> None:
     precommit = session.precommit
     if no_ruff:
-        _update_precommit_repo(precommit, session=session)
-        _update_precommit_nbqa_hook(precommit, session=session)
+        _update_precommit_repo(session)
+        _update_precommit_nbqa_hook(session)
     else:
         _remove_pyupgrade(precommit)
 
 
-def _update_precommit_repo(
-    precommit: ModifiablePrecommit,
-    *,
-    session: Session,
-) -> None:
+def _update_precommit_repo(session: Session, /) -> None:
+    precommit = session.precommit
     expected_hook = Repo(
         repo="https://github.com/asottile/pyupgrade",
         rev="",
         hooks=[
             Hook(
                 id="pyupgrade",
-                args=__get_pyupgrade_version_argument(session=session),
+                args=__get_pyupgrade_version_argument(session),
             )
         ],
     )
     precommit.update_single_hook_repo(expected_hook)
 
 
-def _update_precommit_nbqa_hook(
-    precommit: ModifiablePrecommit,
-    *,
-    session: Session,
-) -> None:
+def _update_precommit_nbqa_hook(session: Session, /) -> None:
+    precommit = session.precommit
     precommit.update_hook(
         repo_url="https://github.com/nbQA-dev/nbQA",
         expected_hook=Hook(
             id="nbqa-pyupgrade",
-            args=__get_pyupgrade_version_argument(session=session),
+            args=__get_pyupgrade_version_argument(session),
         ),
     )
 
 
-def __get_pyupgrade_version_argument(
-    *,
-    session: Session,
-) -> CommentedSeq:
+def __get_pyupgrade_version_argument(session: Session, /) -> CommentedSeq:
     """Get the --py3x-plus argument for pyupgrade.
 
     >>> from compwa_policy.utilities.session import Session
     >>> with Session() as session:
-    ...     __get_pyupgrade_version_argument(session=session)
+    ...     __get_pyupgrade_version_argument(session)
     ['--py310-plus']
     """
-    supported_python_versions = Pyproject.load(
-        session=session
-    ).get_supported_python_versions()
+    pyproject = session.pyproject
+    if pyproject is None:
+        msg = "Cannot determine pyupgrade target without pyproject.toml"
+        raise ValueError(msg)
+    supported_python_versions = pyproject.get_supported_python_versions()
     lowest_version = supported_python_versions[0]
     version_repr = lowest_version.replace(".", "")
     return read_preserved_yaml(f"[--py{version_repr}-plus]")

--- a/src/compwa_policy/python/pyupgrade.py
+++ b/src/compwa_policy/python/pyupgrade.py
@@ -18,43 +18,56 @@ if TYPE_CHECKING:
 def main(session: Session, no_ruff: bool) -> None:
     precommit = session.precommit
     if no_ruff:
-        _update_precommit_repo(precommit)
-        _update_precommit_nbqa_hook(precommit)
+        _update_precommit_repo(precommit, session=session)
+        _update_precommit_nbqa_hook(precommit, session=session)
     else:
         _remove_pyupgrade(precommit)
 
 
-def _update_precommit_repo(precommit: ModifiablePrecommit) -> None:
+def _update_precommit_repo(
+    precommit: ModifiablePrecommit,
+    *,
+    session: Session | None = None,
+) -> None:
     expected_hook = Repo(
         repo="https://github.com/asottile/pyupgrade",
         rev="",
         hooks=[
             Hook(
                 id="pyupgrade",
-                args=__get_pyupgrade_version_argument(),
+                args=__get_pyupgrade_version_argument(session=session),
             )
         ],
     )
     precommit.update_single_hook_repo(expected_hook)
 
 
-def _update_precommit_nbqa_hook(precommit: ModifiablePrecommit) -> None:
+def _update_precommit_nbqa_hook(
+    precommit: ModifiablePrecommit,
+    *,
+    session: Session | None = None,
+) -> None:
     precommit.update_hook(
         repo_url="https://github.com/nbQA-dev/nbQA",
         expected_hook=Hook(
             id="nbqa-pyupgrade",
-            args=__get_pyupgrade_version_argument(),
+            args=__get_pyupgrade_version_argument(session=session),
         ),
     )
 
 
-def __get_pyupgrade_version_argument() -> CommentedSeq:
+def __get_pyupgrade_version_argument(
+    *,
+    session: Session | None = None,
+) -> CommentedSeq:
     """Get the --py3x-plus argument for pyupgrade.
 
     >>> __get_pyupgrade_version_argument()
     ['--py310-plus']
     """
-    supported_python_versions = Pyproject.load().get_supported_python_versions()
+    supported_python_versions = Pyproject.load(
+        session=session
+    ).get_supported_python_versions()
     lowest_version = supported_python_versions[0]
     version_repr = lowest_version.replace(".", "")
     return read_preserved_yaml(f"[--py{version_repr}-plus]")

--- a/src/compwa_policy/python/ruff.py
+++ b/src/compwa_policy/python/ruff.py
@@ -17,7 +17,6 @@ from compwa_policy.utilities.pyproject import (
     complies_with_subset,
     has_dependency,
     has_pyproject_package_name,
-    use_modifiable_pyproject,
 )
 from compwa_policy.utilities.readme import add_badge, remove_badge
 from compwa_policy.utilities.toml import to_toml_array
@@ -34,26 +33,26 @@ if TYPE_CHECKING:
 
 def main(session: Session, has_notebooks: bool, imports_on_top: bool) -> None:
     precommit = session.precommit
-    with use_modifiable_pyproject(session.pyproject) as (config, _):
-        if config is None:
-            return
-        session.changelog += add_badge(
-            "[![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/charliermarsh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)",
-        )
-        config.remove_dependency("radon")
-        session.changelog += _remove_black(precommit, config)
-        session.changelog += _remove_flake8(precommit, config)
-        session.changelog += _remove_isort(precommit, config, imports_on_top)
-        session.changelog += _remove_pydocstyle(precommit, config)
-        session.changelog += _remove_pylint(precommit, config)
-        _move_ruff_lint_config(config)
-        if has_notebooks and imports_on_top:
-            _sort_imports_on_top(precommit, config)
-        _update_ruff_config(precommit, config, has_notebooks)
-        _update_precommit_hook(precommit, has_notebooks)
-        if not has_dependency(config, "ruff"):
-            _update_lint_dependencies(config)
-        session.changelog += _update_vscode_settings()
+    config = session.pyproject
+    if config is None:
+        return
+    session.changelog += add_badge(
+        "[![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/charliermarsh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)",
+    )
+    config.remove_dependency("radon")
+    session.changelog += _remove_black(precommit, config)
+    session.changelog += _remove_flake8(precommit, config)
+    session.changelog += _remove_isort(precommit, config, imports_on_top)
+    session.changelog += _remove_pydocstyle(precommit, config)
+    session.changelog += _remove_pylint(precommit, config)
+    _move_ruff_lint_config(config)
+    if has_notebooks and imports_on_top:
+        _sort_imports_on_top(precommit, config)
+    _update_ruff_config(precommit, config, has_notebooks)
+    _update_precommit_hook(precommit, has_notebooks)
+    if not has_dependency(config, "ruff"):
+        _update_lint_dependencies(config)
+    session.changelog += _update_vscode_settings()
 
 
 def _remove_black(

--- a/src/compwa_policy/python/ruff.py
+++ b/src/compwa_policy/python/ruff.py
@@ -37,96 +37,86 @@ def main(session: Session, has_notebooks: bool, imports_on_top: bool) -> None:
     if config is None:
         return
     session.changelog += add_badge(
+        session,
         "[![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/charliermarsh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)",
-        session=session,
     )
     config.remove_dependency("radon")
-    session.changelog += _remove_black(precommit, config, session=session)
-    session.changelog += _remove_flake8(precommit, config, session=session)
-    session.changelog += _remove_isort(
-        precommit, config, imports_on_top, session=session
-    )
-    session.changelog += _remove_pydocstyle(precommit, config, session=session)
-    session.changelog += _remove_pylint(precommit, config, session=session)
+    session.changelog += _remove_black(session)
+    session.changelog += _remove_flake8(session)
+    session.changelog += _remove_isort(session, imports_on_top)
+    session.changelog += _remove_pydocstyle(session)
+    session.changelog += _remove_pylint(session)
     _move_ruff_lint_config(config)
     if has_notebooks and imports_on_top:
         _sort_imports_on_top(precommit, config)
     _update_ruff_config(precommit, config, has_notebooks)
     _update_precommit_hook(precommit, has_notebooks)
     if not has_dependency(config, "ruff"):
-        _update_lint_dependencies(session=session)
-    session.changelog += _update_vscode_settings(session=session)
+        _update_lint_dependencies(session)
+    session.changelog += _update_vscode_settings(session)
 
 
-def _remove_black(
-    precommit: ModifiablePrecommit,
-    pyproject: ModifiablePyproject,
-    *,
-    session: Session,
-) -> Changelog:
+def _remove_black(session: Session, /) -> Changelog:
+    precommit = session.precommit
+    pyproject = session.pyproject
+    if pyproject is None:
+        return []
     changes: Changelog = []
     changes += vscode.remove_extension_recommendation(
+        session,
         "ms-python.black-formatter",
         unwanted=True,
-        session=session,
     )
     __remove_tool_table(pyproject, "black")
     pyproject.remove_dependency(
         package="black",
         ignored_sections=["doc", "notebooks", "test"],
     )
-    changes += remove_badge(r".*https://github\.com/psf.*/black.*", session=session)
+    changes += remove_badge(session, r".*https://github\.com/psf.*/black.*")
     precommit.remove_hook("black-jupyter")
     precommit.remove_hook("blacken-docs")
-    changes += vscode.remove_settings(
-        ["black-formatter.importStrategy"], session=session
-    )
+    changes += vscode.remove_settings(session, ["black-formatter.importStrategy"])
     return changes
 
 
-def _remove_flake8(
-    precommit: ModifiablePrecommit,
-    pyproject: ModifiablePyproject,
-    *,
-    session: Session,
-) -> Changelog:
+def _remove_flake8(session: Session, /) -> Changelog:
+    precommit = session.precommit
+    pyproject = session.pyproject
+    if pyproject is None:
+        return []
     changes: Changelog = []
-    changes += remove_configs([".flake8"], session=session)
+    changes += remove_configs(session, [".flake8"])
     __remove_nbqa_option(pyproject, "flake8")
     pyproject.remove_dependency("flake8")
     pyproject.remove_dependency("pep8-naming")
     changes += vscode.remove_extension_recommendation(
-        "ms-python.flake8", unwanted=True, session=session
+        session, "ms-python.flake8", unwanted=True
     )
     precommit.remove_hook("autoflake")  # cspell:ignore autoflake
     precommit.remove_hook("flake8")
     precommit.remove_hook("nbqa-flake8")
-    changes += vscode.remove_settings(["flake8.importStrategy"], session=session)
+    changes += vscode.remove_settings(session, ["flake8.importStrategy"])
     return changes
 
 
-def _remove_isort(
-    precommit: ModifiablePrecommit,
-    pyproject: ModifiablePyproject,
-    imports_on_top: bool,
-    *,
-    session: Session,
-) -> Changelog:
+def _remove_isort(session: Session, /, imports_on_top: bool) -> Changelog:
+    precommit = session.precommit
+    pyproject = session.pyproject
+    if pyproject is None:
+        return []
     changes: Changelog = []
     __remove_nbqa_option(pyproject, "black")
     changes += vscode.remove_extension_recommendation(
-        "ms-python.isort", unwanted=True, session=session
+        session, "ms-python.isort", unwanted=True
     )
     precommit.remove_hook("isort")
     if not imports_on_top:
         __remove_tool_table(pyproject, "isort")
         __remove_nbqa_option(pyproject, "isort")
         precommit.remove_hook("nbqa-isort")
-    changes += vscode.remove_settings(
-        ["isort.check", "isort.importStrategy"], session=session
-    )
+    changes += vscode.remove_settings(session, ["isort.check", "isort.importStrategy"])
     changes += remove_badge(
-        r".*https://img\.shields\.io/badge/%20imports\-isort", session=session
+        session, r".*https://img\.shields\.io/badge/%20imports\-isort"
     )
     return changes
 
@@ -152,40 +142,38 @@ def __remove_tool_table(pyproject: ModifiablePyproject, tool_table: str) -> None
         pyproject.changelog.append(msg)
 
 
-def _remove_pydocstyle(
-    precommit: ModifiablePrecommit,
-    pyproject: ModifiablePyproject,
-    *,
-    session: Session,
-) -> Changelog:
+def _remove_pydocstyle(session: Session, /) -> Changelog:
+    precommit = session.precommit
+    pyproject = session.pyproject
+    if pyproject is None:
+        return []
     changes = remove_configs(
+        session,
         [
             ".pydocstyle",
             "docs/.pydocstyle",
             "tests/.pydocstyle",
         ],
-        session=session,
     )
     pyproject.remove_dependency("pydocstyle")
     precommit.remove_hook("pydocstyle")
     return changes
 
 
-def _remove_pylint(
-    precommit: ModifiablePrecommit,
-    pyproject: ModifiablePyproject,
-    *,
-    session: Session,
-) -> Changelog:
+def _remove_pylint(session: Session, /) -> Changelog:
+    precommit = session.precommit
+    pyproject = session.pyproject
+    if pyproject is None:
+        return []
     changes: Changelog = []
-    changes += remove_configs([".pylintrc"], session=session)  # cspell:ignore pylintrc
+    changes += remove_configs(session, [".pylintrc"])  # cspell:ignore pylintrc
     pyproject.remove_dependency("pylint")
     changes += vscode.remove_extension_recommendation(
-        "ms-python.pylint", unwanted=True, session=session
+        session, "ms-python.pylint", unwanted=True
     )
     precommit.remove_hook("pylint")
     precommit.remove_hook("nbqa-pylint")
-    changes += vscode.remove_settings(["pylint.importStrategy"], session=session)
+    changes += vscode.remove_settings(session, ["pylint.importStrategy"])
     return changes
 
 
@@ -695,8 +683,8 @@ def __add_nbqa_isort_pre_commit(precommit: ModifiablePrecommit) -> None:
     precommit.update_single_hook_repo(expected_repo)
 
 
-def _update_lint_dependencies(*, session: Session) -> None:
-    if not has_pyproject_package_name(session=session):
+def _update_lint_dependencies(session: Session, /) -> None:
+    if not has_pyproject_package_name(session):
         return
     pyproject = session.pyproject
     if pyproject is None:
@@ -710,13 +698,12 @@ def _update_lint_dependencies(*, session: Session) -> None:
     pyproject.remove_dependency(ruff, ignored_sections=["dev"])
 
 
-def _update_vscode_settings(*, session: Session) -> Changelog:
+def _update_vscode_settings(session: Session, /) -> Changelog:
     # cspell:ignore charliermarsh
     changes: Changelog = []
-    changes += vscode.add_extension_recommendation(
-        "charliermarsh.ruff", session=session
-    )
+    changes += vscode.add_extension_recommendation(session, "charliermarsh.ruff")
     changes += vscode.update_settings(
+        session,
         {
             "notebook.codeActionsOnSave": {
                 "notebook.source.organizeImports": "explicit"
@@ -732,6 +719,5 @@ def _update_vscode_settings(*, session: Session) -> Changelog:
             "ruff.importStrategy": "fromEnvironment",
             "ruff.organizeImports": True,
         },
-        session=session,
     )
     return changes

--- a/src/compwa_policy/python/ruff.py
+++ b/src/compwa_policy/python/ruff.py
@@ -28,7 +28,7 @@ if TYPE_CHECKING:
     from tomlkit.items import Array
 
     from compwa_policy.utilities.precommit import ModifiablePrecommit
-    from compwa_policy.utilities.session import Changelog, Session
+    from compwa_policy.utilities.session import Session
 
 
 def main(session: Session, has_notebooks: bool, imports_on_top: bool) -> None:
@@ -36,16 +36,16 @@ def main(session: Session, has_notebooks: bool, imports_on_top: bool) -> None:
     config = session.pyproject
     if config is None:
         return
-    session.changelog += add_badge(
+    add_badge(
         session,
         "[![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/charliermarsh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)",
     )
     config.remove_dependency("radon")
-    session.changelog += _remove_black(session)
-    session.changelog += _remove_flake8(session)
-    session.changelog += _remove_isort(session, imports_on_top)
-    session.changelog += _remove_pydocstyle(session)
-    session.changelog += _remove_pylint(session)
+    _remove_black(session)
+    _remove_flake8(session)
+    _remove_isort(session, imports_on_top)
+    _remove_pydocstyle(session)
+    _remove_pylint(session)
     _move_ruff_lint_config(config)
     if has_notebooks and imports_on_top:
         _sort_imports_on_top(precommit, config)
@@ -53,16 +53,15 @@ def main(session: Session, has_notebooks: bool, imports_on_top: bool) -> None:
     _update_precommit_hook(precommit, has_notebooks)
     if not has_dependency(config, "ruff"):
         _update_lint_dependencies(session)
-    session.changelog += _update_vscode_settings(session)
+    _update_vscode_settings(session)
 
 
-def _remove_black(session: Session, /) -> Changelog:
+def _remove_black(session: Session, /) -> None:
     precommit = session.precommit
     pyproject = session.pyproject
     if pyproject is None:
-        return []
-    changes: Changelog = []
-    changes += vscode.remove_extension_recommendation(
+        return
+    vscode.remove_extension_recommendation(
         session,
         "ms-python.black-formatter",
         unwanted=True,
@@ -72,53 +71,42 @@ def _remove_black(session: Session, /) -> Changelog:
         package="black",
         ignored_sections=["doc", "notebooks", "test"],
     )
-    changes += remove_badge(session, r".*https://github\.com/psf.*/black.*")
+    remove_badge(session, r".*https://github\.com/psf.*/black.*")
     precommit.remove_hook("black-jupyter")
     precommit.remove_hook("blacken-docs")
-    changes += vscode.remove_settings(session, ["black-formatter.importStrategy"])
-    return changes
+    vscode.remove_settings(session, ["black-formatter.importStrategy"])
 
 
-def _remove_flake8(session: Session, /) -> Changelog:
+def _remove_flake8(session: Session, /) -> None:
     precommit = session.precommit
     pyproject = session.pyproject
     if pyproject is None:
-        return []
-    changes: Changelog = []
-    changes += remove_configs(session, [".flake8"])
+        return
+    remove_configs(session, [".flake8"])
     __remove_nbqa_option(pyproject, "flake8")
     pyproject.remove_dependency("flake8")
     pyproject.remove_dependency("pep8-naming")
-    changes += vscode.remove_extension_recommendation(
-        session, "ms-python.flake8", unwanted=True
-    )
+    vscode.remove_extension_recommendation(session, "ms-python.flake8", unwanted=True)
     precommit.remove_hook("autoflake")  # cspell:ignore autoflake
     precommit.remove_hook("flake8")
     precommit.remove_hook("nbqa-flake8")
-    changes += vscode.remove_settings(session, ["flake8.importStrategy"])
-    return changes
+    vscode.remove_settings(session, ["flake8.importStrategy"])
 
 
-def _remove_isort(session: Session, /, imports_on_top: bool) -> Changelog:
+def _remove_isort(session: Session, /, imports_on_top: bool) -> None:
     precommit = session.precommit
     pyproject = session.pyproject
     if pyproject is None:
-        return []
-    changes: Changelog = []
+        return
     __remove_nbqa_option(pyproject, "black")
-    changes += vscode.remove_extension_recommendation(
-        session, "ms-python.isort", unwanted=True
-    )
+    vscode.remove_extension_recommendation(session, "ms-python.isort", unwanted=True)
     precommit.remove_hook("isort")
     if not imports_on_top:
         __remove_tool_table(pyproject, "isort")
         __remove_nbqa_option(pyproject, "isort")
         precommit.remove_hook("nbqa-isort")
-    changes += vscode.remove_settings(session, ["isort.check", "isort.importStrategy"])
-    changes += remove_badge(
-        session, r".*https://img\.shields\.io/badge/%20imports\-isort"
-    )
-    return changes
+    vscode.remove_settings(session, ["isort.check", "isort.importStrategy"])
+    remove_badge(session, r".*https://img\.shields\.io/badge/%20imports\-isort")
 
 
 def __remove_nbqa_option(pyproject: ModifiablePyproject, option: str) -> None:
@@ -142,12 +130,12 @@ def __remove_tool_table(pyproject: ModifiablePyproject, tool_table: str) -> None
         pyproject.changelog.append(msg)
 
 
-def _remove_pydocstyle(session: Session, /) -> Changelog:
+def _remove_pydocstyle(session: Session, /) -> None:
     precommit = session.precommit
     pyproject = session.pyproject
     if pyproject is None:
-        return []
-    changes = remove_configs(
+        return
+    remove_configs(
         session,
         [
             ".pydocstyle",
@@ -157,24 +145,19 @@ def _remove_pydocstyle(session: Session, /) -> Changelog:
     )
     pyproject.remove_dependency("pydocstyle")
     precommit.remove_hook("pydocstyle")
-    return changes
 
 
-def _remove_pylint(session: Session, /) -> Changelog:
+def _remove_pylint(session: Session, /) -> None:
     precommit = session.precommit
     pyproject = session.pyproject
     if pyproject is None:
-        return []
-    changes: Changelog = []
-    changes += remove_configs(session, [".pylintrc"])  # cspell:ignore pylintrc
+        return
+    remove_configs(session, [".pylintrc"])  # cspell:ignore pylintrc
     pyproject.remove_dependency("pylint")
-    changes += vscode.remove_extension_recommendation(
-        session, "ms-python.pylint", unwanted=True
-    )
+    vscode.remove_extension_recommendation(session, "ms-python.pylint", unwanted=True)
     precommit.remove_hook("pylint")
     precommit.remove_hook("nbqa-pylint")
-    changes += vscode.remove_settings(session, ["pylint.importStrategy"])
-    return changes
+    vscode.remove_settings(session, ["pylint.importStrategy"])
 
 
 def _move_ruff_lint_config(pyproject: ModifiablePyproject) -> None:
@@ -698,11 +681,10 @@ def _update_lint_dependencies(session: Session, /) -> None:
     pyproject.remove_dependency(ruff, ignored_sections=["dev"])
 
 
-def _update_vscode_settings(session: Session, /) -> Changelog:
+def _update_vscode_settings(session: Session, /) -> None:
     # cspell:ignore charliermarsh
-    changes: Changelog = []
-    changes += vscode.add_extension_recommendation(session, "charliermarsh.ruff")
-    changes += vscode.update_settings(
+    vscode.add_extension_recommendation(session, "charliermarsh.ruff")
+    vscode.update_settings(
         session,
         {
             "notebook.codeActionsOnSave": {
@@ -720,4 +702,3 @@ def _update_vscode_settings(session: Session, /) -> Changelog:
             "ruff.organizeImports": True,
         },
     )
-    return changes

--- a/src/compwa_policy/python/ruff.py
+++ b/src/compwa_policy/python/ruff.py
@@ -54,7 +54,7 @@ def main(session: Session, has_notebooks: bool, imports_on_top: bool) -> None:
     _update_ruff_config(precommit, config, has_notebooks)
     _update_precommit_hook(precommit, has_notebooks)
     if not has_dependency(config, "ruff"):
-        _update_lint_dependencies(config, session=session)
+        _update_lint_dependencies(session=session)
     session.changelog += _update_vscode_settings(session=session)
 
 
@@ -695,12 +695,11 @@ def __add_nbqa_isort_pre_commit(precommit: ModifiablePrecommit) -> None:
     precommit.update_single_hook_repo(expected_repo)
 
 
-def _update_lint_dependencies(
-    pyproject: ModifiablePyproject,
-    *,
-    session: Session,
-) -> None:
+def _update_lint_dependencies(*, session: Session) -> None:
     if not has_pyproject_package_name(session=session):
+        return
+    pyproject = session.pyproject
+    if pyproject is None:
         return
     python_versions = pyproject.get_supported_python_versions()
     if "3.6" in python_versions:

--- a/src/compwa_policy/python/ruff.py
+++ b/src/compwa_policy/python/ruff.py
@@ -62,7 +62,7 @@ def _remove_black(
     precommit: ModifiablePrecommit,
     pyproject: ModifiablePyproject,
     *,
-    session: Session | None = None,
+    session: Session,
 ) -> Changelog:
     changes: Changelog = []
     changes += vscode.remove_extension_recommendation(
@@ -88,7 +88,7 @@ def _remove_flake8(
     precommit: ModifiablePrecommit,
     pyproject: ModifiablePyproject,
     *,
-    session: Session | None = None,
+    session: Session,
 ) -> Changelog:
     changes: Changelog = []
     changes += remove_configs([".flake8"], session=session)
@@ -110,7 +110,7 @@ def _remove_isort(
     pyproject: ModifiablePyproject,
     imports_on_top: bool,
     *,
-    session: Session | None = None,
+    session: Session,
 ) -> Changelog:
     changes: Changelog = []
     __remove_nbqa_option(pyproject, "black")
@@ -156,7 +156,7 @@ def _remove_pydocstyle(
     precommit: ModifiablePrecommit,
     pyproject: ModifiablePyproject,
     *,
-    session: Session | None = None,
+    session: Session,
 ) -> Changelog:
     changes = remove_configs(
         [
@@ -175,7 +175,7 @@ def _remove_pylint(
     precommit: ModifiablePrecommit,
     pyproject: ModifiablePyproject,
     *,
-    session: Session | None = None,
+    session: Session,
 ) -> Changelog:
     changes: Changelog = []
     changes += remove_configs([".pylintrc"], session=session)  # cspell:ignore pylintrc
@@ -698,7 +698,7 @@ def __add_nbqa_isort_pre_commit(precommit: ModifiablePrecommit) -> None:
 def _update_lint_dependencies(
     pyproject: ModifiablePyproject,
     *,
-    session: Session | None = None,
+    session: Session,
 ) -> None:
     if not has_pyproject_package_name(session=session):
         return
@@ -711,7 +711,7 @@ def _update_lint_dependencies(
     pyproject.remove_dependency(ruff, ignored_sections=["dev"])
 
 
-def _update_vscode_settings(*, session: Session | None = None) -> Changelog:
+def _update_vscode_settings(*, session: Session) -> Changelog:
     # cspell:ignore charliermarsh
     changes: Changelog = []
     changes += vscode.add_extension_recommendation(

--- a/src/compwa_policy/python/ruff.py
+++ b/src/compwa_policy/python/ruff.py
@@ -38,58 +38,70 @@ def main(session: Session, has_notebooks: bool, imports_on_top: bool) -> None:
         return
     session.changelog += add_badge(
         "[![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/charliermarsh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)",
+        session=session,
     )
     config.remove_dependency("radon")
-    session.changelog += _remove_black(precommit, config)
-    session.changelog += _remove_flake8(precommit, config)
-    session.changelog += _remove_isort(precommit, config, imports_on_top)
-    session.changelog += _remove_pydocstyle(precommit, config)
-    session.changelog += _remove_pylint(precommit, config)
+    session.changelog += _remove_black(precommit, config, session=session)
+    session.changelog += _remove_flake8(precommit, config, session=session)
+    session.changelog += _remove_isort(
+        precommit, config, imports_on_top, session=session
+    )
+    session.changelog += _remove_pydocstyle(precommit, config, session=session)
+    session.changelog += _remove_pylint(precommit, config, session=session)
     _move_ruff_lint_config(config)
     if has_notebooks and imports_on_top:
         _sort_imports_on_top(precommit, config)
     _update_ruff_config(precommit, config, has_notebooks)
     _update_precommit_hook(precommit, has_notebooks)
     if not has_dependency(config, "ruff"):
-        _update_lint_dependencies(config)
-    session.changelog += _update_vscode_settings()
+        _update_lint_dependencies(config, session=session)
+    session.changelog += _update_vscode_settings(session=session)
 
 
 def _remove_black(
     precommit: ModifiablePrecommit,
     pyproject: ModifiablePyproject,
+    *,
+    session: Session | None = None,
 ) -> Changelog:
     changes: Changelog = []
     changes += vscode.remove_extension_recommendation(
         "ms-python.black-formatter",
         unwanted=True,
+        session=session,
     )
     __remove_tool_table(pyproject, "black")
     pyproject.remove_dependency(
         package="black",
         ignored_sections=["doc", "notebooks", "test"],
     )
-    changes += remove_badge(r".*https://github\.com/psf.*/black.*")
+    changes += remove_badge(r".*https://github\.com/psf.*/black.*", session=session)
     precommit.remove_hook("black-jupyter")
     precommit.remove_hook("blacken-docs")
-    changes += vscode.remove_settings(["black-formatter.importStrategy"])
+    changes += vscode.remove_settings(
+        ["black-formatter.importStrategy"], session=session
+    )
     return changes
 
 
 def _remove_flake8(
     precommit: ModifiablePrecommit,
     pyproject: ModifiablePyproject,
+    *,
+    session: Session | None = None,
 ) -> Changelog:
     changes: Changelog = []
-    changes += remove_configs([".flake8"])
+    changes += remove_configs([".flake8"], session=session)
     __remove_nbqa_option(pyproject, "flake8")
     pyproject.remove_dependency("flake8")
     pyproject.remove_dependency("pep8-naming")
-    changes += vscode.remove_extension_recommendation("ms-python.flake8", unwanted=True)
+    changes += vscode.remove_extension_recommendation(
+        "ms-python.flake8", unwanted=True, session=session
+    )
     precommit.remove_hook("autoflake")  # cspell:ignore autoflake
     precommit.remove_hook("flake8")
     precommit.remove_hook("nbqa-flake8")
-    changes += vscode.remove_settings(["flake8.importStrategy"])
+    changes += vscode.remove_settings(["flake8.importStrategy"], session=session)
     return changes
 
 
@@ -97,17 +109,25 @@ def _remove_isort(
     precommit: ModifiablePrecommit,
     pyproject: ModifiablePyproject,
     imports_on_top: bool,
+    *,
+    session: Session | None = None,
 ) -> Changelog:
     changes: Changelog = []
     __remove_nbqa_option(pyproject, "black")
-    changes += vscode.remove_extension_recommendation("ms-python.isort", unwanted=True)
+    changes += vscode.remove_extension_recommendation(
+        "ms-python.isort", unwanted=True, session=session
+    )
     precommit.remove_hook("isort")
     if not imports_on_top:
         __remove_tool_table(pyproject, "isort")
         __remove_nbqa_option(pyproject, "isort")
         precommit.remove_hook("nbqa-isort")
-    changes += vscode.remove_settings(["isort.check", "isort.importStrategy"])
-    changes += remove_badge(r".*https://img\.shields\.io/badge/%20imports\-isort")
+    changes += vscode.remove_settings(
+        ["isort.check", "isort.importStrategy"], session=session
+    )
+    changes += remove_badge(
+        r".*https://img\.shields\.io/badge/%20imports\-isort", session=session
+    )
     return changes
 
 
@@ -135,12 +155,17 @@ def __remove_tool_table(pyproject: ModifiablePyproject, tool_table: str) -> None
 def _remove_pydocstyle(
     precommit: ModifiablePrecommit,
     pyproject: ModifiablePyproject,
+    *,
+    session: Session | None = None,
 ) -> Changelog:
-    changes = remove_configs([
-        ".pydocstyle",
-        "docs/.pydocstyle",
-        "tests/.pydocstyle",
-    ])
+    changes = remove_configs(
+        [
+            ".pydocstyle",
+            "docs/.pydocstyle",
+            "tests/.pydocstyle",
+        ],
+        session=session,
+    )
     pyproject.remove_dependency("pydocstyle")
     precommit.remove_hook("pydocstyle")
     return changes
@@ -149,14 +174,18 @@ def _remove_pydocstyle(
 def _remove_pylint(
     precommit: ModifiablePrecommit,
     pyproject: ModifiablePyproject,
+    *,
+    session: Session | None = None,
 ) -> Changelog:
     changes: Changelog = []
-    changes += remove_configs([".pylintrc"])  # cspell:ignore pylintrc
+    changes += remove_configs([".pylintrc"], session=session)  # cspell:ignore pylintrc
     pyproject.remove_dependency("pylint")
-    changes += vscode.remove_extension_recommendation("ms-python.pylint", unwanted=True)
+    changes += vscode.remove_extension_recommendation(
+        "ms-python.pylint", unwanted=True, session=session
+    )
     precommit.remove_hook("pylint")
     precommit.remove_hook("nbqa-pylint")
-    changes += vscode.remove_settings(["pylint.importStrategy"])
+    changes += vscode.remove_settings(["pylint.importStrategy"], session=session)
     return changes
 
 
@@ -666,8 +695,12 @@ def __add_nbqa_isort_pre_commit(precommit: ModifiablePrecommit) -> None:
     precommit.update_single_hook_repo(expected_repo)
 
 
-def _update_lint_dependencies(pyproject: ModifiablePyproject) -> None:
-    if not has_pyproject_package_name():
+def _update_lint_dependencies(
+    pyproject: ModifiablePyproject,
+    *,
+    session: Session | None = None,
+) -> None:
+    if not has_pyproject_package_name(session=session):
         return
     python_versions = pyproject.get_supported_python_versions()
     if "3.6" in python_versions:
@@ -678,21 +711,28 @@ def _update_lint_dependencies(pyproject: ModifiablePyproject) -> None:
     pyproject.remove_dependency(ruff, ignored_sections=["dev"])
 
 
-def _update_vscode_settings() -> Changelog:
+def _update_vscode_settings(*, session: Session | None = None) -> Changelog:
     # cspell:ignore charliermarsh
     changes: Changelog = []
-    changes += vscode.add_extension_recommendation("charliermarsh.ruff")
-    changes += vscode.update_settings({
-        "notebook.codeActionsOnSave": {"notebook.source.organizeImports": "explicit"},
-        "notebook.formatOnSave.enabled": True,
-        "[python]": {
-            "editor.codeActionsOnSave": {
-                "source.organizeImports": "explicit",
+    changes += vscode.add_extension_recommendation(
+        "charliermarsh.ruff", session=session
+    )
+    changes += vscode.update_settings(
+        {
+            "notebook.codeActionsOnSave": {
+                "notebook.source.organizeImports": "explicit"
             },
-            "editor.defaultFormatter": "charliermarsh.ruff",
+            "notebook.formatOnSave.enabled": True,
+            "[python]": {
+                "editor.codeActionsOnSave": {
+                    "source.organizeImports": "explicit",
+                },
+                "editor.defaultFormatter": "charliermarsh.ruff",
+            },
+            "ruff.enable": True,
+            "ruff.importStrategy": "fromEnvironment",
+            "ruff.organizeImports": True,
         },
-        "ruff.enable": True,
-        "ruff.importStrategy": "fromEnvironment",
-        "ruff.organizeImports": True,
-    })
+        session=session,
+    )
     return changes

--- a/src/compwa_policy/python/ruff.py
+++ b/src/compwa_policy/python/ruff.py
@@ -67,11 +67,8 @@ def _remove_black(session: Session, /) -> None:
         unwanted=True,
     )
     __remove_tool_table(pyproject, "black")
-    pyproject.remove_dependency(
-        package="black",
-        ignored_sections=["doc", "notebooks", "test"],
-    )
-    remove_badge(session, r".*https://github\.com/psf.*/black.*")
+    pyproject.remove_dependency("black", ignored_sections=["doc", "notebooks", "test"])
+    remove_badge(session, badge_pattern=r".*https://github\.com/psf.*/black.*")
     precommit.remove_hook("black-jupyter")
     precommit.remove_hook("blacken-docs")
     vscode.remove_settings(session, ["black-formatter.importStrategy"])

--- a/src/compwa_policy/python/ty.py
+++ b/src/compwa_policy/python/ty.py
@@ -8,15 +8,12 @@ from typing import TYPE_CHECKING, Literal
 from compwa_policy.utilities import vscode
 from compwa_policy.utilities.precommit.getters import find_hook
 from compwa_policy.utilities.precommit.struct import Hook, Repo
-from compwa_policy.utilities.pyproject import (
-    ModifiablePyproject,
-    use_modifiable_pyproject,
-)
 from compwa_policy.utilities.readme import add_badge, remove_badge
 from compwa_policy.utilities.yaml import read_preserved_yaml
 
 if TYPE_CHECKING:
     from compwa_policy.utilities.precommit import ModifiablePrecommit
+    from compwa_policy.utilities.pyproject import ModifiablePyproject
     from compwa_policy.utilities.session import Changelog, Session
 
 TypeChecker = Literal["mypy", "pyright", "ty"]
@@ -26,18 +23,18 @@ TypeChecker = Literal["mypy", "pyright", "ty"]
 def main(session: Session, type_checkers: set[TypeChecker]) -> None:
     precommit = session.precommit
     session.changelog += _update_vscode_settings(type_checkers)
-    with use_modifiable_pyproject(session.pyproject) as (config, _):
-        if config is None:
-            return
-        if "ty" in type_checkers:
-            _update_configuration(config)
-            config.add_dependency("ty", dependency_group=["style", "dev"])
-            _update_precommit_config(precommit, config)
-            session.changelog += add_badge(
-                "[![ty](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ty/main/assets/badge/v0.json)](https://github.com/astral-sh/ty)",
-            )
-        else:
-            session.changelog += _remove_ty(precommit, config)
+    config = session.pyproject
+    if config is None:
+        return
+    if "ty" in type_checkers:
+        _update_configuration(config)
+        config.add_dependency("ty", dependency_group=["style", "dev"])
+        _update_precommit_config(precommit, config)
+        session.changelog += add_badge(
+            "[![ty](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ty/main/assets/badge/v0.json)](https://github.com/astral-sh/ty)",
+        )
+    else:
+        session.changelog += _remove_ty(precommit, config)
 
 
 def _update_vscode_settings(type_checkers: set[TypeChecker]) -> Changelog:

--- a/src/compwa_policy/python/ty.py
+++ b/src/compwa_policy/python/ty.py
@@ -125,5 +125,5 @@ def _remove_ty(session: Session, /) -> None:
     precommit.remove_hook("ty")
     remove_badge(
         session,
-        r".*https://.+\.com/astral\-sh/ty/main/assets/badge/v0\.json.*",
+        badge_pattern=r".*https://.+\.com/astral\-sh/ty/main/assets/badge/v0\.json.*",
     )

--- a/src/compwa_policy/python/ty.py
+++ b/src/compwa_policy/python/ty.py
@@ -12,7 +12,6 @@ from compwa_policy.utilities.readme import add_badge, remove_badge
 from compwa_policy.utilities.yaml import read_preserved_yaml
 
 if TYPE_CHECKING:
-    from compwa_policy.utilities.precommit import ModifiablePrecommit
     from compwa_policy.utilities.pyproject import ModifiablePyproject
     from compwa_policy.utilities.session import Changelog, Session
 
@@ -21,26 +20,26 @@ TypeChecker = Literal["mypy", "pyright", "ty"]
 
 
 def main(session: Session, type_checkers: set[TypeChecker]) -> None:
-    session.changelog += _update_vscode_settings(type_checkers, session=session)
+    session.changelog += _update_vscode_settings(session, type_checkers)
     config = session.pyproject
     if config is None:
         return
     if "ty" in type_checkers:
         _update_configuration(config)
         config.add_dependency("ty", dependency_group=["style", "dev"])
-        _update_precommit_config(session.precommit, config)
+        _update_precommit_config(session)
         session.changelog += add_badge(
+            session,
             "[![ty](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ty/main/assets/badge/v0.json)](https://github.com/astral-sh/ty)",
-            session=session,
         )
     else:
-        session.changelog += _remove_ty(session=session)
+        session.changelog += _remove_ty(session)
 
 
 def _update_vscode_settings(
-    type_checkers: set[TypeChecker],
-    *,
     session: Session,
+    /,
+    type_checkers: set[TypeChecker],
 ) -> Changelog:
     settings = {
         "ty.completions.autoImport": False,
@@ -50,18 +49,14 @@ def _update_vscode_settings(
     changes: Changelog = []
     if "ty" in type_checkers:
         if "pyright" not in type_checkers:
-            changes += vscode.remove_settings(
-                ["python.languageServer"], session=session
-            )
-        changes += vscode.add_extension_recommendation("astral-sh.ty", session=session)
-        changes += vscode.update_settings(settings, session=session)
+            changes += vscode.remove_settings(session, ["python.languageServer"])
+        changes += vscode.add_extension_recommendation(session, "astral-sh.ty")
+        changes += vscode.update_settings(session, settings)
     else:
         changes += vscode.remove_extension_recommendation(
-            "astral-sh.ty", unwanted=True, session=session
+            session, "astral-sh.ty", unwanted=True
         )
-        changes += vscode.remove_settings(
-            [*settings, "python.languageServer"], session=session
-        )
+        changes += vscode.remove_settings(session, [*settings, "python.languageServer"])
     return changes
 
 
@@ -88,9 +83,11 @@ def _update_configuration(pyproject: ModifiablePyproject) -> None:
         pyproject.changelog.append("Set tool.ty.terminal.error-on-warning = true")
 
 
-def _update_precommit_config(
-    precommit: ModifiablePrecommit, pyproject: ModifiablePyproject
-) -> None:
+def _update_precommit_config(session: Session, /) -> None:
+    precommit = session.precommit
+    pyproject = session.pyproject
+    if pyproject is None:
+        return
     existing_hook = find_hook(precommit.document, r"^ty$")
     exclude = existing_hook.get("exclude") if existing_hook else None
     precommit.remove_hook("ty", repo_url="local")
@@ -116,7 +113,7 @@ def _select_dependency_group(pyproject: ModifiablePyproject) -> str | None:
     return None
 
 
-def _remove_ty(*, session: Session) -> Changelog:
+def _remove_ty(session: Session, /) -> Changelog:
     precommit = session.precommit
     pyproject = session.pyproject
     if pyproject is None:
@@ -131,6 +128,6 @@ def _remove_ty(*, session: Session) -> Changelog:
     pyproject.remove_dependency("ty")
     precommit.remove_hook("ty")
     return remove_badge(
+        session,
         r".*https://.+\.com/astral\-sh/ty/main/assets/badge/v0\.json.*",
-        session=session,
     )

--- a/src/compwa_policy/python/ty.py
+++ b/src/compwa_policy/python/ty.py
@@ -13,14 +13,14 @@ from compwa_policy.utilities.yaml import read_preserved_yaml
 
 if TYPE_CHECKING:
     from compwa_policy.utilities.pyproject import ModifiablePyproject
-    from compwa_policy.utilities.session import Changelog, Session
+    from compwa_policy.utilities.session import Session
 
 TypeChecker = Literal["mypy", "pyright", "ty"]
 """The type of type checkers supported."""
 
 
 def main(session: Session, type_checkers: set[TypeChecker]) -> None:
-    session.changelog += _update_vscode_settings(session, type_checkers)
+    _update_vscode_settings(session, type_checkers)
     config = session.pyproject
     if config is None:
         return
@@ -28,36 +28,32 @@ def main(session: Session, type_checkers: set[TypeChecker]) -> None:
         _update_configuration(config)
         config.add_dependency("ty", dependency_group=["style", "dev"])
         _update_precommit_config(session)
-        session.changelog += add_badge(
+        add_badge(
             session,
             "[![ty](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ty/main/assets/badge/v0.json)](https://github.com/astral-sh/ty)",
         )
     else:
-        session.changelog += _remove_ty(session)
+        _remove_ty(session)
 
 
 def _update_vscode_settings(
     session: Session,
     /,
     type_checkers: set[TypeChecker],
-) -> Changelog:
+) -> None:
     settings = {
         "ty.completions.autoImport": False,
         "ty.diagnosticMode": "workspace",
         "ty.importStrategy": "fromEnvironment",
     }
-    changes: Changelog = []
     if "ty" in type_checkers:
         if "pyright" not in type_checkers:
-            changes += vscode.remove_settings(session, ["python.languageServer"])
-        changes += vscode.add_extension_recommendation(session, "astral-sh.ty")
-        changes += vscode.update_settings(session, settings)
+            vscode.remove_settings(session, ["python.languageServer"])
+        vscode.add_extension_recommendation(session, "astral-sh.ty")
+        vscode.update_settings(session, settings)
     else:
-        changes += vscode.remove_extension_recommendation(
-            session, "astral-sh.ty", unwanted=True
-        )
-        changes += vscode.remove_settings(session, [*settings, "python.languageServer"])
-    return changes
+        vscode.remove_extension_recommendation(session, "astral-sh.ty", unwanted=True)
+        vscode.remove_settings(session, [*settings, "python.languageServer"])
 
 
 def _update_configuration(pyproject: ModifiablePyproject) -> None:
@@ -113,11 +109,11 @@ def _select_dependency_group(pyproject: ModifiablePyproject) -> str | None:
     return None
 
 
-def _remove_ty(session: Session, /) -> Changelog:
+def _remove_ty(session: Session, /) -> None:
     precommit = session.precommit
     pyproject = session.pyproject
     if pyproject is None:
-        return []
+        return
     config_path = Path("ty.toml")
     if config_path.exists():
         config_path.unlink()
@@ -127,7 +123,7 @@ def _remove_ty(session: Session, /) -> Changelog:
         pyproject.changelog.append("Removed ty configuration table")
     pyproject.remove_dependency("ty")
     precommit.remove_hook("ty")
-    return remove_badge(
+    remove_badge(
         session,
         r".*https://.+\.com/astral\-sh/ty/main/assets/badge/v0\.json.*",
     )

--- a/src/compwa_policy/python/ty.py
+++ b/src/compwa_policy/python/ty.py
@@ -41,7 +41,7 @@ def main(session: Session, type_checkers: set[TypeChecker]) -> None:
 def _update_vscode_settings(
     type_checkers: set[TypeChecker],
     *,
-    session: Session | None = None,
+    session: Session,
 ) -> Changelog:
     settings = {
         "ty.completions.autoImport": False,
@@ -121,7 +121,7 @@ def _remove_ty(
     precommit: ModifiablePrecommit,
     pyproject: ModifiablePyproject,
     *,
-    session: Session | None = None,
+    session: Session,
 ) -> Changelog:
     config_path = Path("ty.toml")
     if config_path.exists():

--- a/src/compwa_policy/python/ty.py
+++ b/src/compwa_policy/python/ty.py
@@ -21,7 +21,6 @@ TypeChecker = Literal["mypy", "pyright", "ty"]
 
 
 def main(session: Session, type_checkers: set[TypeChecker]) -> None:
-    precommit = session.precommit
     session.changelog += _update_vscode_settings(type_checkers, session=session)
     config = session.pyproject
     if config is None:
@@ -29,13 +28,13 @@ def main(session: Session, type_checkers: set[TypeChecker]) -> None:
     if "ty" in type_checkers:
         _update_configuration(config)
         config.add_dependency("ty", dependency_group=["style", "dev"])
-        _update_precommit_config(precommit, config)
+        _update_precommit_config(session.precommit, config)
         session.changelog += add_badge(
             "[![ty](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ty/main/assets/badge/v0.json)](https://github.com/astral-sh/ty)",
             session=session,
         )
     else:
-        session.changelog += _remove_ty(precommit, config, session=session)
+        session.changelog += _remove_ty(session=session)
 
 
 def _update_vscode_settings(
@@ -117,12 +116,11 @@ def _select_dependency_group(pyproject: ModifiablePyproject) -> str | None:
     return None
 
 
-def _remove_ty(
-    precommit: ModifiablePrecommit,
-    pyproject: ModifiablePyproject,
-    *,
-    session: Session,
-) -> Changelog:
+def _remove_ty(*, session: Session) -> Changelog:
+    precommit = session.precommit
+    pyproject = session.pyproject
+    if pyproject is None:
+        return []
     config_path = Path("ty.toml")
     if config_path.exists():
         config_path.unlink()

--- a/src/compwa_policy/python/ty.py
+++ b/src/compwa_policy/python/ty.py
@@ -22,7 +22,7 @@ TypeChecker = Literal["mypy", "pyright", "ty"]
 
 def main(session: Session, type_checkers: set[TypeChecker]) -> None:
     precommit = session.precommit
-    session.changelog += _update_vscode_settings(type_checkers)
+    session.changelog += _update_vscode_settings(type_checkers, session=session)
     config = session.pyproject
     if config is None:
         return
@@ -32,12 +32,17 @@ def main(session: Session, type_checkers: set[TypeChecker]) -> None:
         _update_precommit_config(precommit, config)
         session.changelog += add_badge(
             "[![ty](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ty/main/assets/badge/v0.json)](https://github.com/astral-sh/ty)",
+            session=session,
         )
     else:
-        session.changelog += _remove_ty(precommit, config)
+        session.changelog += _remove_ty(precommit, config, session=session)
 
 
-def _update_vscode_settings(type_checkers: set[TypeChecker]) -> Changelog:
+def _update_vscode_settings(
+    type_checkers: set[TypeChecker],
+    *,
+    session: Session | None = None,
+) -> Changelog:
     settings = {
         "ty.completions.autoImport": False,
         "ty.diagnosticMode": "workspace",
@@ -46,12 +51,18 @@ def _update_vscode_settings(type_checkers: set[TypeChecker]) -> Changelog:
     changes: Changelog = []
     if "ty" in type_checkers:
         if "pyright" not in type_checkers:
-            changes += vscode.remove_settings(["python.languageServer"])
-        changes += vscode.add_extension_recommendation("astral-sh.ty")
-        changes += vscode.update_settings(settings)
+            changes += vscode.remove_settings(
+                ["python.languageServer"], session=session
+            )
+        changes += vscode.add_extension_recommendation("astral-sh.ty", session=session)
+        changes += vscode.update_settings(settings, session=session)
     else:
-        changes += vscode.remove_extension_recommendation("astral-sh.ty", unwanted=True)
-        changes += vscode.remove_settings([*settings, "python.languageServer"])
+        changes += vscode.remove_extension_recommendation(
+            "astral-sh.ty", unwanted=True, session=session
+        )
+        changes += vscode.remove_settings(
+            [*settings, "python.languageServer"], session=session
+        )
     return changes
 
 
@@ -107,7 +118,10 @@ def _select_dependency_group(pyproject: ModifiablePyproject) -> str | None:
 
 
 def _remove_ty(
-    precommit: ModifiablePrecommit, pyproject: ModifiablePyproject
+    precommit: ModifiablePrecommit,
+    pyproject: ModifiablePyproject,
+    *,
+    session: Session | None = None,
 ) -> Changelog:
     config_path = Path("ty.toml")
     if config_path.exists():
@@ -118,4 +132,7 @@ def _remove_ty(
         pyproject.changelog.append("Removed ty configuration table")
     pyproject.remove_dependency("ty")
     precommit.remove_hook("ty")
-    return remove_badge(r".*https://.+\.com/astral\-sh/ty/main/assets/badge/v0\.json.*")
+    return remove_badge(
+        r".*https://.+\.com/astral\-sh/ty/main/assets/badge/v0\.json.*",
+        session=session,
+    )

--- a/src/compwa_policy/repo/citation.py
+++ b/src/compwa_policy/repo/citation.py
@@ -33,10 +33,8 @@ def main(session: Session) -> None:
         if not just_converted:
             check_citation_keys()
         add_json_schema_precommit(session.precommit)
-        session.changelog += vscode.add_extension_recommendation(
-            session, "redhat.vscode-yaml"
-        )
-        session.changelog += update_vscode_settings(session)
+        vscode.add_extension_recommendation(session, "redhat.vscode-yaml")
+        update_vscode_settings(session)
 
 
 def convert_zenodo_json() -> Changelog:
@@ -215,8 +213,8 @@ def add_json_schema_precommit(precommit: ModifiablePrecommit) -> None:
     precommit.changelog.append(msg)
 
 
-def update_vscode_settings(session: Session, /) -> Changelog:
-    return vscode.update_settings(
+def update_vscode_settings(session: Session, /) -> None:
+    vscode.update_settings(
         session,
         {
             "yaml.schemas": {

--- a/src/compwa_policy/repo/citation.py
+++ b/src/compwa_policy/repo/citation.py
@@ -215,7 +215,7 @@ def add_json_schema_precommit(precommit: ModifiablePrecommit) -> None:
     precommit.changelog.append(msg)
 
 
-def update_vscode_settings(*, session: Session | None = None) -> Changelog:
+def update_vscode_settings(*, session: Session) -> Changelog:
     return vscode.update_settings(
         {
             "yaml.schemas": {

--- a/src/compwa_policy/repo/citation.py
+++ b/src/compwa_policy/repo/citation.py
@@ -34,9 +34,9 @@ def main(session: Session) -> None:
             check_citation_keys()
         add_json_schema_precommit(session.precommit)
         session.changelog += vscode.add_extension_recommendation(
-            "redhat.vscode-yaml", session=session
+            session, "redhat.vscode-yaml"
         )
-        session.changelog += update_vscode_settings(session=session)
+        session.changelog += update_vscode_settings(session)
 
 
 def convert_zenodo_json() -> Changelog:
@@ -215,8 +215,9 @@ def add_json_schema_precommit(precommit: ModifiablePrecommit) -> None:
     precommit.changelog.append(msg)
 
 
-def update_vscode_settings(*, session: Session) -> Changelog:
+def update_vscode_settings(session: Session, /) -> Changelog:
     return vscode.update_settings(
+        session,
         {
             "yaml.schemas": {
                 "https://citation-file-format.github.io/1.2.0/schema.json": (
@@ -224,5 +225,4 @@ def update_vscode_settings(*, session: Session) -> Changelog:
                 )
             }
         },
-        session=session,
     )

--- a/src/compwa_policy/repo/citation.py
+++ b/src/compwa_policy/repo/citation.py
@@ -33,8 +33,10 @@ def main(session: Session) -> None:
         if not just_converted:
             check_citation_keys()
         add_json_schema_precommit(session.precommit)
-        session.changelog += vscode.add_extension_recommendation("redhat.vscode-yaml")
-        session.changelog += update_vscode_settings()
+        session.changelog += vscode.add_extension_recommendation(
+            "redhat.vscode-yaml", session=session
+        )
+        session.changelog += update_vscode_settings(session=session)
 
 
 def convert_zenodo_json() -> Changelog:
@@ -213,7 +215,7 @@ def add_json_schema_precommit(precommit: ModifiablePrecommit) -> None:
     precommit.changelog.append(msg)
 
 
-def update_vscode_settings() -> Changelog:
+def update_vscode_settings(*, session: Session | None = None) -> Changelog:
     return vscode.update_settings(
         {
             "yaml.schemas": {
@@ -222,4 +224,5 @@ def update_vscode_settings() -> Changelog:
                 )
             }
         },
+        session=session,
     )

--- a/src/compwa_policy/repo/deprecated.py
+++ b/src/compwa_policy/repo/deprecated.py
@@ -32,7 +32,7 @@ def _remove_github_issue_templates(session: Session, /) -> None:
 
 def _remove_markdownlint(session: Session, /) -> None:
     remove_configs(session, [".markdownlint.json", ".markdownlint.yaml"])
-    remove_lines(session, CONFIG_PATH.gitignore, r"\.markdownlint\.json")
+    remove_lines(session, CONFIG_PATH.gitignore, pattern=r"\.markdownlint\.json")
     vscode.remove_extension_recommendation(
         session,  # cspell:ignore davidanson markdownlint
         extension_name="davidanson.vscode-markdownlint",

--- a/src/compwa_policy/repo/deprecated.py
+++ b/src/compwa_policy/repo/deprecated.py
@@ -21,7 +21,7 @@ def remove_deprecated_tools(session: Session, keep_issue_templates: bool) -> Non
         _remove_relink_references(directory)
 
 
-def _remove_github_issue_templates(*, session: Session | None = None) -> Changelog:
+def _remove_github_issue_templates(*, session: Session) -> Changelog:
     return remove_configs(
         [
             ".github/ISSUE_TEMPLATE",
@@ -34,7 +34,7 @@ def _remove_github_issue_templates(*, session: Session | None = None) -> Changel
 def _remove_markdownlint(
     precommit: ModifiablePrecommit,
     *,
-    session: Session | None = None,
+    session: Session,
 ) -> Changelog:
     changes: Changelog = []
     changes += remove_configs(

--- a/src/compwa_policy/repo/deprecated.py
+++ b/src/compwa_policy/repo/deprecated.py
@@ -15,27 +15,39 @@ if TYPE_CHECKING:
 
 def remove_deprecated_tools(session: Session, keep_issue_templates: bool) -> None:
     if not keep_issue_templates:
-        session.changelog += _remove_github_issue_templates()
-    session.changelog += _remove_markdownlint(session.precommit)
+        session.changelog += _remove_github_issue_templates(session=session)
+    session.changelog += _remove_markdownlint(session.precommit, session=session)
     for directory in ["docs", "doc"]:
         _remove_relink_references(directory)
 
 
-def _remove_github_issue_templates() -> Changelog:
-    return remove_configs([
-        ".github/ISSUE_TEMPLATE",
-        ".github/pull_request_template.md",
-    ])
+def _remove_github_issue_templates(*, session: Session | None = None) -> Changelog:
+    return remove_configs(
+        [
+            ".github/ISSUE_TEMPLATE",
+            ".github/pull_request_template.md",
+        ],
+        session=session,
+    )
 
 
-def _remove_markdownlint(precommit: ModifiablePrecommit) -> Changelog:
+def _remove_markdownlint(
+    precommit: ModifiablePrecommit,
+    *,
+    session: Session | None = None,
+) -> Changelog:
     changes: Changelog = []
-    changes += remove_configs([".markdownlint.json", ".markdownlint.yaml"])
-    changes += remove_lines(CONFIG_PATH.gitignore, r"\.markdownlint\.json")
+    changes += remove_configs(
+        [".markdownlint.json", ".markdownlint.yaml"], session=session
+    )
+    changes += remove_lines(
+        CONFIG_PATH.gitignore, r"\.markdownlint\.json", session=session
+    )
     changes += vscode.remove_extension_recommendation(
         # cspell:ignore davidanson markdownlint
         extension_name="davidanson.vscode-markdownlint",
         unwanted=True,
+        session=session,
     )
     precommit.remove_hook("markdownlint")
     return changes

--- a/src/compwa_policy/repo/deprecated.py
+++ b/src/compwa_policy/repo/deprecated.py
@@ -9,19 +9,19 @@ from compwa_policy.errors import PolicyError
 from compwa_policy.utilities import CONFIG_PATH, remove_configs, remove_lines, vscode
 
 if TYPE_CHECKING:
-    from compwa_policy.utilities.session import Changelog, Session
+    from compwa_policy.utilities.session import Session
 
 
 def remove_deprecated_tools(session: Session, keep_issue_templates: bool) -> None:
     if not keep_issue_templates:
-        session.changelog += _remove_github_issue_templates(session)
-    session.changelog += _remove_markdownlint(session)
+        _remove_github_issue_templates(session)
+    _remove_markdownlint(session)
     for directory in ["docs", "doc"]:
         _remove_relink_references(directory)
 
 
-def _remove_github_issue_templates(session: Session, /) -> Changelog:
-    return remove_configs(
+def _remove_github_issue_templates(session: Session, /) -> None:
+    remove_configs(
         session,
         [
             ".github/ISSUE_TEMPLATE",
@@ -30,17 +30,15 @@ def _remove_github_issue_templates(session: Session, /) -> Changelog:
     )
 
 
-def _remove_markdownlint(session: Session, /) -> Changelog:
-    changes: Changelog = []
-    changes += remove_configs(session, [".markdownlint.json", ".markdownlint.yaml"])
-    changes += remove_lines(session, CONFIG_PATH.gitignore, r"\.markdownlint\.json")
-    changes += vscode.remove_extension_recommendation(
+def _remove_markdownlint(session: Session, /) -> None:
+    remove_configs(session, [".markdownlint.json", ".markdownlint.yaml"])
+    remove_lines(session, CONFIG_PATH.gitignore, r"\.markdownlint\.json")
+    vscode.remove_extension_recommendation(
         session,  # cspell:ignore davidanson markdownlint
         extension_name="davidanson.vscode-markdownlint",
         unwanted=True,
     )
     session.precommit.remove_hook("markdownlint")
-    return changes
 
 
 def _remove_relink_references(directory: str) -> None:

--- a/src/compwa_policy/repo/deprecated.py
+++ b/src/compwa_policy/repo/deprecated.py
@@ -9,47 +9,37 @@ from compwa_policy.errors import PolicyError
 from compwa_policy.utilities import CONFIG_PATH, remove_configs, remove_lines, vscode
 
 if TYPE_CHECKING:
-    from compwa_policy.utilities.precommit import ModifiablePrecommit
     from compwa_policy.utilities.session import Changelog, Session
 
 
 def remove_deprecated_tools(session: Session, keep_issue_templates: bool) -> None:
     if not keep_issue_templates:
-        session.changelog += _remove_github_issue_templates(session=session)
-    session.changelog += _remove_markdownlint(session.precommit, session=session)
+        session.changelog += _remove_github_issue_templates(session)
+    session.changelog += _remove_markdownlint(session)
     for directory in ["docs", "doc"]:
         _remove_relink_references(directory)
 
 
-def _remove_github_issue_templates(*, session: Session) -> Changelog:
+def _remove_github_issue_templates(session: Session, /) -> Changelog:
     return remove_configs(
+        session,
         [
             ".github/ISSUE_TEMPLATE",
             ".github/pull_request_template.md",
         ],
-        session=session,
     )
 
 
-def _remove_markdownlint(
-    precommit: ModifiablePrecommit,
-    *,
-    session: Session,
-) -> Changelog:
+def _remove_markdownlint(session: Session, /) -> Changelog:
     changes: Changelog = []
-    changes += remove_configs(
-        [".markdownlint.json", ".markdownlint.yaml"], session=session
-    )
-    changes += remove_lines(
-        CONFIG_PATH.gitignore, r"\.markdownlint\.json", session=session
-    )
+    changes += remove_configs(session, [".markdownlint.json", ".markdownlint.yaml"])
+    changes += remove_lines(session, CONFIG_PATH.gitignore, r"\.markdownlint\.json")
     changes += vscode.remove_extension_recommendation(
-        # cspell:ignore davidanson markdownlint
+        session,  # cspell:ignore davidanson markdownlint
         extension_name="davidanson.vscode-markdownlint",
         unwanted=True,
-        session=session,
     )
-    precommit.remove_hook("markdownlint")
+    session.precommit.remove_hook("markdownlint")
     return changes
 
 

--- a/src/compwa_policy/repo/gitpod.py
+++ b/src/compwa_policy/repo/gitpod.py
@@ -22,7 +22,7 @@ def main(session: Session, use_gitpod: bool, python_version: PythonVersion) -> N
         session.changelog += remove_gitpod_config()
         remove_badge(
             session,
-            r"\[!\[GitPod\]\(https://img.shields.io/badge/gitpod",
+            badge_pattern=r"\[!\[GitPod\]\(https://img.shields.io/badge/gitpod",
         )
         return
     error_message = ""
@@ -46,7 +46,7 @@ def main(session: Session, use_gitpod: bool, python_version: PythonVersion) -> N
         repo_url = pyproject.get_repo_url()
         add_badge(
             session,
-            f"[![GitPod](https://img.shields.io/badge/gitpod-open-blue?logo=gitpod)](https://gitpod.io/#{repo_url})",
+            badge=f"[![GitPod](https://img.shields.io/badge/gitpod-open-blue?logo=gitpod)](https://gitpod.io/#{repo_url})",
         )
     except PolicyError:
         return

--- a/src/compwa_policy/repo/gitpod.py
+++ b/src/compwa_policy/repo/gitpod.py
@@ -60,14 +60,14 @@ def remove_gitpod_config() -> Changelog:
     return []
 
 
-def _extract_extensions(*, session: Session | None = None) -> list[str]:
+def _extract_extensions(*, session: Session) -> list[str]:
     return sorted(vscode.get_recommended_extensions(session=session))
 
 
 def _generate_gitpod_config(
     python_version: PythonVersion,
     *,
-    session: Session | None = None,
+    session: Session,
 ) -> dict:
     with open(COMPWA_POLICY_DIR / ".template" / CONFIG_PATH.gitpod) as stream:
         gitpod_config = yaml.load(stream, Loader=yaml.SafeLoader)

--- a/src/compwa_policy/repo/gitpod.py
+++ b/src/compwa_policy/repo/gitpod.py
@@ -25,11 +25,12 @@ def main(session: Session, use_gitpod: bool, python_version: PythonVersion) -> N
     if not use_gitpod:
         session.changelog += remove_gitpod_config()
         session.changelog += remove_badge(
-            r"\[!\[GitPod\]\(https://img.shields.io/badge/gitpod"
+            r"\[!\[GitPod\]\(https://img.shields.io/badge/gitpod",
+            session=session,
         )
         return
     error_message = ""
-    expected_config = _generate_gitpod_config(python_version)
+    expected_config = _generate_gitpod_config(python_version, session=session)
     if CONFIG_PATH.gitpod.exists():
         with open(CONFIG_PATH.gitpod) as stream:
             existing_config = yaml.load(stream, Loader=yaml.SafeLoader)
@@ -43,9 +44,10 @@ def main(session: Session, use_gitpod: bool, python_version: PythonVersion) -> N
         session.changelog.append(error_message)
         return
     try:
-        repo_url = Pyproject.load().get_repo_url()
+        repo_url = Pyproject.load(session=session).get_repo_url()
         session.changelog += add_badge(
-            f"[![GitPod](https://img.shields.io/badge/gitpod-open-blue?logo=gitpod)](https://gitpod.io/#{repo_url})"
+            f"[![GitPod](https://img.shields.io/badge/gitpod-open-blue?logo=gitpod)](https://gitpod.io/#{repo_url})",
+            session=session,
         )
     except PolicyError:
         return
@@ -58,11 +60,15 @@ def remove_gitpod_config() -> Changelog:
     return []
 
 
-def _extract_extensions() -> list[str]:
-    return sorted(vscode.get_recommended_extensions())
+def _extract_extensions(*, session: Session | None = None) -> list[str]:
+    return sorted(vscode.get_recommended_extensions(session=session))
 
 
-def _generate_gitpod_config(python_version: PythonVersion) -> dict:
+def _generate_gitpod_config(
+    python_version: PythonVersion,
+    *,
+    session: Session | None = None,
+) -> dict:
     with open(COMPWA_POLICY_DIR / ".template" / CONFIG_PATH.gitpod) as stream:
         gitpod_config = yaml.load(stream, Loader=yaml.SafeLoader)
     tasks = gitpod_config["tasks"]
@@ -72,7 +78,7 @@ def _generate_gitpod_config(python_version: PythonVersion) -> dict:
         tasks[1]["init"] = "pip install -e .[dev]"
     else:
         tasks[1]["init"] = f"pip install -c {constraints_file} -e .[dev]"
-    extensions = _extract_extensions()
+    extensions = _extract_extensions(session=session)
     if extensions:
         gitpod_config["vscode"] = {"extensions": extensions}
     return gitpod_config

--- a/src/compwa_policy/repo/gitpod.py
+++ b/src/compwa_policy/repo/gitpod.py
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
 def main(session: Session, use_gitpod: bool, python_version: PythonVersion) -> None:
     if not use_gitpod:
         session.changelog += remove_gitpod_config()
-        session.changelog += remove_badge(
+        remove_badge(
             session,
             r"\[!\[GitPod\]\(https://img.shields.io/badge/gitpod",
         )
@@ -44,7 +44,7 @@ def main(session: Session, use_gitpod: bool, python_version: PythonVersion) -> N
         if pyproject is None:
             return
         repo_url = pyproject.get_repo_url()
-        session.changelog += add_badge(
+        add_badge(
             session,
             f"[![GitPod](https://img.shields.io/badge/gitpod-open-blue?logo=gitpod)](https://gitpod.io/#{repo_url})",
         )

--- a/src/compwa_policy/repo/gitpod.py
+++ b/src/compwa_policy/repo/gitpod.py
@@ -2,14 +2,13 @@
 
 from __future__ import annotations
 
-import json
 import os
 from typing import TYPE_CHECKING
 
 import yaml
 
 from compwa_policy.errors import PolicyError
-from compwa_policy.utilities import COMPWA_POLICY_DIR, CONFIG_PATH
+from compwa_policy.utilities import COMPWA_POLICY_DIR, CONFIG_PATH, vscode
 from compwa_policy.utilities.pyproject import (
     Pyproject,
     PythonVersion,
@@ -59,11 +58,8 @@ def remove_gitpod_config() -> Changelog:
     return []
 
 
-def _extract_extensions() -> dict:
-    if CONFIG_PATH.vscode_extensions.exists():
-        with open(CONFIG_PATH.vscode_extensions) as stream:
-            return json.load(stream)["recommendations"]
-    return {}
+def _extract_extensions() -> list[str]:
+    return sorted(vscode.get_recommended_extensions())
 
 
 def _generate_gitpod_config(python_version: PythonVersion) -> dict:

--- a/src/compwa_policy/repo/gitpod.py
+++ b/src/compwa_policy/repo/gitpod.py
@@ -9,11 +9,7 @@ import yaml
 
 from compwa_policy.errors import PolicyError
 from compwa_policy.utilities import COMPWA_POLICY_DIR, CONFIG_PATH, vscode
-from compwa_policy.utilities.pyproject import (
-    Pyproject,
-    PythonVersion,
-    get_constraints_file,
-)
+from compwa_policy.utilities.pyproject import PythonVersion, get_constraints_file
 from compwa_policy.utilities.readme import add_badge, remove_badge
 from compwa_policy.utilities.yaml import write_yaml
 
@@ -25,12 +21,12 @@ def main(session: Session, use_gitpod: bool, python_version: PythonVersion) -> N
     if not use_gitpod:
         session.changelog += remove_gitpod_config()
         session.changelog += remove_badge(
+            session,
             r"\[!\[GitPod\]\(https://img.shields.io/badge/gitpod",
-            session=session,
         )
         return
     error_message = ""
-    expected_config = _generate_gitpod_config(python_version, session=session)
+    expected_config = _generate_gitpod_config(session, python_version)
     if CONFIG_PATH.gitpod.exists():
         with open(CONFIG_PATH.gitpod) as stream:
             existing_config = yaml.load(stream, Loader=yaml.SafeLoader)
@@ -44,10 +40,13 @@ def main(session: Session, use_gitpod: bool, python_version: PythonVersion) -> N
         session.changelog.append(error_message)
         return
     try:
-        repo_url = Pyproject.load(session=session).get_repo_url()
+        pyproject = session.pyproject
+        if pyproject is None:
+            return
+        repo_url = pyproject.get_repo_url()
         session.changelog += add_badge(
+            session,
             f"[![GitPod](https://img.shields.io/badge/gitpod-open-blue?logo=gitpod)](https://gitpod.io/#{repo_url})",
-            session=session,
         )
     except PolicyError:
         return
@@ -60,15 +59,11 @@ def remove_gitpod_config() -> Changelog:
     return []
 
 
-def _extract_extensions(*, session: Session) -> list[str]:
-    return sorted(vscode.get_recommended_extensions(session=session))
+def _extract_extensions(session: Session, /) -> list[str]:
+    return sorted(vscode.get_recommended_extensions(session))
 
 
-def _generate_gitpod_config(
-    python_version: PythonVersion,
-    *,
-    session: Session,
-) -> dict:
+def _generate_gitpod_config(session: Session, /, python_version: PythonVersion) -> dict:
     with open(COMPWA_POLICY_DIR / ".template" / CONFIG_PATH.gitpod) as stream:
         gitpod_config = yaml.load(stream, Loader=yaml.SafeLoader)
     tasks = gitpod_config["tasks"]
@@ -78,7 +73,7 @@ def _generate_gitpod_config(
         tasks[1]["init"] = "pip install -e .[dev]"
     else:
         tasks[1]["init"] = f"pip install -c {constraints_file} -e .[dev]"
-    extensions = _extract_extensions(session=session)
+    extensions = _extract_extensions(session)
     if extensions:
         gitpod_config["vscode"] = {"extensions": extensions}
     return gitpod_config

--- a/src/compwa_policy/repo/poe.py
+++ b/src/compwa_policy/repo/poe.py
@@ -72,7 +72,7 @@ def main(
             _update_doclive(config)
         if config.has_table("tool.poe.tasks"):
             _set_upgrade_task(config, package_manager)
-    remove_lines(session, CONFIG_PATH.gitignore, r"\.tox/?")
+    remove_lines(session, CONFIG_PATH.gitignore, pattern=r"\.tox/?")
     config.remove_dependency("poethepoet")
     config.remove_dependency("tox")
     config.remove_dependency("tox-uv")
@@ -109,7 +109,7 @@ def _check_expected_sections(pyproject: Pyproject, has_notebooks: bool) -> None:
         raise PolicyError(msg)
 
 
-def _configure_uv_executor(pyproject: ModifiablePyproject) -> None:
+def _configure_uv_executor(pyproject: ModifiablePyproject, /) -> None:
     poe_table = pyproject.get_table("tool.poe")
     executor_table = poe_table.get("executor")
     if executor_table is None or isinstance(executor_table, str):
@@ -142,7 +142,7 @@ def _get_or_create_group_tasks(
     return group["tasks"]
 
 
-def _migrate_tasks_to_groups(pyproject: ModifiablePyproject) -> None:
+def _migrate_tasks_to_groups(pyproject: ModifiablePyproject, /) -> None:
     """Move any doc/test tasks from tool.poe.tasks into their group sub-tables."""
     if not pyproject.has_table("tool.poe.tasks"):
         return
@@ -169,7 +169,7 @@ def _migrate_tasks_to_groups(pyproject: ModifiablePyproject) -> None:
         pyproject.changelog.append(msg)
 
 
-def _set_doc_group(pyproject: ModifiablePyproject) -> None:
+def _set_doc_group(pyproject: ModifiablePyproject, /) -> None:
     if not has_documentation():
         return
     doc_group = pyproject.get_table("tool.poe.groups.doc", create=True)
@@ -178,7 +178,7 @@ def _set_doc_group(pyproject: ModifiablePyproject) -> None:
         pyproject.changelog.append(msg)
 
 
-def _set_test_group(pyproject: ModifiablePyproject) -> None:
+def _set_test_group(pyproject: ModifiablePyproject, /) -> None:
     if not Path("tests").exists():
         return
     test_group = pyproject.get_table("tool.poe.groups.test", create=True)
@@ -187,7 +187,7 @@ def _set_test_group(pyproject: ModifiablePyproject) -> None:
         pyproject.changelog.append(msg)
 
 
-def _set_notebook_group(pyproject: ModifiablePyproject, has_notebooks: bool) -> None:
+def _set_notebook_group(pyproject: ModifiablePyproject, /, has_notebooks: bool) -> None:
     if not has_notebooks and not has_dependency(pyproject, "jupyterlab"):
         return
     notebook_group = pyproject.get_table("tool.poe.groups.notebook", create=True)
@@ -236,7 +236,7 @@ def __has_uv_run(cmd: str | Sequence) -> bool:
     return False
 
 
-def _set_all_task(pyproject: ModifiablePyproject) -> None:
+def _set_all_task(pyproject: ModifiablePyproject, /) -> None:
     task_table = pyproject.get_table("tool.poe.tasks")
     if "all" not in task_table:
         return
@@ -251,7 +251,7 @@ def _set_all_task(pyproject: ModifiablePyproject) -> None:
         pyproject.changelog.append(msg)
 
 
-def _set_jupyter_lab_task(pyproject: ModifiablePyproject) -> None:
+def _set_jupyter_lab_task(pyproject: ModifiablePyproject, /) -> None:
     tasks = _get_or_create_group_tasks(pyproject, "notebook")
     existing = cast("Mapping", tasks.get("lab", {}))
     expected = {
@@ -269,7 +269,7 @@ def _set_jupyter_lab_task(pyproject: ModifiablePyproject) -> None:
         pyproject.changelog.append(msg)
 
 
-def _set_nb_task(pyproject: ModifiablePyproject) -> None:
+def _set_nb_task(pyproject: ModifiablePyproject, /) -> None:
     tasks = _get_or_create_group_tasks(pyproject, "notebook")
     existing = cast("Table", tasks.get("nb", {}))
     expected = {
@@ -313,7 +313,7 @@ def __get_notebook_path() -> str:
     return os.path.commonpath(os.path.dirname(p) for p in notebooks)
 
 
-def _set_test_all_task(pyproject: ModifiablePyproject) -> None:
+def _set_test_all_task(pyproject: ModifiablePyproject, /) -> None:
     supported_python_versions = pyproject.get_supported_python_versions()
     if len(supported_python_versions) <= 1:
         return
@@ -393,7 +393,7 @@ def _set_upgrade_task(
         pyproject.changelog.append(msg)
 
 
-def _update_doclive(pyproject: ModifiablePyproject) -> None:
+def _update_doclive(pyproject: ModifiablePyproject, /) -> None:
     def combine(key: str, value: str) -> str | Array:
         existing_value = executor.get(key)
         if existing_value is None or existing_value == value:

--- a/src/compwa_policy/repo/poe.py
+++ b/src/compwa_policy/repo/poe.py
@@ -72,9 +72,7 @@ def main(
             _update_doclive(config)
         if config.has_table("tool.poe.tasks"):
             _set_upgrade_task(config, package_manager)
-    session.changelog += remove_lines(
-        CONFIG_PATH.gitignore, r"\.tox/?", session=session
-    )
+    session.changelog += remove_lines(session, CONFIG_PATH.gitignore, r"\.tox/?")
     config.remove_dependency("poethepoet")
     config.remove_dependency("tox")
     config.remove_dependency("tox-uv")

--- a/src/compwa_policy/repo/poe.py
+++ b/src/compwa_policy/repo/poe.py
@@ -18,7 +18,6 @@ from compwa_policy.utilities.pyproject import (
     ModifiablePyproject,
     Pyproject,
     has_dependency,
-    use_modifiable_pyproject,
 )
 from compwa_policy.utilities.toml import to_inline_table, to_toml_array
 
@@ -46,37 +45,37 @@ def main(
     has_notebooks: bool,
     package_manager: PackageManagerChoice,
 ) -> None:
-    with use_modifiable_pyproject(session.pyproject) as (config, _):
-        if config is None:
-            return
-        if config.has_table("tool.tox"):
-            del config._document["tool"]["tox"]  # noqa: SLF001
-            msg = f"Removed deprecated tool.tox section from {CONFIG_PATH.pyproject}"
-            config.changelog.append(msg)
-        if config.has_table("tool.poe"):
-            _check_expected_sections(config, has_notebooks)
-            if package_manager == "uv":
-                _configure_uv_executor(config)
-                _migrate_tasks_to_groups(config)
-                _set_doc_group(config)
-                _set_test_group(config)
-                _set_notebook_group(config, has_notebooks)
-                _check_no_uv_run(config)
-                if config.has_table("tool.poe.tasks"):
-                    _set_all_task(config)
-                if has_dependency(config, "jupyterlab"):
-                    _set_jupyter_lab_task(config)
-                if has_notebooks:
-                    config.remove_dependency("nbmake")  # cspell:ignore nbmake
-                    _set_nb_task(config)
-                _set_test_all_task(config)
-                _update_doclive(config)
+    config = session.pyproject
+    if config is None:
+        return
+    if config.has_table("tool.tox"):
+        del config._document["tool"]["tox"]  # noqa: SLF001
+        msg = f"Removed deprecated tool.tox section from {CONFIG_PATH.pyproject}"
+        config.changelog.append(msg)
+    if config.has_table("tool.poe"):
+        _check_expected_sections(config, has_notebooks)
+        if package_manager == "uv":
+            _configure_uv_executor(config)
+            _migrate_tasks_to_groups(config)
+            _set_doc_group(config)
+            _set_test_group(config)
+            _set_notebook_group(config, has_notebooks)
+            _check_no_uv_run(config)
             if config.has_table("tool.poe.tasks"):
-                _set_upgrade_task(config, package_manager)
-        session.changelog += remove_lines(CONFIG_PATH.gitignore, r"\.tox/?")
-        config.remove_dependency("poethepoet")
-        config.remove_dependency("tox")
-        config.remove_dependency("tox-uv")
+                _set_all_task(config)
+            if has_dependency(config, "jupyterlab"):
+                _set_jupyter_lab_task(config)
+            if has_notebooks:
+                config.remove_dependency("nbmake")  # cspell:ignore nbmake
+                _set_nb_task(config)
+            _set_test_all_task(config)
+            _update_doclive(config)
+        if config.has_table("tool.poe.tasks"):
+            _set_upgrade_task(config, package_manager)
+    session.changelog += remove_lines(CONFIG_PATH.gitignore, r"\.tox/?")
+    config.remove_dependency("poethepoet")
+    config.remove_dependency("tox")
+    config.remove_dependency("tox-uv")
 
 
 def _get_all_poe_tasks(poe_table: Mapping) -> set[str]:

--- a/src/compwa_policy/repo/poe.py
+++ b/src/compwa_policy/repo/poe.py
@@ -72,7 +72,7 @@ def main(
             _update_doclive(config)
         if config.has_table("tool.poe.tasks"):
             _set_upgrade_task(config, package_manager)
-    session.changelog += remove_lines(session, CONFIG_PATH.gitignore, r"\.tox/?")
+    remove_lines(session, CONFIG_PATH.gitignore, r"\.tox/?")
     config.remove_dependency("poethepoet")
     config.remove_dependency("tox")
     config.remove_dependency("tox-uv")

--- a/src/compwa_policy/repo/poe.py
+++ b/src/compwa_policy/repo/poe.py
@@ -72,7 +72,9 @@ def main(
             _update_doclive(config)
         if config.has_table("tool.poe.tasks"):
             _set_upgrade_task(config, package_manager)
-    session.changelog += remove_lines(CONFIG_PATH.gitignore, r"\.tox/?")
+    session.changelog += remove_lines(
+        CONFIG_PATH.gitignore, r"\.tox/?", session=session
+    )
     config.remove_dependency("poethepoet")
     config.remove_dependency("tox")
     config.remove_dependency("tox-uv")

--- a/src/compwa_policy/repo/readthedocs.py
+++ b/src/compwa_policy/repo/readthedocs.py
@@ -208,7 +208,7 @@ def __remove_nested_key(dct: dict, dotted_key: str) -> bool:
 def _update_build_step_for_pixi(
     config: ReadTheDocs,
     *,
-    session: Session | None = None,
+    session: Session,
 ) -> None:
     new_command = __get_pixi_install_statement() + "\n"
     pyproject = Pyproject.load(session=session)

--- a/src/compwa_policy/repo/readthedocs.py
+++ b/src/compwa_policy/repo/readthedocs.py
@@ -13,11 +13,7 @@ from ruamel.yaml.scalarstring import DoubleQuotedScalarString, LiteralScalarStri
 
 from compwa_policy.utilities import CONFIG_PATH, get_nested_dict
 from compwa_policy.utilities.match import git_ls_files
-from compwa_policy.utilities.pyproject import (
-    Pyproject,
-    get_constraints_file,
-    has_dependency,
-)
+from compwa_policy.utilities.pyproject import get_constraints_file, has_dependency
 from compwa_policy.utilities.yaml import create_prettier_round_trip_yaml
 
 if TYPE_CHECKING:
@@ -45,8 +41,10 @@ def main(
     _update_os(rtd)
     _update_python_version(rtd, python_version)
     if package_manager == "pixi+uv":
+        pyproject = session.pyproject
+        has_poe = pyproject is not None and has_dependency(pyproject, "poethepoet")
         _remove_redundant_settings(rtd)
-        _update_build_step_for_pixi(rtd, session=session)
+        _update_build_step_for_pixi(rtd, has_poe)
     elif package_manager == "uv":
         apt_packages = set(rtd.document.get("build", {}).get("apt_packages", []))
         pixi_packages = apt_packages & {"graphviz"}
@@ -205,15 +203,10 @@ def __remove_nested_key(dct: dict, dotted_key: str) -> bool:
     return True
 
 
-def _update_build_step_for_pixi(
-    config: ReadTheDocs,
-    *,
-    session: Session,
-) -> None:
+def _update_build_step_for_pixi(config: ReadTheDocs, has_poe: bool) -> None:
     new_command = __get_pixi_install_statement() + "\n"
-    pyproject = Pyproject.load(session=session)
     docs_dir = _determine_docs_dir()
-    if has_dependency(pyproject, "poethepoet"):
+    if has_poe:
         new_command += dedent(Rf"""
             export UV_LINK_MODE=copy
             pixi run poe doc

--- a/src/compwa_policy/repo/readthedocs.py
+++ b/src/compwa_policy/repo/readthedocs.py
@@ -46,7 +46,7 @@ def main(
     _update_python_version(rtd, python_version)
     if package_manager == "pixi+uv":
         _remove_redundant_settings(rtd)
-        _update_build_step_for_pixi(rtd)
+        _update_build_step_for_pixi(rtd, session=session)
     elif package_manager == "uv":
         apt_packages = set(rtd.document.get("build", {}).get("apt_packages", []))
         pixi_packages = apt_packages & {"graphviz"}
@@ -205,9 +205,13 @@ def __remove_nested_key(dct: dict, dotted_key: str) -> bool:
     return True
 
 
-def _update_build_step_for_pixi(config: ReadTheDocs) -> None:
+def _update_build_step_for_pixi(
+    config: ReadTheDocs,
+    *,
+    session: Session | None = None,
+) -> None:
     new_command = __get_pixi_install_statement() + "\n"
-    pyproject = Pyproject.load()
+    pyproject = Pyproject.load(session=session)
     docs_dir = _determine_docs_dir()
     if has_dependency(pyproject, "poethepoet"):
         new_command += dedent(Rf"""

--- a/src/compwa_policy/repo/vscode.py
+++ b/src/compwa_policy/repo/vscode.py
@@ -25,7 +25,7 @@ def main(
     )
 
 
-def _update_extensions(*, session: Session | None = None) -> Changelog:
+def _update_extensions(*, session: Session) -> Changelog:
     changes = vscode.add_extension_recommendation(
         "eamodio.gitlens", session=session
     )  # cspell:ignore eamodio
@@ -61,7 +61,7 @@ def _update_settings(
     is_python_repo: bool,
     package_manager: PackageManagerChoice,
     *,
-    session: Session | None = None,
+    session: Session,
 ) -> Changelog:
     changes = vscode.update_settings(
         {
@@ -115,7 +115,7 @@ def _update_settings(
     return changes
 
 
-def _remove_outdated_settings(*, session: Session | None = None) -> Changelog:
+def _remove_outdated_settings(*, session: Session) -> Changelog:
     outdated_settings = [
         "editor.rulers",
         "githubPullRequests.telemetry.enabled",
@@ -136,7 +136,7 @@ def _remove_outdated_settings(*, session: Session | None = None) -> Changelog:
     return vscode.remove_settings(outdated_settings, session=session)
 
 
-def _update_doc_settings(*, session: Session | None = None) -> Changelog:
+def _update_doc_settings(*, session: Session) -> Changelog:
     if not os.path.exists("docs/"):
         return []
     changes = vscode.update_settings(
@@ -152,7 +152,7 @@ def _update_doc_settings(*, session: Session | None = None) -> Changelog:
     return changes
 
 
-def _update_notebook_settings(*, session: Session | None = None) -> Changelog:
+def _update_notebook_settings(*, session: Session) -> Changelog:
     """https://code.visualstudio.com/updates/v1_83#_go-to-symbol-in-notebooks."""
     if not os.path.exists("docs/"):
         return []
@@ -161,7 +161,7 @@ def _update_notebook_settings(*, session: Session | None = None) -> Changelog:
     )
 
 
-def _update_pytest_settings(*, session: Session | None = None) -> Changelog:
+def _update_pytest_settings(*, session: Session) -> Changelog:
     if not os.path.exists("tests/"):
         return []
     return vscode.update_settings(

--- a/src/compwa_policy/repo/vscode.py
+++ b/src/compwa_policy/repo/vscode.py
@@ -24,31 +24,23 @@ def main(
 
 
 def _update_extensions(session: Session, /) -> None:
-    vscode.add_extension_recommendation(
-        session, "eamodio.gitlens"
-    )  # cspell:ignore eamodio
-    vscode.add_extension_recommendation(
-        session, "mhutchie.git-graph"
-    )  # cspell:ignore mhutchie
-    vscode.add_extension_recommendation(
-        session, "soulcode.vscode-unwanted-extensions"
-    )  # cspell:ignore Soulcode
-    vscode.add_extension_recommendation(session, "stkb.rewrap")  # cspell:ignore stkb
+    # cspell:disable
+    vscode.add_extension_recommendation(session, "eamodio.gitlens")
+    vscode.add_extension_recommendation(session, "mhutchie.git-graph")
+    vscode.add_extension_recommendation(session, "soulcode.vscode-unwanted-extensions")
+    vscode.add_extension_recommendation(session, "stkb.rewrap")
     vscode.remove_extension_recommendation(
         session,
-        "garaioag.garaio-vscode-unwanted-recommendations",  # cspell:ignore garaio garaioag
+        "garaioag.garaio-vscode-unwanted-recommendations",
         unwanted=True,
     )
     vscode.remove_extension_recommendation(
         session,
-        "travisillig.vscode-json-stable-stringify",  # cspell:ignore travisillig
+        "travisillig.vscode-json-stable-stringify",
         unwanted=True,
     )
-    vscode.remove_extension_recommendation(
-        session,
-        "tyriar.sort-lines",  # cspell:ignore tyriar
-        unwanted=True,
-    )
+    vscode.remove_extension_recommendation(session, "tyriar.sort-lines", unwanted=True)
+    # cspell:enable
 
 
 def _update_settings(

--- a/src/compwa_policy/repo/vscode.py
+++ b/src/compwa_policy/repo/vscode.py
@@ -19,84 +19,103 @@ def main(
     is_python_repo: bool,
     package_manager: PackageManagerChoice,
 ) -> None:
-    session.changelog += _update_extensions()
+    session.changelog += _update_extensions(session=session)
     session.changelog += _update_settings(
-        has_notebooks, is_python_repo, package_manager
+        has_notebooks, is_python_repo, package_manager, session=session
     )
 
 
-def _update_extensions() -> Changelog:
+def _update_extensions(*, session: Session | None = None) -> Changelog:
     changes = vscode.add_extension_recommendation(
-        "eamodio.gitlens"
+        "eamodio.gitlens", session=session
     )  # cspell:ignore eamodio
     changes += vscode.add_extension_recommendation(
-        "mhutchie.git-graph"
+        "mhutchie.git-graph", session=session
     )  # cspell:ignore mhutchie
     changes += vscode.add_extension_recommendation(
-        "soulcode.vscode-unwanted-extensions"
+        "soulcode.vscode-unwanted-extensions", session=session
     )  # cspell:ignore Soulcode
-    changes += vscode.add_extension_recommendation("stkb.rewrap")  # cspell:ignore stkb
+    changes += vscode.add_extension_recommendation(
+        "stkb.rewrap", session=session
+    )  # cspell:ignore stkb
     changes += vscode.remove_extension_recommendation(
         "garaioag.garaio-vscode-unwanted-recommendations",  # cspell:ignore garaio garaioag
         unwanted=True,
+        session=session,
     )
     changes += vscode.remove_extension_recommendation(
         "travisillig.vscode-json-stable-stringify",  # cspell:ignore travisillig
         unwanted=True,
+        session=session,
     )
     changes += vscode.remove_extension_recommendation(
         "tyriar.sort-lines",  # cspell:ignore tyriar
         unwanted=True,
+        session=session,
     )
     return changes
 
 
 def _update_settings(
-    has_notebooks: bool, is_python_repo: bool, package_manager: PackageManagerChoice
+    has_notebooks: bool,
+    is_python_repo: bool,
+    package_manager: PackageManagerChoice,
+    *,
+    session: Session | None = None,
 ) -> Changelog:
-    changes = vscode.update_settings({
-        "diffEditor.experimental.showMoves": True,
-        "editor.formatOnSave": True,
-        "gitlens.telemetry.enabled": False,
-        "multiDiffEditor.experimental.enabled": True,
-        "redhat.telemetry.enabled": False,
-        "telemetry.telemetryLevel": "off",
-    })
-    changes += vscode.update_settings({
-        "[git-commit]": {
-            "editor.rulers": [72],
-            "rewrap.wrappingColumn": 72,
+    changes = vscode.update_settings(
+        {
+            "diffEditor.experimental.showMoves": True,
+            "editor.formatOnSave": True,
+            "gitlens.telemetry.enabled": False,
+            "multiDiffEditor.experimental.enabled": True,
+            "redhat.telemetry.enabled": False,
+            "telemetry.telemetryLevel": "off",
         },
-        "[json]": {
-            "editor.wordWrap": "on",
+        session=session,
+    )
+    changes += vscode.update_settings(
+        {
+            "[git-commit]": {
+                "editor.rulers": [72],
+                "rewrap.wrappingColumn": 72,
+            },
+            "[json]": {
+                "editor.wordWrap": "on",
+            },
         },
-    })
-    changes += _remove_outdated_settings()
-    changes += _update_doc_settings()
+        session=session,
+    )
+    changes += _remove_outdated_settings(session=session)
+    changes += _update_doc_settings(session=session)
     if has_notebooks:
-        changes += _update_notebook_settings()
-    changes += _update_pytest_settings()
+        changes += _update_notebook_settings(session=session)
+    changes += _update_pytest_settings(session=session)
     if has_constraint_files():
-        changes += vscode.update_settings({
-            "files.associations": {"**/.constraints/py*.txt": "pip-requirements"}
-        })
+        changes += vscode.update_settings(
+            {"files.associations": {"**/.constraints/py*.txt": "pip-requirements"}},
+            session=session,
+        )
     if is_python_repo:
         if package_manager == "pixi":
             python_path = ".pixi/envs/default/bin/python"
         else:
             python_path = ".venv/bin/python"
-        changes += vscode.update_settings({
-            "python.defaultInterpreterPath": python_path,
-            "rewrap.wrappingColumn": 88,
-        })
+        changes += vscode.update_settings(
+            {
+                "python.defaultInterpreterPath": python_path,
+                "rewrap.wrappingColumn": 88,
+            },
+            session=session,
+        )
         if CONFIG_PATH.envrc.exists():
-            changes += vscode.update_settings({
-                "python.terminal.activateEnvironment": False
-            })
+            changes += vscode.update_settings(
+                {"python.terminal.activateEnvironment": False}, session=session
+            )
     return changes
 
 
-def _remove_outdated_settings() -> Changelog:
+def _remove_outdated_settings(*, session: Session | None = None) -> Changelog:
     outdated_settings = [
         "editor.rulers",
         "githubPullRequests.telemetry.enabled",
@@ -114,34 +133,41 @@ def _remove_outdated_settings() -> Changelog:
         "telemetry.enableCrashReporter",
         "telemetry.enableTelemetry",
     ]
-    return vscode.remove_settings(outdated_settings)
+    return vscode.remove_settings(outdated_settings, session=session)
 
 
-def _update_doc_settings() -> Changelog:
+def _update_doc_settings(*, session: Session | None = None) -> Changelog:
     if not os.path.exists("docs/"):
         return []
-    changes = vscode.update_settings({
-        "livePreview.defaultPreviewPath": "docs/_build/html"
-    })
-    changes += vscode.add_extension_recommendation("ms-vscode.live-server")
+    changes = vscode.update_settings(
+        {"livePreview.defaultPreviewPath": "docs/_build/html"}, session=session
+    )
+    changes += vscode.add_extension_recommendation(
+        "ms-vscode.live-server", session=session
+    )
     # cspell:ignore executablebookproject
     myst_extension = "executablebookproject.myst-highlight"
-    if myst_extension not in vscode.get_unwanted_extensions():
-        changes += vscode.add_extension_recommendation(myst_extension)
+    if myst_extension not in vscode.get_unwanted_extensions(session=session):
+        changes += vscode.add_extension_recommendation(myst_extension, session=session)
     return changes
 
 
-def _update_notebook_settings() -> Changelog:
+def _update_notebook_settings(*, session: Session | None = None) -> Changelog:
     """https://code.visualstudio.com/updates/v1_83#_go-to-symbol-in-notebooks."""
     if not os.path.exists("docs/"):
         return []
-    return vscode.update_settings({"notebook.gotoSymbols.showAllSymbols": True})
+    return vscode.update_settings(
+        {"notebook.gotoSymbols.showAllSymbols": True}, session=session
+    )
 
 
-def _update_pytest_settings() -> Changelog:
+def _update_pytest_settings(*, session: Session | None = None) -> Changelog:
     if not os.path.exists("tests/"):
         return []
-    return vscode.update_settings({
-        "python.testing.pytestEnabled": True,
-        "python.testing.unittestEnabled": False,
-    })
+    return vscode.update_settings(
+        {
+            "python.testing.pytestEnabled": True,
+            "python.testing.unittestEnabled": False,
+        },
+        session=session,
+    )

--- a/src/compwa_policy/repo/vscode.py
+++ b/src/compwa_policy/repo/vscode.py
@@ -10,7 +10,7 @@ from compwa_policy.utilities.python import has_constraint_files
 
 if TYPE_CHECKING:
     from compwa_policy.env.conda import PackageManagerChoice
-    from compwa_policy.utilities.session import Changelog, Session
+    from compwa_policy.utilities.session import Session
 
 
 def main(
@@ -19,41 +19,36 @@ def main(
     is_python_repo: bool,
     package_manager: PackageManagerChoice,
 ) -> None:
-    session.changelog += _update_extensions(session)
-    session.changelog += _update_settings(
-        session, has_notebooks, is_python_repo, package_manager
-    )
+    _update_extensions(session)
+    _update_settings(session, has_notebooks, is_python_repo, package_manager)
 
 
-def _update_extensions(session: Session, /) -> Changelog:
-    changes = vscode.add_extension_recommendation(
+def _update_extensions(session: Session, /) -> None:
+    vscode.add_extension_recommendation(
         session, "eamodio.gitlens"
     )  # cspell:ignore eamodio
-    changes += vscode.add_extension_recommendation(
+    vscode.add_extension_recommendation(
         session, "mhutchie.git-graph"
     )  # cspell:ignore mhutchie
-    changes += vscode.add_extension_recommendation(
+    vscode.add_extension_recommendation(
         session, "soulcode.vscode-unwanted-extensions"
     )  # cspell:ignore Soulcode
-    changes += vscode.add_extension_recommendation(
-        session, "stkb.rewrap"
-    )  # cspell:ignore stkb
-    changes += vscode.remove_extension_recommendation(
+    vscode.add_extension_recommendation(session, "stkb.rewrap")  # cspell:ignore stkb
+    vscode.remove_extension_recommendation(
         session,
         "garaioag.garaio-vscode-unwanted-recommendations",  # cspell:ignore garaio garaioag
         unwanted=True,
     )
-    changes += vscode.remove_extension_recommendation(
+    vscode.remove_extension_recommendation(
         session,
         "travisillig.vscode-json-stable-stringify",  # cspell:ignore travisillig
         unwanted=True,
     )
-    changes += vscode.remove_extension_recommendation(
+    vscode.remove_extension_recommendation(
         session,
         "tyriar.sort-lines",  # cspell:ignore tyriar
         unwanted=True,
     )
-    return changes
 
 
 def _update_settings(
@@ -62,8 +57,8 @@ def _update_settings(
     has_notebooks: bool,
     is_python_repo: bool,
     package_manager: PackageManagerChoice,
-) -> Changelog:
-    changes = vscode.update_settings(
+) -> None:
+    vscode.update_settings(
         session,
         {
             "diffEditor.experimental.showMoves": True,
@@ -74,7 +69,7 @@ def _update_settings(
             "telemetry.telemetryLevel": "off",
         },
     )
-    changes += vscode.update_settings(
+    vscode.update_settings(
         session,
         {
             "[git-commit]": {
@@ -86,13 +81,13 @@ def _update_settings(
             },
         },
     )
-    changes += _remove_outdated_settings(session)
-    changes += _update_doc_settings(session)
+    _remove_outdated_settings(session)
+    _update_doc_settings(session)
     if has_notebooks:
-        changes += _update_notebook_settings(session)
-    changes += _update_pytest_settings(session)
+        _update_notebook_settings(session)
+    _update_pytest_settings(session)
     if has_constraint_files():
-        changes += vscode.update_settings(
+        vscode.update_settings(
             session,
             {"files.associations": {"**/.constraints/py*.txt": "pip-requirements"}},
         )
@@ -101,7 +96,7 @@ def _update_settings(
             python_path = ".pixi/envs/default/bin/python"
         else:
             python_path = ".venv/bin/python"
-        changes += vscode.update_settings(
+        vscode.update_settings(
             session,
             {
                 "python.defaultInterpreterPath": python_path,
@@ -109,13 +104,12 @@ def _update_settings(
             },
         )
         if CONFIG_PATH.envrc.exists():
-            changes += vscode.update_settings(
+            vscode.update_settings(
                 session, {"python.terminal.activateEnvironment": False}
             )
-    return changes
 
 
-def _remove_outdated_settings(session: Session, /) -> Changelog:
+def _remove_outdated_settings(session: Session, /) -> None:
     outdated_settings = [
         "editor.rulers",
         "githubPullRequests.telemetry.enabled",
@@ -133,36 +127,33 @@ def _remove_outdated_settings(session: Session, /) -> Changelog:
         "telemetry.enableCrashReporter",
         "telemetry.enableTelemetry",
     ]
-    return vscode.remove_settings(session, outdated_settings)
+    vscode.remove_settings(session, outdated_settings)
 
 
-def _update_doc_settings(session: Session, /) -> Changelog:
+def _update_doc_settings(session: Session, /) -> None:
     if not os.path.exists("docs/"):
-        return []
-    changes = vscode.update_settings(
+        return
+    vscode.update_settings(
         session, {"livePreview.defaultPreviewPath": "docs/_build/html"}
     )
-    changes += vscode.add_extension_recommendation(session, "ms-vscode.live-server")
+    vscode.add_extension_recommendation(session, "ms-vscode.live-server")
     # cspell:ignore executablebookproject
     myst_extension = "executablebookproject.myst-highlight"
     if myst_extension not in vscode.get_unwanted_extensions(session):
-        changes += vscode.add_extension_recommendation(session, myst_extension)
-    return changes
+        vscode.add_extension_recommendation(session, myst_extension)
 
 
-def _update_notebook_settings(session: Session, /) -> Changelog:
+def _update_notebook_settings(session: Session, /) -> None:
     """https://code.visualstudio.com/updates/v1_83#_go-to-symbol-in-notebooks."""
     if not os.path.exists("docs/"):
-        return []
-    return vscode.update_settings(
-        session, {"notebook.gotoSymbols.showAllSymbols": True}
-    )
+        return
+    vscode.update_settings(session, {"notebook.gotoSymbols.showAllSymbols": True})
 
 
-def _update_pytest_settings(session: Session, /) -> Changelog:
+def _update_pytest_settings(session: Session, /) -> None:
     if not os.path.exists("tests/"):
-        return []
-    return vscode.update_settings(
+        return
+    vscode.update_settings(
         session,
         {
             "python.testing.pytestEnabled": True,

--- a/src/compwa_policy/repo/vscode.py
+++ b/src/compwa_policy/repo/vscode.py
@@ -19,51 +19,52 @@ def main(
     is_python_repo: bool,
     package_manager: PackageManagerChoice,
 ) -> None:
-    session.changelog += _update_extensions(session=session)
+    session.changelog += _update_extensions(session)
     session.changelog += _update_settings(
-        has_notebooks, is_python_repo, package_manager, session=session
+        session, has_notebooks, is_python_repo, package_manager
     )
 
 
-def _update_extensions(*, session: Session) -> Changelog:
+def _update_extensions(session: Session, /) -> Changelog:
     changes = vscode.add_extension_recommendation(
-        "eamodio.gitlens", session=session
+        session, "eamodio.gitlens"
     )  # cspell:ignore eamodio
     changes += vscode.add_extension_recommendation(
-        "mhutchie.git-graph", session=session
+        session, "mhutchie.git-graph"
     )  # cspell:ignore mhutchie
     changes += vscode.add_extension_recommendation(
-        "soulcode.vscode-unwanted-extensions", session=session
+        session, "soulcode.vscode-unwanted-extensions"
     )  # cspell:ignore Soulcode
     changes += vscode.add_extension_recommendation(
-        "stkb.rewrap", session=session
+        session, "stkb.rewrap"
     )  # cspell:ignore stkb
     changes += vscode.remove_extension_recommendation(
+        session,
         "garaioag.garaio-vscode-unwanted-recommendations",  # cspell:ignore garaio garaioag
         unwanted=True,
-        session=session,
     )
     changes += vscode.remove_extension_recommendation(
+        session,
         "travisillig.vscode-json-stable-stringify",  # cspell:ignore travisillig
         unwanted=True,
-        session=session,
     )
     changes += vscode.remove_extension_recommendation(
+        session,
         "tyriar.sort-lines",  # cspell:ignore tyriar
         unwanted=True,
-        session=session,
     )
     return changes
 
 
 def _update_settings(
+    session: Session,
+    /,
     has_notebooks: bool,
     is_python_repo: bool,
     package_manager: PackageManagerChoice,
-    *,
-    session: Session,
 ) -> Changelog:
     changes = vscode.update_settings(
+        session,
         {
             "diffEditor.experimental.showMoves": True,
             "editor.formatOnSave": True,
@@ -72,9 +73,9 @@ def _update_settings(
             "redhat.telemetry.enabled": False,
             "telemetry.telemetryLevel": "off",
         },
-        session=session,
     )
     changes += vscode.update_settings(
+        session,
         {
             "[git-commit]": {
                 "editor.rulers": [72],
@@ -84,17 +85,16 @@ def _update_settings(
                 "editor.wordWrap": "on",
             },
         },
-        session=session,
     )
-    changes += _remove_outdated_settings(session=session)
-    changes += _update_doc_settings(session=session)
+    changes += _remove_outdated_settings(session)
+    changes += _update_doc_settings(session)
     if has_notebooks:
-        changes += _update_notebook_settings(session=session)
-    changes += _update_pytest_settings(session=session)
+        changes += _update_notebook_settings(session)
+    changes += _update_pytest_settings(session)
     if has_constraint_files():
         changes += vscode.update_settings(
+            session,
             {"files.associations": {"**/.constraints/py*.txt": "pip-requirements"}},
-            session=session,
         )
     if is_python_repo:
         if package_manager == "pixi":
@@ -102,20 +102,20 @@ def _update_settings(
         else:
             python_path = ".venv/bin/python"
         changes += vscode.update_settings(
+            session,
             {
                 "python.defaultInterpreterPath": python_path,
                 "rewrap.wrappingColumn": 88,
             },
-            session=session,
         )
         if CONFIG_PATH.envrc.exists():
             changes += vscode.update_settings(
-                {"python.terminal.activateEnvironment": False}, session=session
+                session, {"python.terminal.activateEnvironment": False}
             )
     return changes
 
 
-def _remove_outdated_settings(*, session: Session) -> Changelog:
+def _remove_outdated_settings(session: Session, /) -> Changelog:
     outdated_settings = [
         "editor.rulers",
         "githubPullRequests.telemetry.enabled",
@@ -133,41 +133,39 @@ def _remove_outdated_settings(*, session: Session) -> Changelog:
         "telemetry.enableCrashReporter",
         "telemetry.enableTelemetry",
     ]
-    return vscode.remove_settings(outdated_settings, session=session)
+    return vscode.remove_settings(session, outdated_settings)
 
 
-def _update_doc_settings(*, session: Session) -> Changelog:
+def _update_doc_settings(session: Session, /) -> Changelog:
     if not os.path.exists("docs/"):
         return []
     changes = vscode.update_settings(
-        {"livePreview.defaultPreviewPath": "docs/_build/html"}, session=session
+        session, {"livePreview.defaultPreviewPath": "docs/_build/html"}
     )
-    changes += vscode.add_extension_recommendation(
-        "ms-vscode.live-server", session=session
-    )
+    changes += vscode.add_extension_recommendation(session, "ms-vscode.live-server")
     # cspell:ignore executablebookproject
     myst_extension = "executablebookproject.myst-highlight"
-    if myst_extension not in vscode.get_unwanted_extensions(session=session):
-        changes += vscode.add_extension_recommendation(myst_extension, session=session)
+    if myst_extension not in vscode.get_unwanted_extensions(session):
+        changes += vscode.add_extension_recommendation(session, myst_extension)
     return changes
 
 
-def _update_notebook_settings(*, session: Session) -> Changelog:
+def _update_notebook_settings(session: Session, /) -> Changelog:
     """https://code.visualstudio.com/updates/v1_83#_go-to-symbol-in-notebooks."""
     if not os.path.exists("docs/"):
         return []
     return vscode.update_settings(
-        {"notebook.gotoSymbols.showAllSymbols": True}, session=session
+        session, {"notebook.gotoSymbols.showAllSymbols": True}
     )
 
 
-def _update_pytest_settings(*, session: Session) -> Changelog:
+def _update_pytest_settings(session: Session, /) -> Changelog:
     if not os.path.exists("tests/"):
         return []
     return vscode.update_settings(
+        session,
         {
             "python.testing.pytestEnabled": True,
             "python.testing.unittestEnabled": False,
         },
-        session=session,
     )

--- a/src/compwa_policy/utilities/__init__.py
+++ b/src/compwa_policy/utilities/__init__.py
@@ -9,9 +9,9 @@ from pathlib import Path
 from typing import TYPE_CHECKING, NamedTuple
 
 import compwa_policy
-from compwa_policy.utilities.resource import ModifiablePath
 
 if TYPE_CHECKING:
+    from compwa_policy.utilities.resource import ModifiablePath
     from compwa_policy.utilities.session import Changelog, Session
 
 
@@ -48,9 +48,7 @@ CONFIG_PATH = _ConfigFilePaths()
 COMPWA_POLICY_DIR = Path(compwa_policy.__file__).parent.absolute()
 
 
-def append_safe(
-    expected_line: str, path: Path, *, session: Session | None = None
-) -> bool:
+def append_safe(expected_line: str, path: Path, *, session: Session) -> bool:
     """Add a line to a file if it is not already present."""
     resource = _get_path_resource(path, session=session)
     lines = resource.read_text().splitlines() if resource.exists else []
@@ -58,7 +56,6 @@ def append_safe(
         return False
     content = resource.read_text() if resource.exists else ""
     resource.write_text(content + expected_line + "\n")
-    _dump_without_session(resource, session=session)
     return True
 
 
@@ -122,49 +119,29 @@ def write(
         raise TypeError(msg)
 
 
-def remove_configs(paths: list[str], *, session: Session | None = None) -> Changelog:
-    changes: Changelog = []
+def remove_configs(paths: list[str], *, session: Session) -> Changelog:
     for path in paths:
         resource = _get_path_resource(path, session=session)
-        message = f"Removed {path}"
-        if resource.remove(message):
-            changes.append(message)
-            _dump_without_session(resource, session=session)
-    return [] if session is not None else changes
+        resource.remove(f"Removed {path}")
+    return []
 
 
 def _get_path_resource(
     path: Path | str,
     *,
-    session: Session | None = None,
+    session: Session,
 ) -> ModifiablePath:
     normalized = Path(path)
-    if session is not None:
-        return session.get_path(normalized)
-    return ModifiablePath.load_path(normalized)
+    return session.get_path(normalized)
 
 
-def _dump_without_session(
-    resource: ModifiablePath,
-    *,
-    session: Session | None = None,
-) -> None:
-    if session is None and resource.changed:
-        resource.dump()
-
-
-def __remove_file(path: str, *, session: Session | None = None) -> Changelog:
+def __remove_file(path: str, *, session: Session) -> Changelog:
     resource = _get_path_resource(path, session=session)
-    message = f"Removed {path}"
-    if not resource.remove(message):
-        return []
-    _dump_without_session(resource, session=session)
-    if session is not None:
-        return []
-    return [message]
+    resource.remove(f"Removed {path}")
+    return []
 
 
-def rename_file(old: str, new: str, *, session: Session | None = None) -> Changelog:
+def rename_file(old: str, new: str, *, session: Session) -> Changelog:
     source = _get_path_resource(old, session=session)
     if not source.exists:
         return []
@@ -173,9 +150,7 @@ def rename_file(old: str, new: str, *, session: Session | None = None) -> Change
     target = _get_path_resource(new, session=session)
     target.write_text(content, message)
     source.remove()
-    _dump_without_session(target, session=session)
-    _dump_without_session(source, session=session)
-    return [] if session is not None else [message]
+    return []
 
 
 def remove_lines(
@@ -183,7 +158,7 @@ def remove_lines(
     pattern: str,
     flags: re.RegexFlag = re.IGNORECASE,
     *,
-    session: Session | None = None,
+    session: Session,
 ) -> Changelog:
     resource = _get_path_resource(file, session=session)
     if not resource.exists:
@@ -195,14 +170,12 @@ def remove_lines(
             f"Removed {pattern!r} from {file} and removed file because it was empty."
         )
         resource.remove(message)
-        _dump_without_session(resource, session=session)
-        return [] if session is not None else [message]
+        return []
     if len(filtered_lines) == len(lines):
         return []
     message = f"Removed {pattern!r} from {file}"
     resource.write_text("".join(filtered_lines), message)
-    _dump_without_session(resource, session=session)
-    return [] if session is not None else [message]
+    return []
 
 
 def natural_sorting(text: str) -> list[float | str]:
@@ -217,7 +190,7 @@ def update_file(
     relative_path: Path,
     in_template_folder: bool = False,
     *,
-    session: Session | None = None,
+    session: Session,
 ) -> Changelog:
     if in_template_folder:
         template_dir = COMPWA_POLICY_DIR / ".template"
@@ -229,14 +202,12 @@ def update_file(
     if not resource.exists:
         message = f"{relative_path} is missing, so created a new one. Please commit it."
         resource.write_text(expected_content, message)
-        _dump_without_session(resource, session=session)
-        return [] if session is not None else [message]
+        return []
     existing_content = resource.read_text()
     if expected_content != existing_content:
         message = f"{relative_path} has been updated."
         resource.write_text(expected_content, message)
-        _dump_without_session(resource, session=session)
-        return [] if session is not None else [message]
+        return []
     return []
 
 

--- a/src/compwa_policy/utilities/__init__.py
+++ b/src/compwa_policy/utilities/__init__.py
@@ -9,10 +9,10 @@ from pathlib import Path
 from typing import TYPE_CHECKING, NamedTuple
 
 import compwa_policy
-from compwa_policy.utilities.resource import ModifiablePath, get_active_session
+from compwa_policy.utilities.resource import ModifiablePath
 
 if TYPE_CHECKING:
-    from compwa_policy.utilities.session import Changelog
+    from compwa_policy.utilities.session import Changelog, Session
 
 
 class _ConfigFilePaths(NamedTuple):
@@ -48,15 +48,17 @@ CONFIG_PATH = _ConfigFilePaths()
 COMPWA_POLICY_DIR = Path(compwa_policy.__file__).parent.absolute()
 
 
-def append_safe(expected_line: str, path: Path) -> bool:
+def append_safe(
+    expected_line: str, path: Path, *, session: Session | None = None
+) -> bool:
     """Add a line to a file if it is not already present."""
-    resource = _get_path_resource(path)
+    resource = _get_path_resource(path, session=session)
     lines = resource.read_text().splitlines() if resource.exists else []
     if expected_line in {line.strip() for line in lines}:
         return False
     content = resource.read_text() if resource.exists else ""
     resource.write_text(content + expected_line + "\n")
-    _dump_without_session(resource)
+    _dump_without_session(resource, session=session)
     return True
 
 
@@ -82,10 +84,14 @@ def hash_file(path: Path | str) -> str:
     return sha256.hexdigest()
 
 
-def read(input: Path | io.TextIOBase | str) -> str:  # noqa: A002
+def read(
+    input: Path | io.TextIOBase | str,  # noqa: A002
+    *,
+    session: Session | None = None,
+) -> str:
     if isinstance(input, (Path, str)):
-        if get_active_session() is not None:
-            return _get_path_resource(input).read_text()
+        if session is not None:
+            return _get_path_resource(input, session=session).read_text()
         with open(input) as input_stream:
             return input_stream.read()
     if isinstance(input, io.TextIOBase):
@@ -94,12 +100,17 @@ def read(input: Path | io.TextIOBase | str) -> str:  # noqa: A002
     raise TypeError(msg)
 
 
-def write(content: str, target: Path | io.TextIOBase | str) -> None:
+def write(
+    content: str,
+    target: Path | io.TextIOBase | str,
+    *,
+    session: Session | None = None,
+) -> None:
     if isinstance(target, str):
         target = Path(target)
     if isinstance(target, Path):
-        if get_active_session() is not None:
-            _get_path_resource(target).write_text(content)
+        if session is not None:
+            _get_path_resource(target, session=session).write_text(content)
             return
         target.parent.mkdir(exist_ok=True)
         with open(target, "w") as output_stream:
@@ -111,59 +122,70 @@ def write(content: str, target: Path | io.TextIOBase | str) -> None:
         raise TypeError(msg)
 
 
-def remove_configs(paths: list[str]) -> Changelog:
+def remove_configs(paths: list[str], *, session: Session | None = None) -> Changelog:
     changes: Changelog = []
     for path in paths:
-        resource = _get_path_resource(path)
+        resource = _get_path_resource(path, session=session)
         message = f"Removed {path}"
         if resource.remove(message):
             changes.append(message)
-            _dump_without_session(resource)
-    return [] if get_active_session() is not None else changes
+            _dump_without_session(resource, session=session)
+    return [] if session is not None else changes
 
 
-def _get_path_resource(path: Path | str) -> ModifiablePath:
+def _get_path_resource(
+    path: Path | str,
+    *,
+    session: Session | None = None,
+) -> ModifiablePath:
     normalized = Path(path)
-    session = get_active_session()
     if session is not None:
         return session.get_path(normalized)
     return ModifiablePath.load_path(normalized)
 
 
-def _dump_without_session(resource: ModifiablePath) -> None:
-    if get_active_session() is None and resource.changed:
+def _dump_without_session(
+    resource: ModifiablePath,
+    *,
+    session: Session | None = None,
+) -> None:
+    if session is None and resource.changed:
         resource.dump()
 
 
-def __remove_file(path: str) -> Changelog:
-    resource = _get_path_resource(path)
+def __remove_file(path: str, *, session: Session | None = None) -> Changelog:
+    resource = _get_path_resource(path, session=session)
     message = f"Removed {path}"
     if not resource.remove(message):
         return []
-    _dump_without_session(resource)
-    if get_active_session() is not None:
+    _dump_without_session(resource, session=session)
+    if session is not None:
         return []
     return [message]
 
 
-def rename_file(old: str, new: str) -> Changelog:
-    source = _get_path_resource(old)
+def rename_file(old: str, new: str, *, session: Session | None = None) -> Changelog:
+    source = _get_path_resource(old, session=session)
     if not source.exists:
         return []
     content = source.read_text()
     message = f"File {old} has been renamed to {new}"
-    target = _get_path_resource(new)
+    target = _get_path_resource(new, session=session)
     target.write_text(content, message)
     source.remove()
-    _dump_without_session(target)
-    _dump_without_session(source)
-    return [] if get_active_session() is not None else [message]
+    _dump_without_session(target, session=session)
+    _dump_without_session(source, session=session)
+    return [] if session is not None else [message]
 
 
 def remove_lines(
-    file: Path, pattern: str, flags: re.RegexFlag = re.IGNORECASE
+    file: Path,
+    pattern: str,
+    flags: re.RegexFlag = re.IGNORECASE,
+    *,
+    session: Session | None = None,
 ) -> Changelog:
-    resource = _get_path_resource(file)
+    resource = _get_path_resource(file, session=session)
     if not resource.exists:
         return []
     lines = resource.read_text().splitlines(True)
@@ -173,14 +195,14 @@ def remove_lines(
             f"Removed {pattern!r} from {file} and removed file because it was empty."
         )
         resource.remove(message)
-        _dump_without_session(resource)
-        return [] if get_active_session() is not None else [message]
+        _dump_without_session(resource, session=session)
+        return [] if session is not None else [message]
     if len(filtered_lines) == len(lines):
         return []
     message = f"Removed {pattern!r} from {file}"
     resource.write_text("".join(filtered_lines), message)
-    _dump_without_session(resource)
-    return [] if get_active_session() is not None else [message]
+    _dump_without_session(resource, session=session)
+    return [] if session is not None else [message]
 
 
 def natural_sorting(text: str) -> list[float | str]:
@@ -191,25 +213,30 @@ def natural_sorting(text: str) -> list[float | str]:
     ]
 
 
-def update_file(relative_path: Path, in_template_folder: bool = False) -> Changelog:
+def update_file(
+    relative_path: Path,
+    in_template_folder: bool = False,
+    *,
+    session: Session | None = None,
+) -> Changelog:
     if in_template_folder:
         template_dir = COMPWA_POLICY_DIR / ".template"
     else:
         template_dir = COMPWA_POLICY_DIR
     template_path = template_dir / relative_path
     expected_content = template_path.read_text()
-    resource = _get_path_resource(relative_path)
+    resource = _get_path_resource(relative_path, session=session)
     if not resource.exists:
         message = f"{relative_path} is missing, so created a new one. Please commit it."
         resource.write_text(expected_content, message)
-        _dump_without_session(resource)
-        return [] if get_active_session() is not None else [message]
+        _dump_without_session(resource, session=session)
+        return [] if session is not None else [message]
     existing_content = resource.read_text()
     if expected_content != existing_content:
         message = f"{relative_path} has been updated."
         resource.write_text(expected_content, message)
-        _dump_without_session(resource)
-        return [] if get_active_session() is not None else [message]
+        _dump_without_session(resource, session=session)
+        return [] if session is not None else [message]
     return []
 
 

--- a/src/compwa_policy/utilities/__init__.py
+++ b/src/compwa_policy/utilities/__init__.py
@@ -4,15 +4,12 @@ from __future__ import annotations
 
 import hashlib
 import io
-import os
 import re
-import shutil
 from pathlib import Path
-from shutil import copyfile
 from typing import TYPE_CHECKING, NamedTuple
 
 import compwa_policy
-from compwa_policy.utilities.resource import ModifiableConfigFiles, get_active_session
+from compwa_policy.utilities.resource import ModifiablePath, get_active_session
 
 if TYPE_CHECKING:
     from compwa_policy.utilities.session import Changelog
@@ -53,10 +50,13 @@ COMPWA_POLICY_DIR = Path(compwa_policy.__file__).parent.absolute()
 
 def append_safe(expected_line: str, path: Path) -> bool:
     """Add a line to a file if it is not already present."""
-    if path.exists() and contains_line(path, expected_line):
+    resource = _get_path_resource(path)
+    lines = resource.read_text().splitlines() if resource.exists else []
+    if expected_line in {line.strip() for line in lines}:
         return False
-    with path.open("a") as stream:
-        stream.write(expected_line + "\n")
+    content = resource.read_text() if resource.exists else ""
+    resource.write_text(content + expected_line + "\n")
+    _dump_without_session(resource)
     return True
 
 
@@ -84,6 +84,8 @@ def hash_file(path: Path | str) -> str:
 
 def read(input: Path | io.TextIOBase | str) -> str:  # noqa: A002
     if isinstance(input, (Path, str)):
+        if get_active_session() is not None:
+            return _get_path_resource(input).read_text()
         with open(input) as input_stream:
             return input_stream.read()
     if isinstance(input, io.TextIOBase):
@@ -96,6 +98,9 @@ def write(content: str, target: Path | io.TextIOBase | str) -> None:
     if isinstance(target, str):
         target = Path(target)
     if isinstance(target, Path):
+        if get_active_session() is not None:
+            _get_path_resource(target).write_text(content)
+            return
         target.parent.mkdir(exist_ok=True)
         with open(target, "w") as output_stream:
             output_stream.write(content)
@@ -107,51 +112,75 @@ def write(content: str, target: Path | io.TextIOBase | str) -> None:
 
 
 def remove_configs(paths: list[str]) -> Changelog:
-    session = get_active_session()
-    if session is not None:
-        session.get(ModifiableConfigFiles).remove(paths)
-        return []
     changes: Changelog = []
     for path in paths:
-        changes += __remove_file(path)
-    return changes
+        resource = _get_path_resource(path)
+        message = f"Removed {path}"
+        if resource.remove(message):
+            changes.append(message)
+            _dump_without_session(resource)
+    return [] if get_active_session() is not None else changes
+
+
+def _get_path_resource(path: Path | str) -> ModifiablePath:
+    normalized = Path(path)
+    session = get_active_session()
+    if session is not None:
+        return session.get_path(normalized)
+    return ModifiablePath.load_path(normalized)
+
+
+def _dump_without_session(resource: ModifiablePath) -> None:
+    if get_active_session() is None and resource.changed:
+        resource.dump()
 
 
 def __remove_file(path: str) -> Changelog:
-    if not os.path.exists(path):
+    resource = _get_path_resource(path)
+    message = f"Removed {path}"
+    if not resource.remove(message):
         return []
-    if os.path.isdir(path):
-        shutil.rmtree(path)
-    else:
-        os.remove(path)
-    return [f"Removed {path}"]
+    _dump_without_session(resource)
+    if get_active_session() is not None:
+        return []
+    return [message]
 
 
 def rename_file(old: str, new: str) -> Changelog:
-    if os.path.exists(old):
-        os.rename(old, new)
-        return [f"File {old} has been renamed to {new}"]
-    return []
+    source = _get_path_resource(old)
+    if not source.exists:
+        return []
+    content = source.read_text()
+    message = f"File {old} has been renamed to {new}"
+    target = _get_path_resource(new)
+    target.write_text(content, message)
+    source.remove()
+    _dump_without_session(target)
+    _dump_without_session(source)
+    return [] if get_active_session() is not None else [message]
 
 
 def remove_lines(
     file: Path, pattern: str, flags: re.RegexFlag = re.IGNORECASE
 ) -> Changelog:
-    if not file.exists():
+    resource = _get_path_resource(file)
+    if not resource.exists:
         return []
-    with open(file) as stream:
-        lines = stream.readlines()
+    lines = resource.read_text().splitlines(True)
     filtered_lines = [s for s in lines if not re.match(pattern, s.strip(), flags)]
     if not any(line.strip() for line in filtered_lines):
-        file.unlink()
-        return [
+        message = (
             f"Removed {pattern!r} from {file} and removed file because it was empty."
-        ]
+        )
+        resource.remove(message)
+        _dump_without_session(resource)
+        return [] if get_active_session() is not None else [message]
     if len(filtered_lines) == len(lines):
         return []
-    with open(file, "w") as stream:
-        stream.writelines(filtered_lines)
-    return [f"Removed {pattern!r} from {file}"]
+    message = f"Removed {pattern!r} from {file}"
+    resource.write_text("".join(filtered_lines), message)
+    _dump_without_session(resource)
+    return [] if get_active_session() is not None else [message]
 
 
 def natural_sorting(text: str) -> list[float | str]:
@@ -168,16 +197,19 @@ def update_file(relative_path: Path, in_template_folder: bool = False) -> Change
     else:
         template_dir = COMPWA_POLICY_DIR
     template_path = template_dir / relative_path
-    if not os.path.exists(relative_path):
-        copyfile(template_path, relative_path)
-        return [f"{relative_path} is missing, so created a new one. Please commit it."]
-    with open(template_path) as f:
-        expected_content = f.read()
-    with open(relative_path) as f:
-        existing_content = f.read()
+    expected_content = template_path.read_text()
+    resource = _get_path_resource(relative_path)
+    if not resource.exists:
+        message = f"{relative_path} is missing, so created a new one. Please commit it."
+        resource.write_text(expected_content, message)
+        _dump_without_session(resource)
+        return [] if get_active_session() is not None else [message]
+    existing_content = resource.read_text()
     if expected_content != existing_content:
-        copyfile(template_path, relative_path)
-        return [f"{relative_path} has been updated."]
+        message = f"{relative_path} has been updated."
+        resource.write_text(expected_content, message)
+        _dump_without_session(resource)
+        return [] if get_active_session() is not None else [message]
     return []
 
 

--- a/src/compwa_policy/utilities/__init__.py
+++ b/src/compwa_policy/utilities/__init__.py
@@ -12,7 +12,7 @@ import compwa_policy
 
 if TYPE_CHECKING:
     from compwa_policy.utilities.resource import ModifiablePath
-    from compwa_policy.utilities.session import Changelog, Session
+    from compwa_policy.utilities.session import Session
 
 
 class _ConfigFilePaths(NamedTuple):
@@ -119,11 +119,10 @@ def write(
         raise TypeError(msg)
 
 
-def remove_configs(session: Session, /, paths: list[str]) -> Changelog:
+def remove_configs(session: Session, /, paths: list[str]) -> None:
     for path in paths:
         resource = _get_path_resource(session, path)
         resource.remove(f"Removed {path}")
-    return []
 
 
 def _get_path_resource(session: Session, /, path: Path | str) -> ModifiablePath:
@@ -131,22 +130,20 @@ def _get_path_resource(session: Session, /, path: Path | str) -> ModifiablePath:
     return session.get_path(normalized)
 
 
-def __remove_file(session: Session, /, path: str) -> Changelog:
+def __remove_file(session: Session, /, path: str) -> None:
     resource = _get_path_resource(session, path)
     resource.remove(f"Removed {path}")
-    return []
 
 
-def rename_file(session: Session, /, old: str, new: str) -> Changelog:
+def rename_file(session: Session, /, old: str, new: str) -> None:
     source = _get_path_resource(session, old)
     if not source.exists:
-        return []
+        return
     content = source.read_text()
     message = f"File {old} has been renamed to {new}"
     target = _get_path_resource(session, new)
     target.write_text(content, message)
     source.remove()
-    return []
 
 
 def remove_lines(
@@ -155,10 +152,10 @@ def remove_lines(
     file: Path,
     pattern: str,
     flags: re.RegexFlag = re.IGNORECASE,
-) -> Changelog:
+) -> None:
     resource = _get_path_resource(session, file)
     if not resource.exists:
-        return []
+        return
     lines = resource.read_text().splitlines(True)
     filtered_lines = [s for s in lines if not re.match(pattern, s.strip(), flags)]
     if not any(line.strip() for line in filtered_lines):
@@ -166,12 +163,11 @@ def remove_lines(
             f"Removed {pattern!r} from {file} and removed file because it was empty."
         )
         resource.remove(message)
-        return []
+        return
     if len(filtered_lines) == len(lines):
-        return []
+        return
     message = f"Removed {pattern!r} from {file}"
     resource.write_text("".join(filtered_lines), message)
-    return []
 
 
 def natural_sorting(text: str) -> list[float | str]:
@@ -187,7 +183,7 @@ def update_file(
     /,
     relative_path: Path,
     in_template_folder: bool = False,
-) -> Changelog:
+) -> None:
     if in_template_folder:
         template_dir = COMPWA_POLICY_DIR / ".template"
     else:
@@ -198,13 +194,12 @@ def update_file(
     if not resource.exists:
         message = f"{relative_path} is missing, so created a new one. Please commit it."
         resource.write_text(expected_content, message)
-        return []
+        return
     existing_content = resource.read_text()
     if expected_content != existing_content:
         message = f"{relative_path} has been updated."
         resource.write_text(expected_content, message)
-        return []
-    return []
+        return
 
 
 def __attempt_number_cast(text: str) -> float | str:

--- a/src/compwa_policy/utilities/__init__.py
+++ b/src/compwa_policy/utilities/__init__.py
@@ -12,6 +12,7 @@ from shutil import copyfile
 from typing import TYPE_CHECKING, NamedTuple
 
 import compwa_policy
+from compwa_policy.utilities.resource import ModifiableConfigFiles, get_active_session
 
 if TYPE_CHECKING:
     from compwa_policy.utilities.session import Changelog
@@ -106,6 +107,10 @@ def write(content: str, target: Path | io.TextIOBase | str) -> None:
 
 
 def remove_configs(paths: list[str]) -> Changelog:
+    session = get_active_session()
+    if session is not None:
+        session.get(ModifiableConfigFiles).remove(paths)
+        return []
     changes: Changelog = []
     for path in paths:
         changes += __remove_file(path)

--- a/src/compwa_policy/utilities/__init__.py
+++ b/src/compwa_policy/utilities/__init__.py
@@ -48,9 +48,9 @@ CONFIG_PATH = _ConfigFilePaths()
 COMPWA_POLICY_DIR = Path(compwa_policy.__file__).parent.absolute()
 
 
-def append_safe(expected_line: str, path: Path, *, session: Session) -> bool:
+def append_safe(session: Session, /, expected_line: str, path: Path) -> bool:
     """Add a line to a file if it is not already present."""
-    resource = _get_path_resource(path, session=session)
+    resource = _get_path_resource(session, path)
     lines = resource.read_text().splitlines() if resource.exists else []
     if expected_line in {line.strip() for line in lines}:
         return False
@@ -88,7 +88,7 @@ def read(
 ) -> str:
     if isinstance(input, (Path, str)):
         if session is not None:
-            return _get_path_resource(input, session=session).read_text()
+            return _get_path_resource(session, input).read_text()
         with open(input) as input_stream:
             return input_stream.read()
     if isinstance(input, io.TextIOBase):
@@ -107,7 +107,7 @@ def write(
         target = Path(target)
     if isinstance(target, Path):
         if session is not None:
-            _get_path_resource(target, session=session).write_text(content)
+            _get_path_resource(session, target).write_text(content)
             return
         target.parent.mkdir(exist_ok=True)
         with open(target, "w") as output_stream:
@@ -119,48 +119,44 @@ def write(
         raise TypeError(msg)
 
 
-def remove_configs(paths: list[str], *, session: Session) -> Changelog:
+def remove_configs(session: Session, /, paths: list[str]) -> Changelog:
     for path in paths:
-        resource = _get_path_resource(path, session=session)
+        resource = _get_path_resource(session, path)
         resource.remove(f"Removed {path}")
     return []
 
 
-def _get_path_resource(
-    path: Path | str,
-    *,
-    session: Session,
-) -> ModifiablePath:
+def _get_path_resource(session: Session, /, path: Path | str) -> ModifiablePath:
     normalized = Path(path)
     return session.get_path(normalized)
 
 
-def __remove_file(path: str, *, session: Session) -> Changelog:
-    resource = _get_path_resource(path, session=session)
+def __remove_file(session: Session, /, path: str) -> Changelog:
+    resource = _get_path_resource(session, path)
     resource.remove(f"Removed {path}")
     return []
 
 
-def rename_file(old: str, new: str, *, session: Session) -> Changelog:
-    source = _get_path_resource(old, session=session)
+def rename_file(session: Session, /, old: str, new: str) -> Changelog:
+    source = _get_path_resource(session, old)
     if not source.exists:
         return []
     content = source.read_text()
     message = f"File {old} has been renamed to {new}"
-    target = _get_path_resource(new, session=session)
+    target = _get_path_resource(session, new)
     target.write_text(content, message)
     source.remove()
     return []
 
 
 def remove_lines(
+    session: Session,
+    /,
     file: Path,
     pattern: str,
     flags: re.RegexFlag = re.IGNORECASE,
-    *,
-    session: Session,
 ) -> Changelog:
-    resource = _get_path_resource(file, session=session)
+    resource = _get_path_resource(session, file)
     if not resource.exists:
         return []
     lines = resource.read_text().splitlines(True)
@@ -187,10 +183,10 @@ def natural_sorting(text: str) -> list[float | str]:
 
 
 def update_file(
+    session: Session,
+    /,
     relative_path: Path,
     in_template_folder: bool = False,
-    *,
-    session: Session,
 ) -> Changelog:
     if in_template_folder:
         template_dir = COMPWA_POLICY_DIR / ".template"
@@ -198,7 +194,7 @@ def update_file(
         template_dir = COMPWA_POLICY_DIR
     template_path = template_dir / relative_path
     expected_content = template_path.read_text()
-    resource = _get_path_resource(relative_path, session=session)
+    resource = _get_path_resource(session, relative_path)
     if not resource.exists:
         message = f"{relative_path} is missing, so created a new one. Please commit it."
         resource.write_text(expected_content, message)

--- a/src/compwa_policy/utilities/precommit/__init__.py
+++ b/src/compwa_policy/utilities/precommit/__init__.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import io
 import sys
-from contextlib import AbstractContextManager
 from pathlib import Path
 from typing import IO, TYPE_CHECKING, TypeVar
 
@@ -15,6 +14,7 @@ from compwa_policy.utilities.precommit.setters import (
     update_precommit_hook,
     update_single_hook_precommit_repo,
 )
+from compwa_policy.utilities.resource import Changelog, ModifiableResource
 from compwa_policy.utilities.yaml import create_prettier_round_trip_yaml
 
 if sys.version_info >= (3, 11):
@@ -28,7 +28,6 @@ if TYPE_CHECKING:
     from ruamel.yaml import YAML
 
     from compwa_policy.utilities.precommit.struct import Hook, PrecommitConfig, Repo
-    from compwa_policy.utilities.session import Changelog
 
 T = TypeVar("T", bound="Precommit")
 
@@ -77,7 +76,7 @@ class Precommit:
         return find_repo_with_index(self.__document, search_pattern)
 
 
-class ModifiablePrecommit(Precommit, AbstractContextManager):
+class ModifiablePrecommit(Precommit, ModifiableResource):
     def __init__(
         self, document: PrecommitConfig, parser: YAML, source: IO | Path | None = None
     ) -> None:

--- a/src/compwa_policy/utilities/pyproject/__init__.py
+++ b/src/compwa_policy/utilities/pyproject/__init__.py
@@ -314,7 +314,7 @@ def _complies_minimally(obj: Any, other: Any) -> bool:
     return obj == other
 
 
-def has_pyproject_package_name(*, session: Session | None = None) -> bool:
+def has_pyproject_package_name(*, session: Session) -> bool:
     if not CONFIG_PATH.pyproject.exists():
         return False
     pyproject = Pyproject.load(session=session)

--- a/src/compwa_policy/utilities/pyproject/__init__.py
+++ b/src/compwa_policy/utilities/pyproject/__init__.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import io
 import sys
 from collections import abc
-from contextlib import AbstractContextManager, contextmanager
 from pathlib import Path
 from typing import IO, TYPE_CHECKING, Any, Final, Literal, TypeVar, final, overload
 
@@ -28,6 +27,7 @@ from compwa_policy.utilities.pyproject.setters import (
     remove_dependency,
     split_dependency_definition,
 )
+from compwa_policy.utilities.resource import Changelog, ModifiableResource
 
 if sys.version_info >= (3, 11):
     from typing import Self
@@ -42,7 +42,6 @@ if TYPE_CHECKING:
     from types import TracebackType
 
     from compwa_policy.utilities.pyproject._struct import PyprojectTOML
-    from compwa_policy.utilities.session import Changelog
 
 T = TypeVar("T", bound="Pyproject")
 _NO_FALLBACK: Final = object()
@@ -114,7 +113,7 @@ class Pyproject:
 
 
 @frozen(slots=False)
-class ModifiablePyproject(Pyproject, AbstractContextManager):
+class ModifiablePyproject(Pyproject, ModifiableResource):
     """Stateful representation of a :code:`pyproject.toml` file.
 
     Use this class to apply multiple modifications to a :code:`pyproject.toml` file in
@@ -164,7 +163,11 @@ class ModifiablePyproject(Pyproject, AbstractContextManager):
         return False
 
     def dump(self, target: IO | Path | str | None = None) -> None:
-        if target is None and self._source is None:
+        if target is None:
+            target = self._source
+        if target is None and CONFIG_PATH.pyproject.exists():
+            target = CONFIG_PATH.pyproject
+        if target is None:
             msg = "Target required when source is not a file or I/O stream"
             raise ValueError(msg)
         if isinstance(target, io.IOBase):
@@ -221,21 +224,6 @@ class ModifiablePyproject(Pyproject, AbstractContextManager):
     def changelog(self) -> Changelog:
         self.__assert_is_in_context()
         return self._changelog
-
-
-@contextmanager
-def use_modifiable_pyproject(
-    pyproject: ModifiablePyproject | None = None,
-    *,
-    load: bool = True,
-) -> abc.Iterator[tuple[ModifiablePyproject | None, bool]]:
-    if pyproject is not None:
-        yield pyproject, False
-    elif load and CONFIG_PATH.pyproject.exists():
-        with ModifiablePyproject.load() as local_pyproject:
-            yield local_pyproject, True
-    else:
-        yield None, False
 
 
 def complies_with_subset(

--- a/src/compwa_policy/utilities/pyproject/__init__.py
+++ b/src/compwa_policy/utilities/pyproject/__init__.py
@@ -221,6 +221,7 @@ class ModifiablePyproject(Pyproject, ModifiableResource):
     def add_dependency(
         self,
         package: str,
+        /,
         dependency_group: str | Sequence[str] | None = None,
         optional_key: str | Sequence[str] | None = None,
     ) -> None:
@@ -233,7 +234,7 @@ class ModifiablePyproject(Pyproject, ModifiableResource):
             self._changelog.append(msg)
 
     def remove_dependency(
-        self, package: str, ignored_sections: Iterable[str] | None = None
+        self, package: str, /, ignored_sections: Iterable[str] | None = None
     ) -> None:
         self.__assert_is_in_context()
         updated = remove_dependency(self._document, package, ignored_sections)

--- a/src/compwa_policy/utilities/pyproject/__init__.py
+++ b/src/compwa_policy/utilities/pyproject/__init__.py
@@ -37,11 +37,7 @@ from compwa_policy.utilities.pyproject.setters import (
     remove_dependency,
     split_dependency_definition,
 )
-from compwa_policy.utilities.resource import (
-    Changelog,
-    ModifiableResource,
-    get_active_session,
-)
+from compwa_policy.utilities.resource import Changelog, ModifiableResource
 
 if sys.version_info >= (3, 11):
     from typing import Self
@@ -56,6 +52,7 @@ if TYPE_CHECKING:
     from types import TracebackType
 
     from compwa_policy.utilities.pyproject._struct import PyprojectTOML
+    from compwa_policy.utilities.session import Session
 
 T = TypeVar("T", bound="Pyproject")
 _NO_FALLBACK: Final = object()
@@ -69,9 +66,13 @@ class Pyproject:
     _source: IO | Path | None = field(default=None)
 
     @classmethod
-    def load(cls, source: IO | Path | str = CONFIG_PATH.pyproject) -> Self:
+    def load(
+        cls,
+        source: IO | Path | str = CONFIG_PATH.pyproject,
+        *,
+        session: Session | None = None,
+    ) -> Self:
         """Load a :code:`pyproject.toml` file from a file, I/O stream, or `str`."""
-        session = get_active_session()
         if cls is Pyproject and source == CONFIG_PATH.pyproject and session is not None:
             managed = session.pyproject
             if managed is not None:
@@ -144,8 +145,14 @@ class ModifiablePyproject(Pyproject, ModifiableResource):
 
     @override
     @classmethod
-    def load(cls, source: IO | Path | str = CONFIG_PATH.pyproject) -> Self:
+    def load(
+        cls,
+        source: IO | Path | str = CONFIG_PATH.pyproject,
+        *,
+        session: Session | None = None,
+    ) -> Self:
         """Load a :code:`pyproject.toml` file from a file, I/O stream, or `str`."""
+        _ = session
         if isinstance(source, io.IOBase):
             current_position = source.tell()
             source.seek(0)
@@ -250,7 +257,13 @@ class ModifiablePixi(ModifiablePyproject):
 
     @override
     @classmethod
-    def load(cls, source: IO | Path | str = CONFIG_PATH.pixi_toml) -> Self:
+    def load(
+        cls,
+        source: IO | Path | str = CONFIG_PATH.pixi_toml,
+        *,
+        session: Session | None = None,
+    ) -> Self:
+        _ = session
         if source == CONFIG_PATH.pixi_toml and not CONFIG_PATH.pixi_toml.exists():
             return cls(tomlkit.document(), CONFIG_PATH.pixi_toml)  # ty:ignore[invalid-argument-type]
         return super().load(source)
@@ -301,10 +314,10 @@ def _complies_minimally(obj: Any, other: Any) -> bool:
     return obj == other
 
 
-def has_pyproject_package_name() -> bool:
+def has_pyproject_package_name(*, session: Session | None = None) -> bool:
     if not CONFIG_PATH.pyproject.exists():
         return False
-    pyproject = Pyproject.load()
+    pyproject = Pyproject.load(session=session)
     return pyproject.get_package_name() is not None
 
 

--- a/src/compwa_policy/utilities/pyproject/__init__.py
+++ b/src/compwa_policy/utilities/pyproject/__init__.py
@@ -6,7 +6,17 @@ import io
 import sys
 from collections import abc
 from pathlib import Path
-from typing import IO, TYPE_CHECKING, Any, Final, Literal, TypeVar, final, overload
+from typing import (
+    IO,
+    TYPE_CHECKING,
+    Any,
+    Final,
+    Literal,
+    TypeVar,
+    cast,
+    final,
+    overload,
+)
 
 import rtoml
 import tomlkit
@@ -27,7 +37,11 @@ from compwa_policy.utilities.pyproject.setters import (
     remove_dependency,
     split_dependency_definition,
 )
-from compwa_policy.utilities.resource import Changelog, ModifiableResource
+from compwa_policy.utilities.resource import (
+    Changelog,
+    ModifiableResource,
+    get_active_session,
+)
 
 if sys.version_info >= (3, 11):
     from typing import Self
@@ -57,6 +71,11 @@ class Pyproject:
     @classmethod
     def load(cls, source: IO | Path | str = CONFIG_PATH.pyproject) -> Self:
         """Load a :code:`pyproject.toml` file from a file, I/O stream, or `str`."""
+        session = get_active_session()
+        if cls is Pyproject and source == CONFIG_PATH.pyproject and session is not None:
+            managed = session.pyproject
+            if managed is not None:
+                return cast("Self", managed)
         document = load_pyproject_toml(source, modifiable=False)
         if isinstance(source, str):
             return cls(document)
@@ -224,6 +243,17 @@ class ModifiablePyproject(Pyproject, ModifiableResource):
     def changelog(self) -> Changelog:
         self.__assert_is_in_context()
         return self._changelog
+
+
+class ModifiablePixi(ModifiablePyproject):
+    """Session-owned representation of :file:`pixi.toml`."""
+
+    @override
+    @classmethod
+    def load(cls, source: IO | Path | str = CONFIG_PATH.pixi_toml) -> Self:
+        if source == CONFIG_PATH.pixi_toml and not CONFIG_PATH.pixi_toml.exists():
+            return cls(tomlkit.document(), CONFIG_PATH.pixi_toml)  # ty:ignore[invalid-argument-type]
+        return super().load(source)
 
 
 def complies_with_subset(

--- a/src/compwa_policy/utilities/pyproject/__init__.py
+++ b/src/compwa_policy/utilities/pyproject/__init__.py
@@ -314,10 +314,10 @@ def _complies_minimally(obj: Any, other: Any) -> bool:
     return obj == other
 
 
-def has_pyproject_package_name(*, session: Session) -> bool:
-    if not CONFIG_PATH.pyproject.exists():
+def has_pyproject_package_name(session: Session, /) -> bool:
+    pyproject = session.pyproject
+    if pyproject is None:
         return False
-    pyproject = Pyproject.load(session=session)
     return pyproject.get_package_name() is not None
 
 

--- a/src/compwa_policy/utilities/pyproject/getters.py
+++ b/src/compwa_policy/utilities/pyproject/getters.py
@@ -36,7 +36,7 @@ def get_package_name(doc: PyprojectTOML, raise_on_missing: bool = False):
     package_name = project.get("name")
     if package_name is None:
         return None
-    return package_name
+    return str(package_name)
 
 
 def get_project_urls(pyproject: PyprojectTOML) -> ProjectURLs:
@@ -62,7 +62,7 @@ def get_source_url(pyproject: PyprojectTOML) -> str:
     if source_url is None:
         msg = '[project.urls] in pyproject.toml does not contain a "Source" URL'
         raise PolicyError(msg)
-    return source_url
+    return str(source_url)
 
 
 def get_supported_python_versions(pyproject: PyprojectTOML) -> list[PythonVersion]:

--- a/src/compwa_policy/utilities/pyproject/getters.py
+++ b/src/compwa_policy/utilities/pyproject/getters.py
@@ -36,7 +36,7 @@ def get_package_name(doc: PyprojectTOML, raise_on_missing: bool = False):
     package_name = project.get("name")
     if package_name is None:
         return None
-    return str(package_name)
+    return package_name
 
 
 def get_project_urls(pyproject: PyprojectTOML) -> ProjectURLs:
@@ -62,7 +62,7 @@ def get_source_url(pyproject: PyprojectTOML) -> str:
     if source_url is None:
         msg = '[project.urls] in pyproject.toml does not contain a "Source" URL'
         raise PolicyError(msg)
-    return str(source_url)
+    return source_url
 
 
 def get_supported_python_versions(pyproject: PyprojectTOML) -> list[PythonVersion]:

--- a/src/compwa_policy/utilities/readme.py
+++ b/src/compwa_policy/utilities/readme.py
@@ -7,14 +7,12 @@ from typing import TYPE_CHECKING
 
 from compwa_policy.errors import PolicyError
 from compwa_policy.utilities import CONFIG_PATH
-from compwa_policy.utilities.resource import (
-    Changelog,
-    ModifiableResource,
-    get_active_session,
-)
+from compwa_policy.utilities.resource import Changelog, ModifiableResource
 
 if TYPE_CHECKING:
     from pathlib import Path
+
+    from compwa_policy.utilities.session import Session
 
 __README_PATH = str(CONFIG_PATH.readme)
 
@@ -78,8 +76,7 @@ class ModifiableReadme(ModifiableResource):
         )
 
 
-def add_badge(badge: str) -> Changelog:
-    session = get_active_session()
+def add_badge(badge: str, *, session: Session | None = None) -> Changelog:
     if session is not None:
         session.get(ModifiableReadme).add_badge(badge)
         return []
@@ -89,8 +86,11 @@ def add_badge(badge: str) -> Changelog:
     return resource.changelog
 
 
-def remove_badge(badge_pattern: str) -> Changelog:
-    session = get_active_session()
+def remove_badge(
+    badge_pattern: str,
+    *,
+    session: Session | None = None,
+) -> Changelog:
     if session is not None:
         session.get(ModifiableReadme).remove_badge(badge_pattern)
         return []

--- a/src/compwa_policy/utilities/readme.py
+++ b/src/compwa_policy/utilities/readme.py
@@ -76,11 +76,9 @@ class ModifiableReadme(ModifiableResource):
         )
 
 
-def add_badge(session: Session, /, badge: str) -> Changelog:
+def add_badge(session: Session, /, badge: str) -> None:
     session.get(ModifiableReadme).add_badge(badge)
-    return []
 
 
-def remove_badge(session: Session, /, badge_pattern: str) -> Changelog:
+def remove_badge(session: Session, /, badge_pattern: str) -> None:
     session.get(ModifiableReadme).remove_badge(badge_pattern)
-    return []

--- a/src/compwa_policy/utilities/readme.py
+++ b/src/compwa_policy/utilities/readme.py
@@ -76,15 +76,11 @@ class ModifiableReadme(ModifiableResource):
         )
 
 
-def add_badge(badge: str, *, session: Session) -> Changelog:
+def add_badge(session: Session, /, badge: str) -> Changelog:
     session.get(ModifiableReadme).add_badge(badge)
     return []
 
 
-def remove_badge(
-    badge_pattern: str,
-    *,
-    session: Session,
-) -> Changelog:
+def remove_badge(session: Session, /, badge_pattern: str) -> Changelog:
     session.get(ModifiableReadme).remove_badge(badge_pattern)
     return []

--- a/src/compwa_policy/utilities/readme.py
+++ b/src/compwa_policy/utilities/readme.py
@@ -2,57 +2,99 @@
 
 from __future__ import annotations
 
-import os.path
 import re
 from typing import TYPE_CHECKING
 
 from compwa_policy.errors import PolicyError
+from compwa_policy.utilities import CONFIG_PATH
+from compwa_policy.utilities.resource import (
+    Changelog,
+    ModifiableResource,
+    get_active_session,
+)
 
 if TYPE_CHECKING:
-    from compwa_policy.utilities.session import Changelog
+    from pathlib import Path
 
-__README_PATH = "README.md"
+__README_PATH = str(CONFIG_PATH.readme)
+
+
+class ModifiableReadme(ModifiableResource):
+    """In-memory representation of :file:`README.md`."""
+
+    def __init__(self, lines: list[str], source: Path, *, exists: bool) -> None:
+        self._lines = lines
+        self._source = source
+        self._exists = exists
+        self._changelog: Changelog = []
+
+    @classmethod
+    def load(cls, source: Path = CONFIG_PATH.readme) -> ModifiableReadme:
+        if not source.exists():
+            return cls([], source, exists=False)
+        with source.open() as stream:
+            return cls(stream.readlines(), source, exists=True)
+
+    @property
+    def changelog(self) -> Changelog:
+        return self._changelog
+
+    def dump(self) -> None:
+        if not self._changelog:
+            return
+        with self._source.open("w") as stream:
+            stream.writelines(self._lines)
+
+    def add_badge(self, badge: str) -> None:
+        if not self._exists:
+            return
+        stripped_lines = {line.strip("\n") for line in self._lines}
+        stripped_lines = {line.strip("<br>") for line in stripped_lines}
+        stripped_lines = {line.strip("<br />") for line in stripped_lines}
+        if badge in stripped_lines:
+            return
+        error_message = f"{self._source} is missing a badge:\n  {badge}\n"
+        if not self._lines:
+            error_message += f"{self._source} contains no title, so cannot add badge"
+            raise PolicyError(error_message)
+        insert_position = 0
+        for insert_position, line in enumerate(self._lines):  # noqa: B007
+            if line.startswith("#"):
+                break
+        self._lines.insert(insert_position + 1, f"\n{badge}")
+        self._changelog.append(error_message + "Problem has been fixed.")
+
+    def remove_badge(self, badge_pattern: str) -> None:
+        if not self._exists:
+            return
+        badge_line = next(
+            (line for line in self._lines if re.match(badge_pattern, line)), None
+        )
+        if badge_line is None:
+            return
+        self._lines.remove(badge_line)
+        self._changelog.append(
+            f"A badge has been removed from {self._source}:\n\n  {badge_line}"
+        )
 
 
 def add_badge(badge: str) -> Changelog:
-    if not os.path.exists(__README_PATH):
+    session = get_active_session()
+    if session is not None:
+        session.get(ModifiableReadme).add_badge(badge)
         return []
-    with open(__README_PATH) as stream:
-        lines = stream.readlines()
-    stripped_lines = {s.strip("\n") for s in lines}
-    stripped_lines = {s.strip("<br>") for s in stripped_lines}
-    stripped_lines = {s.strip("<br />") for s in stripped_lines}
-    if badge not in stripped_lines:
-        error_message = f"{__README_PATH} is missing a badge:\n"
-        error_message += f"  {badge}\n"
-        insert_position = 0
-        for insert_position, line in enumerate(lines):  # noqa: B007
-            if line.startswith("#"):  # find first Markdown section
-                break
-        if len(lines) == 0:
-            error_message += f"{__README_PATH} contains no title, so cannot add badge"
-            raise PolicyError(error_message)
-        lines.insert(insert_position + 1, f"\n{badge}")
-        with open(__README_PATH, "w") as stream:
-            stream.writelines(lines)
-        error_message += "Problem has been fixed."
-        return [error_message]
-    return []
+    resource = ModifiableReadme.load()
+    resource.add_badge(badge)
+    resource.dump()
+    return resource.changelog
 
 
 def remove_badge(badge_pattern: str) -> Changelog:
-    if not os.path.exists(__README_PATH):
+    session = get_active_session()
+    if session is not None:
+        session.get(ModifiableReadme).remove_badge(badge_pattern)
         return []
-    with open(__README_PATH) as stream:
-        lines = stream.readlines()
-    badge_line = None
-    for line in lines:
-        if re.match(badge_pattern, line):
-            badge_line = line
-            break
-    if badge_line is None:
-        return []
-    lines.remove(badge_line)
-    with open(__README_PATH, "w") as stream:
-        stream.writelines(lines)
-    return [f"A badge has been removed from {__README_PATH}:\n\n  {badge_line}"]
+    resource = ModifiableReadme.load()
+    resource.remove_badge(badge_pattern)
+    resource.dump()
+    return resource.changelog

--- a/src/compwa_policy/utilities/readme.py
+++ b/src/compwa_policy/utilities/readme.py
@@ -76,25 +76,15 @@ class ModifiableReadme(ModifiableResource):
         )
 
 
-def add_badge(badge: str, *, session: Session | None = None) -> Changelog:
-    if session is not None:
-        session.get(ModifiableReadme).add_badge(badge)
-        return []
-    resource = ModifiableReadme.load()
-    resource.add_badge(badge)
-    resource.dump()
-    return resource.changelog
+def add_badge(badge: str, *, session: Session) -> Changelog:
+    session.get(ModifiableReadme).add_badge(badge)
+    return []
 
 
 def remove_badge(
     badge_pattern: str,
     *,
-    session: Session | None = None,
+    session: Session,
 ) -> Changelog:
-    if session is not None:
-        session.get(ModifiableReadme).remove_badge(badge_pattern)
-        return []
-    resource = ModifiableReadme.load()
-    resource.remove_badge(badge_pattern)
-    resource.dump()
-    return resource.changelog
+    session.get(ModifiableReadme).remove_badge(badge_pattern)
+    return []

--- a/src/compwa_policy/utilities/resource.py
+++ b/src/compwa_policy/utilities/resource.py
@@ -2,12 +2,12 @@
 
 from __future__ import annotations
 
-import os
 import shutil
 import sys
 from abc import ABC, abstractmethod
 from contextlib import AbstractContextManager
 from contextvars import ContextVar, Token
+from pathlib import Path
 from typing import TYPE_CHECKING, TypeAlias
 
 if sys.version_info >= (3, 11):
@@ -58,6 +58,11 @@ class ModifiableResource(AbstractContextManager, ABC):
     def dump(self) -> None:
         """Write the in-memory representation to the working tree."""
 
+    @property
+    def changed(self) -> bool:
+        """Whether the resource needs to be flushed."""
+        return bool(self.changelog)
+
     def __enter__(self) -> Self:
         return self
 
@@ -70,31 +75,85 @@ class ModifiableResource(AbstractContextManager, ABC):
         return False
 
 
-class ModifiableConfigFiles(ModifiableResource):
-    """A deferred set of standalone config paths to remove on flush."""
+class ModifiablePath(ModifiableResource):
+    """Deferred in-memory state for one arbitrary working-tree path."""
 
-    def __init__(self) -> None:
-        self._paths: list[str] = []
+    def __init__(
+        self,
+        path: Path,
+        content: bytes | None,
+        *,
+        is_directory: bool = False,
+    ) -> None:
+        self.path = path
+        self._original_content = content
+        self._content = content
+        self._is_directory = is_directory
+        self._original_is_directory = is_directory
         self._changelog: Changelog = []
 
     @classmethod
     def load(cls) -> Self:
-        return cls()
+        msg = "ModifiablePath requires a path identity"
+        raise TypeError(msg)
+
+    @classmethod
+    def load_path(cls, path: Path | str) -> Self:
+        path = Path(path)
+        if path.is_dir():
+            return cls(path, None, is_directory=True)
+        if path.exists():
+            return cls(path, path.read_bytes())
+        return cls(path, None)
 
     @property
     def changelog(self) -> Changelog:
         return self._changelog
 
-    def remove(self, paths: list[str]) -> None:
-        for path in paths:
-            if path in self._paths or not os.path.exists(path):
-                continue
-            self._paths.append(path)
-            self._changelog.append(f"Removed {path}")
+    @property
+    def changed(self) -> bool:
+        return (
+            self._content != self._original_content
+            or self._is_directory != self._original_is_directory
+        )
+
+    @property
+    def exists(self) -> bool:
+        return self._is_directory or self._content is not None
+
+    def read_text(self) -> str:
+        if self._content is None:
+            msg = f"{self.path} does not exist or is a directory"
+            raise FileNotFoundError(msg)
+        return self._content.decode()
+
+    def write_text(self, content: str, message: str | None = None) -> bool:
+        encoded = content.encode()
+        if not self._is_directory and self._content == encoded:
+            return False
+        self._content = encoded
+        self._is_directory = False
+        if message is not None:
+            self._changelog.append(message)
+        return True
+
+    def remove(self, message: str | None = None) -> bool:
+        if not self.exists:
+            return False
+        self._content = None
+        self._is_directory = False
+        if message is not None:
+            self._changelog.append(message)
+        return True
 
     def dump(self) -> None:
-        for path in self._paths:
-            if os.path.isdir(path):
-                shutil.rmtree(path)
-            elif os.path.exists(path):
-                os.remove(path)
+        if not self.exists:
+            if self.path.is_dir():
+                shutil.rmtree(self.path)
+            else:
+                self.path.unlink(missing_ok=True)
+            return
+        if not self.changed:
+            return
+        self.path.parent.mkdir(exist_ok=True, parents=True)
+        self.path.write_bytes(self._content or b"")

--- a/src/compwa_policy/utilities/resource.py
+++ b/src/compwa_policy/utilities/resource.py
@@ -6,7 +6,6 @@ import shutil
 import sys
 from abc import ABC, abstractmethod
 from contextlib import AbstractContextManager
-from contextvars import ContextVar, Token
 from pathlib import Path
 from typing import TYPE_CHECKING, TypeAlias
 
@@ -17,28 +16,11 @@ else:
 if TYPE_CHECKING:
     from types import TracebackType
 
-    from compwa_policy.utilities.session import Session
-
-
 ChangelogItem: TypeAlias = str
 """A user-facing message that describes one policy change."""
 
 Changelog: TypeAlias = list[ChangelogItem]
 """Messages reported by a policy check."""
-
-_ACTIVE_SESSION: ContextVar[Session | None] = ContextVar("active_session", default=None)
-
-
-def get_active_session() -> Session | None:
-    return _ACTIVE_SESSION.get()
-
-
-def activate_session(session: Session) -> Token[Session | None]:
-    return _ACTIVE_SESSION.set(session)
-
-
-def deactivate_session(token: Token[Session | None]) -> None:
-    _ACTIVE_SESSION.reset(token)
 
 
 class ModifiableResource(AbstractContextManager, ABC):

--- a/src/compwa_policy/utilities/resource.py
+++ b/src/compwa_policy/utilities/resource.py
@@ -1,0 +1,100 @@
+"""Common interface for mutable, file-backed policy resources."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import sys
+from abc import ABC, abstractmethod
+from contextlib import AbstractContextManager
+from contextvars import ContextVar, Token
+from typing import TYPE_CHECKING, TypeAlias
+
+if sys.version_info >= (3, 11):
+    from typing import Self
+else:
+    from typing_extensions import Self
+if TYPE_CHECKING:
+    from types import TracebackType
+
+    from compwa_policy.utilities.session import Session
+
+
+ChangelogItem: TypeAlias = str
+"""A user-facing message that describes one policy change."""
+
+Changelog: TypeAlias = list[ChangelogItem]
+"""Messages reported by a policy check."""
+
+_ACTIVE_SESSION: ContextVar[Session | None] = ContextVar("active_session", default=None)
+
+
+def get_active_session() -> Session | None:
+    return _ACTIVE_SESSION.get()
+
+
+def activate_session(session: Session) -> Token[Session | None]:
+    return _ACTIVE_SESSION.set(session)
+
+
+def deactivate_session(token: Token[Session | None]) -> None:
+    _ACTIVE_SESSION.reset(token)
+
+
+class ModifiableResource(AbstractContextManager, ABC):
+    """A file loaded once and written once after in-memory modification."""
+
+    @classmethod
+    @abstractmethod
+    def load(cls) -> Self:
+        """Load the resource from the working tree."""
+
+    @property
+    @abstractmethod
+    def changelog(self) -> Changelog:
+        """Changes made to the in-memory representation."""
+
+    @abstractmethod
+    def dump(self) -> None:
+        """Write the in-memory representation to the working tree."""
+
+    def __enter__(self) -> Self:
+        return self
+
+    def __exit__(
+        self,
+        _exc_type: type[BaseException] | None,
+        _exc_value: BaseException | None,
+        _tb: TracebackType | None,
+    ) -> bool:
+        return False
+
+
+class ModifiableConfigFiles(ModifiableResource):
+    """A deferred set of standalone config paths to remove on flush."""
+
+    def __init__(self) -> None:
+        self._paths: list[str] = []
+        self._changelog: Changelog = []
+
+    @classmethod
+    def load(cls) -> Self:
+        return cls()
+
+    @property
+    def changelog(self) -> Changelog:
+        return self._changelog
+
+    def remove(self, paths: list[str]) -> None:
+        for path in paths:
+            if path in self._paths or not os.path.exists(path):
+                continue
+            self._paths.append(path)
+            self._changelog.append(f"Removed {path}")
+
+    def dump(self) -> None:
+        for path in self._paths:
+            if os.path.isdir(path):
+                shutil.rmtree(path)
+            elif os.path.exists(path):
+                os.remove(path)

--- a/src/compwa_policy/utilities/session.py
+++ b/src/compwa_policy/utilities/session.py
@@ -27,8 +27,6 @@ from compwa_policy.utilities.resource import (
     Changelog,
     ModifiablePath,
     ModifiableResource,
-    activate_session,
-    deactivate_session,
 )
 
 if sys.version_info >= (3, 11):
@@ -38,7 +36,6 @@ else:
 
 if TYPE_CHECKING:
     from collections.abc import Hashable
-    from contextvars import Token
     from types import TracebackType
 
 
@@ -68,7 +65,6 @@ class Session(AbstractContextManager):
         self._entered: set[tuple[Hashable, ...]] = set()
         self._flushed: set[tuple[Hashable, ...]] = set()
         self._is_in_context = False
-        self._active_token: Token[Session | None] | None = None
         self.changelog: Changelog = []
         """Change messages that do not belong to one of the managed containers."""
 
@@ -146,7 +142,6 @@ class Session(AbstractContextManager):
 
     def __enter__(self) -> Self:
         self._is_in_context = True
-        self._active_token = activate_session(self)
         for resource_type, resource in self._loaded.items():
             resource.__enter__()
             self._entered.add(resource_type)
@@ -163,7 +158,4 @@ class Session(AbstractContextManager):
                 self.flush()
         finally:
             self._is_in_context = False
-            if self._active_token is not None:
-                deactivate_session(self._active_token)
-                self._active_token = None
         return False

--- a/src/compwa_policy/utilities/session.py
+++ b/src/compwa_policy/utilities/session.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import sys
 from contextlib import AbstractContextManager
+from pathlib import Path
 from typing import TYPE_CHECKING, TypeVar, cast
 
 from compwa_policy.utilities import CONFIG_PATH
@@ -24,6 +25,7 @@ from compwa_policy.utilities.precommit import ModifiablePrecommit
 from compwa_policy.utilities.pyproject import ModifiablePyproject
 from compwa_policy.utilities.resource import (
     Changelog,
+    ModifiablePath,
     ModifiableResource,
     activate_session,
     deactivate_session,
@@ -35,6 +37,7 @@ else:
     from typing_extensions import Self
 
 if TYPE_CHECKING:
+    from collections.abc import Hashable
     from contextvars import Token
     from types import TracebackType
 
@@ -55,13 +58,15 @@ class Session(AbstractContextManager):
         precommit: ModifiablePrecommit | None = None,
         pyproject: ModifiablePyproject | None = None,
     ) -> None:
-        self._loaded: dict[type[ModifiableResource], ModifiableResource] = {}
+        self._loaded: dict[tuple[Hashable, ...], ModifiableResource] = {}
         if precommit is not None:
-            self._loaded[type(precommit)] = precommit
+            key = (type(precommit),)
+            self._loaded[key] = precommit
         if pyproject is not None:
-            self._loaded[type(pyproject)] = pyproject
-        self._entered: set[type[ModifiableResource]] = set()
-        self._flushed: set[type[ModifiableResource]] = set()
+            key = (type(pyproject),)
+            self._loaded[key] = pyproject
+        self._entered: set[tuple[Hashable, ...]] = set()
+        self._flushed: set[tuple[Hashable, ...]] = set()
         self._is_in_context = False
         self._active_token: Token[Session | None] | None = None
         self.changelog: Changelog = []
@@ -74,21 +79,35 @@ class Session(AbstractContextManager):
 
     def get(self, resource: type[R]) -> R:
         """Return the one session-owned instance of *resource*, loading it lazily."""
-        loaded = self._loaded.get(resource)
+        key = (resource,)
+        loaded = self._loaded.get(key)
         if loaded is None:
             loaded = resource.load()
-            self._loaded[resource] = loaded
-        if self._is_in_context and resource not in self._entered:
+            self._loaded[key] = loaded
+        if self._is_in_context and key not in self._entered:
             loaded.__enter__()  # noqa: PLC2801
-            self._entered.add(resource)
+            self._entered.add(key)
         return cast("R", loaded)
+
+    def get_path(self, path: Path | str) -> ModifiablePath:
+        """Return the session-owned generic resource for one working-tree path."""
+        normalized = Path(path)
+        key = (ModifiablePath, normalized)
+        loaded = self._loaded.get(key)
+        if loaded is None:
+            loaded = ModifiablePath.load_path(normalized)
+            self._loaded[key] = loaded
+        if self._is_in_context and key not in self._entered:
+            loaded.__enter__()  # noqa: PLC2801
+            self._entered.add(key)
+        return cast("ModifiablePath", loaded)
 
     @property
     def precommit(self) -> ModifiablePrecommit:
         """The managed :code:`.pre-commit-config.yaml` file."""
         if (
             not CONFIG_PATH.precommit.exists()
-            and ModifiablePrecommit not in self._loaded
+            and (ModifiablePrecommit,) not in self._loaded
         ):
             msg = "This session has no .pre-commit-config.yaml loaded"
             raise ValueError(msg)
@@ -99,7 +118,7 @@ class Session(AbstractContextManager):
         """The managed :code:`pyproject.toml` file, if the repository has one."""
         if (
             not CONFIG_PATH.pyproject.exists()
-            and ModifiablePyproject not in self._loaded
+            and (ModifiablePyproject,) not in self._loaded
         ):
             return None
         return self.get(ModifiablePyproject)
@@ -120,7 +139,7 @@ class Session(AbstractContextManager):
         """Write each changed resource at most once and return the run changelog."""
         messages = self.collect_changes()
         for resource_type, resource in self._loaded.items():
-            if resource_type not in self._flushed and resource.changelog:
+            if resource_type not in self._flushed and resource.changed:
                 resource.dump()
                 self._flushed.add(resource_type)
         return messages

--- a/src/compwa_policy/utilities/session.py
+++ b/src/compwa_policy/utilities/session.py
@@ -7,24 +7,27 @@ managed file is loaded once and, on exit, written back only if it changed. Each 
 reports its modifications either by mutating one of the managed containers (whose own
 changelog is collected here) or by appending to :attr:`Session.changelog` directly.
 
-.. note::
-
-    The two follow-up issues on this design extend this class *additively*: opening the
-    session to more file containers (:code:`README.md`, :code:`.vscode/*`, ...) and
-    dispatching the check hooks over the session. The public interface used by the
-    checks (:attr:`~.Session.precommit`, :attr:`~.Session.pyproject`,
-    :attr:`~.Session.changelog`) is intended to stay stable across both.
+Resources are discovered lazily through :meth:`Session.get`; adding another file type
+therefore requires implementing
+:class:`~compwa_policy.utilities.resource.ModifiableResource`, without modifying
+:class:`Session`.
 """
 
 from __future__ import annotations
 
 import sys
 from contextlib import AbstractContextManager
-from typing import TYPE_CHECKING, TypeAlias
+from typing import TYPE_CHECKING, TypeVar, cast
 
 from compwa_policy.utilities import CONFIG_PATH
 from compwa_policy.utilities.precommit import ModifiablePrecommit
 from compwa_policy.utilities.pyproject import ModifiablePyproject
+from compwa_policy.utilities.resource import (
+    Changelog,
+    ModifiableResource,
+    activate_session,
+    deactivate_session,
+)
 
 if sys.version_info >= (3, 11):
     from typing import Self
@@ -32,14 +35,11 @@ else:
     from typing_extensions import Self
 
 if TYPE_CHECKING:
+    from contextvars import Token
     from types import TracebackType
 
 
-ChangelogItem: TypeAlias = str
-"""A user-facing message that describes one policy change."""
-
-Changelog: TypeAlias = list[ChangelogItem]
-"""Messages reported by a policy check."""
+R = TypeVar("R", bound=ModifiableResource)
 
 
 class Session(AbstractContextManager):
@@ -55,37 +55,54 @@ class Session(AbstractContextManager):
         precommit: ModifiablePrecommit | None = None,
         pyproject: ModifiablePyproject | None = None,
     ) -> None:
-        self._precommit = precommit
-        self._pyproject = pyproject
+        self._loaded: dict[type[ModifiableResource], ModifiableResource] = {}
+        if precommit is not None:
+            self._loaded[type(precommit)] = precommit
+        if pyproject is not None:
+            self._loaded[type(pyproject)] = pyproject
+        self._entered: set[type[ModifiableResource]] = set()
+        self._flushed: set[type[ModifiableResource]] = set()
+        self._is_in_context = False
+        self._active_token: Token[Session | None] | None = None
         self.changelog: Changelog = []
         """Change messages that do not belong to one of the managed containers."""
 
     @classmethod
-    def load(cls, precommit: ModifiablePrecommit | None = None) -> Self:
-        """Load every managed file that is present in the working directory.
+    def load(cls, precommit: ModifiablePrecommit | None = None) -> Session:
+        """Create a lazy session, optionally with an injected pre-commit resource."""
+        return cls(precommit=precommit)
 
-        An already-loaded *precommit* can be injected (the remaining files are still
-        read from disk); otherwise it is loaded from the working directory as well.
-        """
-        if precommit is None and CONFIG_PATH.precommit.exists():
-            precommit = ModifiablePrecommit.load()
-        pyproject = (
-            ModifiablePyproject.load() if CONFIG_PATH.pyproject.exists() else None
-        )
-        return cls(precommit, pyproject)
+    def get(self, resource: type[R]) -> R:
+        """Return the one session-owned instance of *resource*, loading it lazily."""
+        loaded = self._loaded.get(resource)
+        if loaded is None:
+            loaded = resource.load()
+            self._loaded[resource] = loaded
+        if self._is_in_context and resource not in self._entered:
+            loaded.__enter__()  # noqa: PLC2801
+            self._entered.add(resource)
+        return cast("R", loaded)
 
     @property
     def precommit(self) -> ModifiablePrecommit:
         """The managed :code:`.pre-commit-config.yaml` file."""
-        if self._precommit is None:
+        if (
+            not CONFIG_PATH.precommit.exists()
+            and ModifiablePrecommit not in self._loaded
+        ):
             msg = "This session has no .pre-commit-config.yaml loaded"
             raise ValueError(msg)
-        return self._precommit
+        return self.get(ModifiablePrecommit)
 
     @property
     def pyproject(self) -> ModifiablePyproject | None:
         """The managed :code:`pyproject.toml` file, if the repository has one."""
-        return self._pyproject
+        if (
+            not CONFIG_PATH.pyproject.exists()
+            and ModifiablePyproject not in self._loaded
+        ):
+            return None
+        return self.get(ModifiablePyproject)
 
     def collect_changes(self) -> Changelog:
         """Aggregate every reported change.
@@ -95,17 +112,25 @@ class Session(AbstractContextManager):
         checks ran), then the container changelogs.
         """
         messages: Changelog = list(self.changelog)
-        if self._precommit is not None:
-            messages += self._precommit.changelog
-        if self._pyproject is not None:
-            messages += self._pyproject.changelog
+        for resource in self._loaded.values():
+            messages += resource.changelog
+        return messages
+
+    def flush(self) -> Changelog:
+        """Write each changed resource at most once and return the run changelog."""
+        messages = self.collect_changes()
+        for resource_type, resource in self._loaded.items():
+            if resource_type not in self._flushed and resource.changelog:
+                resource.dump()
+                self._flushed.add(resource_type)
         return messages
 
     def __enter__(self) -> Self:
-        if self._precommit is not None:
-            self._precommit.__enter__()
-        if self._pyproject is not None:
-            self._pyproject.__enter__()
+        self._is_in_context = True
+        self._active_token = activate_session(self)
+        for resource_type, resource in self._loaded.items():
+            resource.__enter__()
+            self._entered.add(resource_type)
         return self
 
     def __exit__(
@@ -114,8 +139,12 @@ class Session(AbstractContextManager):
         exc_value: BaseException | None,
         tb: TracebackType | None,
     ) -> bool:
-        if self._pyproject is not None:
-            self._pyproject.__exit__(exc_type, exc_value, tb)
-        if self._precommit is not None:
-            self._precommit.__exit__(exc_type, exc_value, tb)
+        try:
+            if exc_type is None:
+                self.flush()
+        finally:
+            self._is_in_context = False
+            if self._active_token is not None:
+                deactivate_session(self._active_token)
+                self._active_token = None
         return False

--- a/src/compwa_policy/utilities/session.py
+++ b/src/compwa_policy/utilities/session.py
@@ -22,7 +22,7 @@ from typing import TYPE_CHECKING, TypeVar, cast
 
 from compwa_policy.utilities import CONFIG_PATH
 from compwa_policy.utilities.precommit import ModifiablePrecommit
-from compwa_policy.utilities.pyproject import ModifiablePyproject
+from compwa_policy.utilities.pyproject import ModifiablePixi, ModifiablePyproject
 from compwa_policy.utilities.resource import (
     Changelog,
     ModifiablePath,
@@ -118,6 +118,11 @@ class Session(AbstractContextManager):
         ):
             return None
         return self.get(ModifiablePyproject)
+
+    @property
+    def pixi(self) -> ModifiablePixi:
+        """The managed :code:`pixi.toml` file."""
+        return self.get(ModifiablePixi)
 
     def collect_changes(self) -> Changelog:
         """Aggregate every reported change.

--- a/src/compwa_policy/utilities/session.py
+++ b/src/compwa_policy/utilities/session.py
@@ -73,7 +73,7 @@ class Session(AbstractContextManager):
         """Create a lazy session, optionally with an injected pre-commit resource."""
         return cls(precommit=precommit)
 
-    def get(self, resource: type[R]) -> R:
+    def get(self, resource: type[R], /) -> R:
         """Return the one session-owned instance of *resource*, loading it lazily."""
         key = (resource,)
         loaded = self._loaded.get(key)
@@ -85,7 +85,7 @@ class Session(AbstractContextManager):
             self._entered.add(key)
         return cast("R", loaded)
 
-    def get_path(self, path: Path | str) -> ModifiablePath:
+    def get_path(self, path: Path | str, /) -> ModifiablePath:
         """Return the session-owned generic resource for one working-tree path."""
         normalized = Path(path)
         key = (ModifiablePath, normalized)

--- a/src/compwa_policy/utilities/vscode.py
+++ b/src/compwa_policy/utilities/vscode.py
@@ -10,14 +10,12 @@ from functools import cache
 from typing import TYPE_CHECKING, Any, TypeVar
 
 from compwa_policy.utilities import CONFIG_PATH
-from compwa_policy.utilities.resource import (
-    Changelog,
-    ModifiableResource,
-    get_active_session,
-)
+from compwa_policy.utilities.resource import Changelog, ModifiableResource
 
 if TYPE_CHECKING:
     from pathlib import Path
+
+    from compwa_policy.utilities.session import Session
 if sys.version_info >= (3, 11):
     from typing import Self
 else:
@@ -130,15 +128,13 @@ class ModifiableVscodeExtensions(_ModifiableJsonResource):
         )
 
 
-def get_recommended_extensions() -> set[str]:
-    session = get_active_session()
+def get_recommended_extensions(*, session: Session | None = None) -> set[str]:
     if session is not None:
         return session.get(ModifiableVscodeExtensions).get_recommended()
     return _get_extension_recommendations("recommendations")
 
 
-def get_unwanted_extensions() -> set[str]:
-    session = get_active_session()
+def get_unwanted_extensions(*, session: Session | None = None) -> set[str]:
     if session is not None:
         return session.get(ModifiableVscodeExtensions).get_unwanted()
     return _get_extension_recommendations("unwantedRecommendations")
@@ -151,8 +147,11 @@ def _get_extension_recommendations(key: str) -> set[str]:
     return {ext.lower() for ext in extensions}
 
 
-def remove_settings(keys: RemovedKeys) -> Changelog:
-    session = get_active_session()
+def remove_settings(
+    keys: RemovedKeys,
+    *,
+    session: Session | None = None,
+) -> Changelog:
     if session is not None:
         session.get(ModifiableVscodeSettings).remove(keys)
         return []
@@ -202,8 +201,11 @@ def _remove_keys(obj: T, keys: RemovedKeys) -> T:
     return obj
 
 
-def update_settings(new_settings: dict) -> Changelog:
-    session = get_active_session()
+def update_settings(
+    new_settings: dict,
+    *,
+    session: Session | None = None,
+) -> Changelog:
     if session is not None:
         session.get(ModifiableVscodeSettings).update(new_settings)
         return []
@@ -259,8 +261,11 @@ def _update_settings_if_changed(old: dict, new: dict) -> Changelog:
     return ["Updated VS Code settings"]
 
 
-def add_extension_recommendation(extension_name: str) -> Changelog:
-    session = get_active_session()
+def add_extension_recommendation(
+    extension_name: str,
+    *,
+    session: Session | None = None,
+) -> Changelog:
     if session is not None:
         session.get(ModifiableVscodeExtensions).add_recommendation(extension_name)
         return []
@@ -270,8 +275,11 @@ def add_extension_recommendation(extension_name: str) -> Changelog:
     return resource.changelog
 
 
-def add_unwanted_extension(extension_name: str) -> Changelog:
-    session = get_active_session()
+def add_unwanted_extension(
+    extension_name: str,
+    *,
+    session: Session | None = None,
+) -> Changelog:
     if session is not None:
         session.get(ModifiableVscodeExtensions).add_unwanted(extension_name)
         return []
@@ -309,9 +317,11 @@ def __remove_extension(extension_name: str, key: str) -> Changelog:
 
 
 def remove_extension_recommendation(
-    extension_name: str, *, unwanted: bool = False
+    extension_name: str,
+    *,
+    unwanted: bool = False,
+    session: Session | None = None,
 ) -> Changelog:
-    session = get_active_session()
     if session is not None:
         session.get(ModifiableVscodeExtensions).remove_recommendation(
             extension_name, unwanted=unwanted

--- a/src/compwa_policy/utilities/vscode.py
+++ b/src/compwa_policy/utilities/vscode.py
@@ -128,16 +128,12 @@ class ModifiableVscodeExtensions(_ModifiableJsonResource):
         )
 
 
-def get_recommended_extensions(*, session: Session | None = None) -> set[str]:
-    if session is not None:
-        return session.get(ModifiableVscodeExtensions).get_recommended()
-    return _get_extension_recommendations("recommendations")
+def get_recommended_extensions(*, session: Session) -> set[str]:
+    return session.get(ModifiableVscodeExtensions).get_recommended()
 
 
-def get_unwanted_extensions(*, session: Session | None = None) -> set[str]:
-    if session is not None:
-        return session.get(ModifiableVscodeExtensions).get_unwanted()
-    return _get_extension_recommendations("unwantedRecommendations")
+def get_unwanted_extensions(*, session: Session) -> set[str]:
+    return session.get(ModifiableVscodeExtensions).get_unwanted()
 
 
 @cache
@@ -150,15 +146,10 @@ def _get_extension_recommendations(key: str) -> set[str]:
 def remove_settings(
     keys: RemovedKeys,
     *,
-    session: Session | None = None,
+    session: Session,
 ) -> Changelog:
-    if session is not None:
-        session.get(ModifiableVscodeSettings).remove(keys)
-        return []
-    resource = ModifiableVscodeSettings.load()
-    resource.remove(keys)
-    resource.dump()
-    return resource.changelog
+    session.get(ModifiableVscodeSettings).remove(keys)
+    return []
 
 
 def _remove_keys(obj: T, keys: RemovedKeys) -> T:
@@ -204,15 +195,10 @@ def _remove_keys(obj: T, keys: RemovedKeys) -> T:
 def update_settings(
     new_settings: dict,
     *,
-    session: Session | None = None,
+    session: Session,
 ) -> Changelog:
-    if session is not None:
-        session.get(ModifiableVscodeSettings).update(new_settings)
-        return []
-    resource = ModifiableVscodeSettings.load()
-    resource.update(new_settings)
-    resource.dump()
-    return resource.changelog
+    session.get(ModifiableVscodeSettings).update(new_settings)
+    return []
 
 
 def _update_dict_recursively(old: dict, new: dict, sort: bool = False) -> dict:
@@ -264,29 +250,19 @@ def _update_settings_if_changed(old: dict, new: dict) -> Changelog:
 def add_extension_recommendation(
     extension_name: str,
     *,
-    session: Session | None = None,
+    session: Session,
 ) -> Changelog:
-    if session is not None:
-        session.get(ModifiableVscodeExtensions).add_recommendation(extension_name)
-        return []
-    resource = ModifiableVscodeExtensions.load()
-    resource.add_recommendation(extension_name)
-    resource.dump()
-    return resource.changelog
+    session.get(ModifiableVscodeExtensions).add_recommendation(extension_name)
+    return []
 
 
 def add_unwanted_extension(
     extension_name: str,
     *,
-    session: Session | None = None,
+    session: Session,
 ) -> Changelog:
-    if session is not None:
-        session.get(ModifiableVscodeExtensions).add_unwanted(extension_name)
-        return []
-    resource = ModifiableVscodeExtensions.load()
-    resource.add_unwanted(extension_name)
-    resource.dump()
-    return resource.changelog
+    session.get(ModifiableVscodeExtensions).add_unwanted(extension_name)
+    return []
 
 
 def __add_extension(extension_name: str, key: str) -> Changelog:
@@ -320,17 +296,12 @@ def remove_extension_recommendation(
     extension_name: str,
     *,
     unwanted: bool = False,
-    session: Session | None = None,
+    session: Session,
 ) -> Changelog:
-    if session is not None:
-        session.get(ModifiableVscodeExtensions).remove_recommendation(
-            extension_name, unwanted=unwanted
-        )
-        return []
-    resource = ModifiableVscodeExtensions.load()
-    resource.remove_recommendation(extension_name, unwanted=unwanted)
-    resource.dump()
-    return resource.changelog
+    session.get(ModifiableVscodeExtensions).remove_recommendation(
+        extension_name, unwanted=unwanted
+    )
+    return []
 
 
 def _to_lower(lst: list[str]) -> list[str]:

--- a/src/compwa_policy/utilities/vscode.py
+++ b/src/compwa_policy/utilities/vscode.py
@@ -143,9 +143,8 @@ def _get_extension_recommendations(key: str) -> set[str]:
     return {ext.lower() for ext in extensions}
 
 
-def remove_settings(session: Session, /, keys: RemovedKeys) -> Changelog:
+def remove_settings(session: Session, /, keys: RemovedKeys) -> None:
     session.get(ModifiableVscodeSettings).remove(keys)
-    return []
 
 
 def _remove_keys(obj: T, keys: RemovedKeys) -> T:
@@ -188,9 +187,8 @@ def _remove_keys(obj: T, keys: RemovedKeys) -> T:
     return obj
 
 
-def update_settings(session: Session, /, new_settings: dict) -> Changelog:
+def update_settings(session: Session, /, new_settings: dict) -> None:
     session.get(ModifiableVscodeSettings).update(new_settings)
-    return []
 
 
 def _update_dict_recursively(old: dict, new: dict, sort: bool = False) -> dict:
@@ -239,14 +237,12 @@ def _update_settings_if_changed(old: dict, new: dict) -> Changelog:
     return ["Updated VS Code settings"]
 
 
-def add_extension_recommendation(session: Session, /, extension_name: str) -> Changelog:
+def add_extension_recommendation(session: Session, /, extension_name: str) -> None:
     session.get(ModifiableVscodeExtensions).add_recommendation(extension_name)
-    return []
 
 
-def add_unwanted_extension(session: Session, /, extension_name: str) -> Changelog:
+def add_unwanted_extension(session: Session, /, extension_name: str) -> None:
     session.get(ModifiableVscodeExtensions).add_unwanted(extension_name)
-    return []
 
 
 def __add_extension(extension_name: str, key: str) -> Changelog:
@@ -278,11 +274,10 @@ def __remove_extension(extension_name: str, key: str) -> Changelog:
 
 def remove_extension_recommendation(
     session: Session, /, extension_name: str, *, unwanted: bool = False
-) -> Changelog:
+) -> None:
     session.get(ModifiableVscodeExtensions).remove_recommendation(
         extension_name, unwanted=unwanted
     )
-    return []
 
 
 def _to_lower(lst: list[str]) -> list[str]:

--- a/src/compwa_policy/utilities/vscode.py
+++ b/src/compwa_policy/utilities/vscode.py
@@ -128,11 +128,11 @@ class ModifiableVscodeExtensions(_ModifiableJsonResource):
         )
 
 
-def get_recommended_extensions(*, session: Session) -> set[str]:
+def get_recommended_extensions(session: Session, /) -> set[str]:
     return session.get(ModifiableVscodeExtensions).get_recommended()
 
 
-def get_unwanted_extensions(*, session: Session) -> set[str]:
+def get_unwanted_extensions(session: Session, /) -> set[str]:
     return session.get(ModifiableVscodeExtensions).get_unwanted()
 
 
@@ -143,11 +143,7 @@ def _get_extension_recommendations(key: str) -> set[str]:
     return {ext.lower() for ext in extensions}
 
 
-def remove_settings(
-    keys: RemovedKeys,
-    *,
-    session: Session,
-) -> Changelog:
+def remove_settings(session: Session, /, keys: RemovedKeys) -> Changelog:
     session.get(ModifiableVscodeSettings).remove(keys)
     return []
 
@@ -192,11 +188,7 @@ def _remove_keys(obj: T, keys: RemovedKeys) -> T:
     return obj
 
 
-def update_settings(
-    new_settings: dict,
-    *,
-    session: Session,
-) -> Changelog:
+def update_settings(session: Session, /, new_settings: dict) -> Changelog:
     session.get(ModifiableVscodeSettings).update(new_settings)
     return []
 
@@ -247,20 +239,12 @@ def _update_settings_if_changed(old: dict, new: dict) -> Changelog:
     return ["Updated VS Code settings"]
 
 
-def add_extension_recommendation(
-    extension_name: str,
-    *,
-    session: Session,
-) -> Changelog:
+def add_extension_recommendation(session: Session, /, extension_name: str) -> Changelog:
     session.get(ModifiableVscodeExtensions).add_recommendation(extension_name)
     return []
 
 
-def add_unwanted_extension(
-    extension_name: str,
-    *,
-    session: Session,
-) -> Changelog:
+def add_unwanted_extension(session: Session, /, extension_name: str) -> Changelog:
     session.get(ModifiableVscodeExtensions).add_unwanted(extension_name)
     return []
 
@@ -293,10 +277,7 @@ def __remove_extension(extension_name: str, key: str) -> Changelog:
 
 
 def remove_extension_recommendation(
-    extension_name: str,
-    *,
-    unwanted: bool = False,
-    session: Session,
+    session: Session, /, extension_name: str, *, unwanted: bool = False
 ) -> Changelog:
     session.get(ModifiableVscodeExtensions).remove_recommendation(
         extension_name, unwanted=unwanted

--- a/src/compwa_policy/utilities/vscode.py
+++ b/src/compwa_policy/utilities/vscode.py
@@ -3,18 +3,25 @@
 from __future__ import annotations
 
 import json
+import sys
 from collections import abc
 from collections.abc import Iterable, Sized
 from functools import cache
 from typing import TYPE_CHECKING, Any, TypeVar
 
 from compwa_policy.utilities import CONFIG_PATH
+from compwa_policy.utilities.resource import (
+    Changelog,
+    ModifiableResource,
+    get_active_session,
+)
 
 if TYPE_CHECKING:
     from pathlib import Path
-
-    from compwa_policy.utilities.session import Changelog
-
+if sys.version_info >= (3, 11):
+    from typing import Self
+else:
+    from typing_extensions import Self
 
 K = TypeVar("K")
 V = TypeVar("V")
@@ -25,11 +32,115 @@ RemovedKeys = Iterable[str] | dict[str, "RemovedKeys"]
 """Type for keys to be removed from a (nested) dictionary."""
 
 
+class _ModifiableJsonResource(ModifiableResource):
+    path: Path
+
+    def __init__(self, document: dict, *, exists: bool) -> None:
+        self._document = document
+        self._exists = exists
+        self._changelog: Changelog = []
+
+    @classmethod
+    def load(cls) -> Self:
+        if not cls.path.exists():
+            return cls({}, exists=False)
+        with cls.path.open() as stream:
+            return cls(json.load(stream), exists=True)
+
+    @property
+    def changelog(self) -> Changelog:
+        return self._changelog
+
+    def dump(self) -> None:
+        if not self._changelog:
+            return
+        self.path.parent.mkdir(exist_ok=True)
+        _dump_config(self._document, self.path)
+
+
+class ModifiableVscodeSettings(_ModifiableJsonResource):
+    """In-memory representation of :file:`.vscode/settings.json`."""
+
+    path = CONFIG_PATH.vscode_settings
+
+    def remove(self, keys: RemovedKeys) -> None:
+        updated = _remove_keys(self._document, keys)
+        if updated != self._document:
+            self._document = updated
+            self._changelog.append("Updated VS Code settings")
+
+    def update(self, new_settings: dict) -> None:
+        updated = _update_dict_recursively(self._document, new_settings)
+        if updated != self._document:
+            self._document = updated
+            self._changelog.append("Updated VS Code settings")
+
+
+class ModifiableVscodeExtensions(_ModifiableJsonResource):
+    """In-memory representation of :file:`.vscode/extensions.json`."""
+
+    path = CONFIG_PATH.vscode_extensions
+
+    def get_recommended(self) -> set[str]:
+        return self._get("recommendations")
+
+    def get_unwanted(self) -> set[str]:
+        return self._get("unwantedRecommendations")
+
+    def add_recommendation(self, extension_name: str) -> None:
+        self._add(extension_name, "recommendations")
+        self._remove(extension_name, "unwantedRecommendations")
+
+    def add_unwanted(self, extension_name: str) -> None:
+        self._add(extension_name, "unwantedRecommendations")
+        self._remove(extension_name, "recommendations")
+
+    def remove_recommendation(
+        self, extension_name: str, *, unwanted: bool = False
+    ) -> None:
+        self._remove(extension_name, "recommendations")
+        if unwanted:
+            self.add_unwanted(extension_name)
+
+    def _get(self, key: str) -> set[str]:
+        return set(_to_lower(self._document.get(key, [])))
+
+    def _add(self, extension_name: str, key: str) -> None:
+        extensions = _to_lower(self._document.get(key, []))
+        extension_name = extension_name.lower()
+        if extension_name in extensions:
+            return
+        extensions.append(extension_name)
+        self._document[key] = sorted(extensions)
+        self._changelog.append(
+            f'Added VS Code extension recommendation "{extension_name}"'
+        )
+
+    def _remove(self, extension_name: str, key: str) -> None:
+        if not self._exists:
+            return
+        extensions = _to_lower(self._document.get(key, []))
+        extension_name = extension_name.lower()
+        if extension_name not in extensions:
+            return
+        extensions.remove(extension_name)
+        self._document[key] = sorted(extensions)
+        self._changelog.append(
+            f'Removed VS Code extension recommendation "{extension_name}"'
+        )
+
+
 def get_recommended_extensions() -> set[str]:
+    session = get_active_session()
+    if session is not None:
+        return session.get(ModifiableVscodeExtensions).get_recommended()
     return _get_extension_recommendations("recommendations")
 
 
 def get_unwanted_extensions() -> set[str]:
+    session = get_active_session()
+    if session is not None:
+        return session.get(ModifiableVscodeExtensions).get_unwanted()
     return _get_extension_recommendations("unwantedRecommendations")
 
 
@@ -41,9 +152,14 @@ def _get_extension_recommendations(key: str) -> set[str]:
 
 
 def remove_settings(keys: RemovedKeys) -> Changelog:
-    settings = __load_config(CONFIG_PATH.vscode_settings, create=True)
-    new_settings = _remove_keys(settings, keys)
-    return _update_settings_if_changed(settings, new=new_settings)
+    session = get_active_session()
+    if session is not None:
+        session.get(ModifiableVscodeSettings).remove(keys)
+        return []
+    resource = ModifiableVscodeSettings.load()
+    resource.remove(keys)
+    resource.dump()
+    return resource.changelog
 
 
 def _remove_keys(obj: T, keys: RemovedKeys) -> T:
@@ -87,9 +203,14 @@ def _remove_keys(obj: T, keys: RemovedKeys) -> T:
 
 
 def update_settings(new_settings: dict) -> Changelog:
-    old = __load_config(CONFIG_PATH.vscode_settings, create=True)
-    updated = _update_dict_recursively(old, new_settings)
-    return _update_settings_if_changed(old, updated)
+    session = get_active_session()
+    if session is not None:
+        session.get(ModifiableVscodeSettings).update(new_settings)
+        return []
+    resource = ModifiableVscodeSettings.load()
+    resource.update(new_settings)
+    resource.dump()
+    return resource.changelog
 
 
 def _update_dict_recursively(old: dict, new: dict, sort: bool = False) -> dict:
@@ -134,32 +255,40 @@ def _determine_new_value(old: V, new: V, sort: bool = False) -> V:
 def _update_settings_if_changed(old: dict, new: dict) -> Changelog:
     if old == new:
         return []
-    __dump_config(new, CONFIG_PATH.vscode_settings)
+    _dump_config(new, CONFIG_PATH.vscode_settings)
     return ["Updated VS Code settings"]
 
 
 def add_extension_recommendation(extension_name: str) -> Changelog:
-    changes: Changelog = []
-    changes += __add_extension(extension_name, key="recommendations")
-    changes += __remove_extension(extension_name, key="unwantedRecommendations")
-    return changes
+    session = get_active_session()
+    if session is not None:
+        session.get(ModifiableVscodeExtensions).add_recommendation(extension_name)
+        return []
+    resource = ModifiableVscodeExtensions.load()
+    resource.add_recommendation(extension_name)
+    resource.dump()
+    return resource.changelog
 
 
 def add_unwanted_extension(extension_name: str) -> Changelog:
-    changes: Changelog = []
-    changes += __add_extension(extension_name, key="unwantedRecommendations")
-    changes += __remove_extension(extension_name, key="recommendations")
-    return changes
+    session = get_active_session()
+    if session is not None:
+        session.get(ModifiableVscodeExtensions).add_unwanted(extension_name)
+        return []
+    resource = ModifiableVscodeExtensions.load()
+    resource.add_unwanted(extension_name)
+    resource.dump()
+    return resource.changelog
 
 
 def __add_extension(extension_name: str, key: str) -> Changelog:
     config = __load_config(CONFIG_PATH.vscode_extensions, create=True)
-    recommended_extensions = __to_lower(config.get(key, []))
+    recommended_extensions = _to_lower(config.get(key, []))
     extension_name = extension_name.lower()
     if extension_name not in set(recommended_extensions):
         recommended_extensions.append(extension_name)
         config[key] = sorted(recommended_extensions)
-        __dump_config(config, CONFIG_PATH.vscode_extensions)
+        _dump_config(config, CONFIG_PATH.vscode_extensions)
         return [f'Added VS Code extension recommendation "{extension_name}"']
     return []
 
@@ -169,12 +298,12 @@ def __remove_extension(extension_name: str, key: str) -> Changelog:
         return []
     with open(CONFIG_PATH.vscode_extensions) as stream:
         config = json.load(stream)
-    recommended_extensions = __to_lower(config.get(key, []))
+    recommended_extensions = _to_lower(config.get(key, []))
     extension_name = extension_name.lower()
     if extension_name in recommended_extensions:
         recommended_extensions.remove(extension_name)
         config[key] = sorted(recommended_extensions)
-        __dump_config(config, CONFIG_PATH.vscode_extensions)
+        _dump_config(config, CONFIG_PATH.vscode_extensions)
         return [f'Removed VS Code extension recommendation "{extension_name}"']
     return []
 
@@ -182,18 +311,23 @@ def __remove_extension(extension_name: str, key: str) -> Changelog:
 def remove_extension_recommendation(
     extension_name: str, *, unwanted: bool = False
 ) -> Changelog:
-    changes: Changelog = []
-    changes += __remove_extension(extension_name, key="recommendations")
-    if unwanted:
-        changes += add_unwanted_extension(extension_name)
-    return changes
+    session = get_active_session()
+    if session is not None:
+        session.get(ModifiableVscodeExtensions).remove_recommendation(
+            extension_name, unwanted=unwanted
+        )
+        return []
+    resource = ModifiableVscodeExtensions.load()
+    resource.remove_recommendation(extension_name, unwanted=unwanted)
+    resource.dump()
+    return resource.changelog
 
 
-def __to_lower(lst: list[str]) -> list[str]:
+def _to_lower(lst: list[str]) -> list[str]:
     return [e.lower() for e in lst]
 
 
-def __dump_config(config: dict, path: Path) -> None:
+def _dump_config(config: dict, path: Path) -> None:
     with open(path, "w") as stream:
         json.dump(config, stream, ensure_ascii=False, indent=2, sort_keys=True)
         stream.write("\n")

--- a/src/compwa_policy/utilities/yaml.py
+++ b/src/compwa_policy/utilities/yaml.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+import io
 from typing import TYPE_CHECKING, Any
 
 import yaml
 from ruamel.yaml import YAML
+
+from compwa_policy.utilities import write
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -45,11 +48,12 @@ def read_preserved_yaml(src: str) -> Any:
 
 def write_yaml(definition: dict, output_path: Path | str) -> None:
     """Write a `dict` to disk with standardized YAML formatting."""
-    with open(output_path, "w") as stream:
-        yaml.dump(
-            definition,
-            stream,
-            sort_keys=False,
-            Dumper=_IncreasedYamlIndent,
-            default_flow_style=False,
-        )
+    stream = io.StringIO()
+    yaml.dump(
+        definition,
+        stream,
+        sort_keys=False,
+        Dumper=_IncreasedYamlIndent,
+        default_flow_style=False,
+    )
+    write(stream.getvalue(), output_path)

--- a/tests/env/test_conda.py
+++ b/tests/env/test_conda.py
@@ -46,14 +46,14 @@ def describe_update_conda_environment():
         monkeypatch.chdir(tmp_path)
         (tmp_path / "pyproject.toml").write_text("[project]\nversion = '0.1'\n")
         with Session() as session:
-            conda.update_conda_environment(session, "3.12")
+            conda.update_conda_environment(session, python_version="3.12")
 
     def updates_python_version(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
         monkeypatch.chdir(tmp_path)
         _write_pyproject(tmp_path)
         (tmp_path / "environment.yml").write_text(_ENVIRONMENT)
         with Session() as session:
-            conda.update_conda_environment(session, "3.12")
+            conda.update_conda_environment(session, python_version="3.12")
             changes = session.collect_changes()
         assert any("Updated Conda environment" in m for m in changes)
         result = (tmp_path / "environment.yml").read_text()
@@ -64,7 +64,7 @@ def describe_update_conda_environment():
         _write_pyproject(tmp_path)
         (tmp_path / "environment.yml").write_text(_ENVIRONMENT.replace("3.10", "3.12"))
         with Session() as session:
-            conda.update_conda_environment(session, "3.12")
+            conda.update_conda_environment(session, python_version="3.12")
 
     def uses_constraints_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
         monkeypatch.chdir(tmp_path)
@@ -74,7 +74,7 @@ def describe_update_conda_environment():
         (constraints / "py3.12.txt").write_text("numpy==1.0\n")
         (tmp_path / "environment.yml").write_text(_ENVIRONMENT.replace("3.10", "3.12"))
         with Session() as session:
-            conda.update_conda_environment(session, "3.12")
+            conda.update_conda_environment(session, python_version="3.12")
             changes = session.collect_changes()
         assert any("Updated Conda environment" in m for m in changes)
         result = (tmp_path / "environment.yml").read_text()

--- a/tests/env/test_conda.py
+++ b/tests/env/test_conda.py
@@ -46,14 +46,14 @@ def describe_update_conda_environment():
         monkeypatch.chdir(tmp_path)
         (tmp_path / "pyproject.toml").write_text("[project]\nversion = '0.1'\n")
         with Session() as session:
-            conda.update_conda_environment("3.12", session=session)
+            conda.update_conda_environment(session, "3.12")
 
     def updates_python_version(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
         monkeypatch.chdir(tmp_path)
         _write_pyproject(tmp_path)
         (tmp_path / "environment.yml").write_text(_ENVIRONMENT)
         with Session() as session:
-            changes = conda.update_conda_environment("3.12", session=session)
+            changes = conda.update_conda_environment(session, "3.12")
         assert any("Updated Conda environment" in m for m in changes)
         result = (tmp_path / "environment.yml").read_text()
         assert "python==3.12.*" in result
@@ -63,7 +63,7 @@ def describe_update_conda_environment():
         _write_pyproject(tmp_path)
         (tmp_path / "environment.yml").write_text(_ENVIRONMENT.replace("3.10", "3.12"))
         with Session() as session:
-            conda.update_conda_environment("3.12", session=session)
+            conda.update_conda_environment(session, "3.12")
 
     def uses_constraints_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
         monkeypatch.chdir(tmp_path)
@@ -73,7 +73,7 @@ def describe_update_conda_environment():
         (constraints / "py3.12.txt").write_text("numpy==1.0\n")
         (tmp_path / "environment.yml").write_text(_ENVIRONMENT.replace("3.10", "3.12"))
         with Session() as session:
-            changes = conda.update_conda_environment("3.12", session=session)
+            changes = conda.update_conda_environment(session, "3.12")
         assert any("Updated Conda environment" in m for m in changes)
         result = (tmp_path / "environment.yml").read_text()
         assert "-c .constraints/py3.12.txt -e .[dev]" in result

--- a/tests/env/test_conda.py
+++ b/tests/env/test_conda.py
@@ -53,7 +53,8 @@ def describe_update_conda_environment():
         _write_pyproject(tmp_path)
         (tmp_path / "environment.yml").write_text(_ENVIRONMENT)
         with Session() as session:
-            changes = conda.update_conda_environment(session, "3.12")
+            conda.update_conda_environment(session, "3.12")
+            changes = session.collect_changes()
         assert any("Updated Conda environment" in m for m in changes)
         result = (tmp_path / "environment.yml").read_text()
         assert "python==3.12.*" in result
@@ -73,7 +74,8 @@ def describe_update_conda_environment():
         (constraints / "py3.12.txt").write_text("numpy==1.0\n")
         (tmp_path / "environment.yml").write_text(_ENVIRONMENT.replace("3.10", "3.12"))
         with Session() as session:
-            changes = conda.update_conda_environment(session, "3.12")
+            conda.update_conda_environment(session, "3.12")
+            changes = session.collect_changes()
         assert any("Updated Conda environment" in m for m in changes)
         result = (tmp_path / "environment.yml").read_text()
         assert "-c .constraints/py3.12.txt -e .[dev]" in result

--- a/tests/env/test_conda.py
+++ b/tests/env/test_conda.py
@@ -45,13 +45,15 @@ def describe_update_conda_environment():
     def is_noop_without_package_name(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
         monkeypatch.chdir(tmp_path)
         (tmp_path / "pyproject.toml").write_text("[project]\nversion = '0.1'\n")
-        conda.update_conda_environment("3.12")  # no package name -> no-op
+        with Session() as session:
+            conda.update_conda_environment("3.12", session=session)
 
     def updates_python_version(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
         monkeypatch.chdir(tmp_path)
         _write_pyproject(tmp_path)
         (tmp_path / "environment.yml").write_text(_ENVIRONMENT)
-        changes = conda.update_conda_environment("3.12")
+        with Session() as session:
+            changes = conda.update_conda_environment("3.12", session=session)
         assert any("Updated Conda environment" in m for m in changes)
         result = (tmp_path / "environment.yml").read_text()
         assert "python==3.12.*" in result
@@ -60,7 +62,8 @@ def describe_update_conda_environment():
         monkeypatch.chdir(tmp_path)
         _write_pyproject(tmp_path)
         (tmp_path / "environment.yml").write_text(_ENVIRONMENT.replace("3.10", "3.12"))
-        conda.update_conda_environment("3.12")  # already up to date -> no error
+        with Session() as session:
+            conda.update_conda_environment("3.12", session=session)
 
     def uses_constraints_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
         monkeypatch.chdir(tmp_path)
@@ -69,7 +72,8 @@ def describe_update_conda_environment():
         constraints.mkdir()
         (constraints / "py3.12.txt").write_text("numpy==1.0\n")
         (tmp_path / "environment.yml").write_text(_ENVIRONMENT.replace("3.10", "3.12"))
-        changes = conda.update_conda_environment("3.12")
+        with Session() as session:
+            changes = conda.update_conda_environment("3.12", session=session)
         assert any("Updated Conda environment" in m for m in changes)
         result = (tmp_path / "environment.yml").read_text()
         assert "-c .constraints/py3.12.txt -e .[dev]" in result

--- a/tests/env/test_uv.py
+++ b/tests/env/test_uv.py
@@ -93,7 +93,7 @@ def describe_update_python_version_file():
             '[project]\nname = "x"\nrequires-python = ">=3.10"\n'
         )
         with Session() as session:
-            _update_python_version_file(session, "3.12")
+            _update_python_version_file(session, dev_python_version="3.12")
             changes = session.collect_changes()
         assert any("Updated .python-version" in m for m in changes)
         assert (tmp_path / ".python-version").read_text().strip() == "3.12"
@@ -105,7 +105,7 @@ def describe_update_python_version_file():
         )
         (tmp_path / ".python-version").write_text("3.12\n")
         with Session() as session:
-            _update_python_version_file(session, "3.12")
+            _update_python_version_file(session, dev_python_version="3.12")
             changes = session.collect_changes()
         assert any("Removed .python-version" in m for m in changes)
         assert not (tmp_path / ".python-version").exists()
@@ -117,7 +117,7 @@ def describe_update_python_version_file():
         )
         (tmp_path / ".python-version").write_text("3.12\n")
         with Session() as session:
-            _update_python_version_file(session, "3.12")
+            _update_python_version_file(session, dev_python_version="3.12")
 
 
 def describe_update_editor_config():

--- a/tests/env/test_uv.py
+++ b/tests/env/test_uv.py
@@ -15,6 +15,7 @@ from compwa_policy.env.uv import (
     main,
 )
 from compwa_policy.utilities.precommit import ModifiablePrecommit
+from compwa_policy.utilities.pyproject import ModifiablePyproject
 from compwa_policy.utilities.session import Session
 
 
@@ -33,7 +34,8 @@ def describe_remove_uv_configuration():
         (tmp_path / "pyproject.toml").write_text(
             '[project]\nname = "x"\n\n[tool.uv]\nmanaged = true\n'
         )
-        _remove_uv_configuration()
+        with ModifiablePyproject.load() as pyproject:
+            _remove_uv_configuration(pyproject)
         assert "[tool.uv]" not in (tmp_path / "pyproject.toml").read_text()
 
 
@@ -91,7 +93,7 @@ def describe_update_python_version_file():
             '[project]\nname = "x"\nrequires-python = ">=3.10"\n'
         )
         with Session() as session:
-            changes = _update_python_version_file("3.12", session=session)
+            changes = _update_python_version_file(session, "3.12")
         assert any("Updated .python-version" in m for m in changes)
         assert (tmp_path / ".python-version").read_text().strip() == "3.12"
 
@@ -102,7 +104,7 @@ def describe_update_python_version_file():
         )
         (tmp_path / ".python-version").write_text("3.12\n")
         with Session() as session:
-            changes = _update_python_version_file("3.12", session=session)
+            changes = _update_python_version_file(session, "3.12")
         assert any("Removed .python-version" in m for m in changes)
         assert not (tmp_path / ".python-version").exists()
 
@@ -113,7 +115,7 @@ def describe_update_python_version_file():
         )
         (tmp_path / ".python-version").write_text("3.12\n")
         with Session() as session:
-            _update_python_version_file("3.12", session=session)
+            _update_python_version_file(session, "3.12")
 
 
 def describe_update_editor_config():
@@ -141,7 +143,7 @@ def describe_update_contributing_file():
         )
         (tmp_path / "CONTRIBUTING.md").write_text("outdated\n")
         with Session() as session:
-            changes = _update_contributing_file("ComPWA", "policy", session=session)
+            changes = _update_contributing_file(session, "ComPWA", "policy")
         assert any("Updated CONTRIBUTING.md" in m for m in changes)
         result = (tmp_path / "CONTRIBUTING.md").read_text()
         assert "policy" in result

--- a/tests/env/test_uv.py
+++ b/tests/env/test_uv.py
@@ -90,7 +90,8 @@ def describe_update_python_version_file():
         (tmp_path / "pyproject.toml").write_text(
             '[project]\nname = "x"\nrequires-python = ">=3.10"\n'
         )
-        changes = _update_python_version_file("3.12")
+        with Session() as session:
+            changes = _update_python_version_file("3.12", session=session)
         assert any("Updated .python-version" in m for m in changes)
         assert (tmp_path / ".python-version").read_text().strip() == "3.12"
 
@@ -100,7 +101,8 @@ def describe_update_python_version_file():
             '[project]\nname = "x"\nrequires-python = "==3.12.*"\n'
         )
         (tmp_path / ".python-version").write_text("3.12\n")
-        changes = _update_python_version_file("3.12")
+        with Session() as session:
+            changes = _update_python_version_file("3.12", session=session)
         assert any("Removed .python-version" in m for m in changes)
         assert not (tmp_path / ".python-version").exists()
 
@@ -110,7 +112,8 @@ def describe_update_python_version_file():
             '[project]\nname = "x"\nrequires-python = ">=3.10"\n'
         )
         (tmp_path / ".python-version").write_text("3.12\n")
-        _update_python_version_file("3.12")  # already up to date -> no error
+        with Session() as session:
+            _update_python_version_file("3.12", session=session)
 
 
 def describe_update_editor_config():
@@ -137,7 +140,8 @@ def describe_update_contributing_file():
             '[tool.poe.tasks.style]\ncmd = "check"\n'
         )
         (tmp_path / "CONTRIBUTING.md").write_text("outdated\n")
-        changes = _update_contributing_file("ComPWA", "policy")
+        with Session() as session:
+            changes = _update_contributing_file("ComPWA", "policy", session=session)
         assert any("Updated CONTRIBUTING.md" in m for m in changes)
         result = (tmp_path / "CONTRIBUTING.md").read_text()
         assert "policy" in result

--- a/tests/env/test_uv.py
+++ b/tests/env/test_uv.py
@@ -93,7 +93,8 @@ def describe_update_python_version_file():
             '[project]\nname = "x"\nrequires-python = ">=3.10"\n'
         )
         with Session() as session:
-            changes = _update_python_version_file(session, "3.12")
+            _update_python_version_file(session, "3.12")
+            changes = session.collect_changes()
         assert any("Updated .python-version" in m for m in changes)
         assert (tmp_path / ".python-version").read_text().strip() == "3.12"
 
@@ -104,7 +105,8 @@ def describe_update_python_version_file():
         )
         (tmp_path / ".python-version").write_text("3.12\n")
         with Session() as session:
-            changes = _update_python_version_file(session, "3.12")
+            _update_python_version_file(session, "3.12")
+            changes = session.collect_changes()
         assert any("Removed .python-version" in m for m in changes)
         assert not (tmp_path / ".python-version").exists()
 
@@ -143,7 +145,8 @@ def describe_update_contributing_file():
         )
         (tmp_path / "CONTRIBUTING.md").write_text("outdated\n")
         with Session() as session:
-            changes = _update_contributing_file(session, "ComPWA", "policy")
+            _update_contributing_file(session, "ComPWA", "policy")
+            changes = session.collect_changes()
         assert any("Updated CONTRIBUTING.md" in m for m in changes)
         result = (tmp_path / "CONTRIBUTING.md").read_text()
         assert "policy" in result

--- a/tests/format/test_prettier.py
+++ b/tests/format/test_prettier.py
@@ -54,7 +54,7 @@ def describe_remove_configuration():
         (tmp_path / ".prettierrc.json").write_text("{}")
         (tmp_path / ".prettierrc").write_text("{}")
         with Session() as session:
-            changes = _remove_configuration(session=session)
+            changes = _remove_configuration(session)
         assert any("Removed redundant configuration files" in m for m in changes)
         assert not (tmp_path / ".prettierrc.json").exists()
         assert not (tmp_path / ".prettierrc").exists()
@@ -63,7 +63,7 @@ def describe_remove_configuration():
         monkeypatch.chdir(tmp_path)
         (tmp_path / "README.md").write_text("# Title\n")
         with Session() as session:
-            _remove_configuration(session=session)
+            _remove_configuration(session)
 
 
 def describe_update_prettier_ignore():

--- a/tests/format/test_prettier.py
+++ b/tests/format/test_prettier.py
@@ -53,7 +53,8 @@ def describe_remove_configuration():
         monkeypatch.chdir(tmp_path)
         (tmp_path / ".prettierrc.json").write_text("{}")
         (tmp_path / ".prettierrc").write_text("{}")
-        changes = _remove_configuration()
+        with Session() as session:
+            changes = _remove_configuration(session=session)
         assert any("Removed redundant configuration files" in m for m in changes)
         assert not (tmp_path / ".prettierrc.json").exists()
         assert not (tmp_path / ".prettierrc").exists()
@@ -61,7 +62,8 @@ def describe_remove_configuration():
     def is_noop_without_files(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
         monkeypatch.chdir(tmp_path)
         (tmp_path / "README.md").write_text("# Title\n")
-        _remove_configuration()  # no config files and no badge to remove
+        with Session() as session:
+            _remove_configuration(session=session)
 
 
 def describe_update_prettier_ignore():

--- a/tests/format/test_prettier.py
+++ b/tests/format/test_prettier.py
@@ -54,7 +54,8 @@ def describe_remove_configuration():
         (tmp_path / ".prettierrc.json").write_text("{}")
         (tmp_path / ".prettierrc").write_text("{}")
         with Session() as session:
-            changes = _remove_configuration(session)
+            _remove_configuration(session)
+            changes = session.collect_changes()
         assert any("Removed redundant configuration files" in m for m in changes)
         assert not (tmp_path / ".prettierrc.json").exists()
         assert not (tmp_path / ".prettierrc").exists()

--- a/tests/format/test_toml.py
+++ b/tests/format/test_toml.py
@@ -107,7 +107,8 @@ def describe_update_tomlsort_config():
     def configures_sort_first(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
         monkeypatch.chdir(tmp_path)
         (tmp_path / "pyproject.toml").write_text('[project]\nname = "x"\n')
-        changes = _update_tomlsort_config()
+        with Session() as session:
+            changes = _update_tomlsort_config(session=session)
         assert any("toml-sort" in m for m in changes)
         result = (tmp_path / "pyproject.toml").read_text()
         assert "[tool.tomlsort]" in result
@@ -118,9 +119,11 @@ def describe_update_tomlsort_config():
     ):
         monkeypatch.chdir(tmp_path)
         (tmp_path / "pyproject.toml").write_text("[tool.other]\nkey = 1\n")
-        _update_tomlsort_config()
+        with Session() as session:
+            _update_tomlsort_config(session=session)
         assert "sort_first" not in (tmp_path / "pyproject.toml").read_text()
-        assert _update_tomlsort_config() == []
+        with Session() as session:
+            assert _update_tomlsort_config(session=session) == []
 
 
 def describe_update_taplo_config():
@@ -131,7 +134,8 @@ def describe_update_taplo_config():
     ):
         git_init(tmp_path)
         monkeypatch.chdir(tmp_path)
-        changes = _update_taplo_config()
+        with Session() as session:
+            changes = _update_taplo_config(session=session)
         assert any(".taplo.toml" in m for m in changes)
         assert (tmp_path / ".taplo.toml").exists()
 
@@ -142,9 +146,11 @@ def describe_update_taplo_config():
     ):
         git_init(tmp_path)
         monkeypatch.chdir(tmp_path)
-        assert _update_taplo_config()
+        with Session() as session:
+            assert _update_taplo_config(session=session)
         before = (tmp_path / ".taplo.toml").read_text()
-        assert _update_taplo_config() == []
+        with Session() as session:
+            assert _update_taplo_config(session=session) == []
         assert (tmp_path / ".taplo.toml").read_text() == before
 
 
@@ -152,8 +158,8 @@ def describe_update_vscode_extensions():
     def recommends_even_better_toml(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
         # cspell:ignore tamasfe
         monkeypatch.chdir(tmp_path)
-        changes = _update_vscode_extensions()
-        assert changes
+        with Session() as session:
+            _update_vscode_extensions(session=session)
         extensions = (tmp_path / ".vscode" / "extensions.json").read_text()
         assert "tamasfe.even-better-toml" in extensions
 

--- a/tests/format/test_toml.py
+++ b/tests/format/test_toml.py
@@ -108,7 +108,8 @@ def describe_update_tomlsort_config():
         monkeypatch.chdir(tmp_path)
         (tmp_path / "pyproject.toml").write_text('[project]\nname = "x"\n')
         with Session() as session:
-            changes = _update_tomlsort_config(session=session)
+            _update_tomlsort_config(session=session)
+            changes = session.collect_changes()
         assert any("toml-sort" in m for m in changes)
         result = (tmp_path / "pyproject.toml").read_text()
         assert "[tool.tomlsort]" in result

--- a/tests/format/test_toml.py
+++ b/tests/format/test_toml.py
@@ -108,7 +108,7 @@ def describe_update_tomlsort_config():
         monkeypatch.chdir(tmp_path)
         (tmp_path / "pyproject.toml").write_text('[project]\nname = "x"\n')
         with Session() as session:
-            _update_tomlsort_config(session=session)
+            _update_tomlsort_config(session)
             changes = session.collect_changes()
         assert any("toml-sort" in m for m in changes)
         result = (tmp_path / "pyproject.toml").read_text()
@@ -121,10 +121,10 @@ def describe_update_tomlsort_config():
         monkeypatch.chdir(tmp_path)
         (tmp_path / "pyproject.toml").write_text("[tool.other]\nkey = 1\n")
         with Session() as session:
-            _update_tomlsort_config(session=session)
+            _update_tomlsort_config(session)
         assert "sort_first" not in (tmp_path / "pyproject.toml").read_text()
         with Session() as session:
-            assert _update_tomlsort_config(session=session) == []
+            assert _update_tomlsort_config(session) == []
 
 
 def describe_update_taplo_config():
@@ -136,7 +136,7 @@ def describe_update_taplo_config():
         git_init(tmp_path)
         monkeypatch.chdir(tmp_path)
         with Session() as session:
-            changes = _update_taplo_config(session=session)
+            changes = _update_taplo_config(session)
         assert any(".taplo.toml" in m for m in changes)
         assert (tmp_path / ".taplo.toml").exists()
 
@@ -148,10 +148,10 @@ def describe_update_taplo_config():
         git_init(tmp_path)
         monkeypatch.chdir(tmp_path)
         with Session() as session:
-            assert _update_taplo_config(session=session)
+            assert _update_taplo_config(session)
         before = (tmp_path / ".taplo.toml").read_text()
         with Session() as session:
-            assert _update_taplo_config(session=session) == []
+            assert _update_taplo_config(session) == []
         assert (tmp_path / ".taplo.toml").read_text() == before
 
 
@@ -160,7 +160,7 @@ def describe_update_vscode_extensions():
         # cspell:ignore tamasfe
         monkeypatch.chdir(tmp_path)
         with Session() as session:
-            _update_vscode_extensions(session=session)
+            _update_vscode_extensions(session)
         extensions = (tmp_path / ".vscode" / "extensions.json").read_text()
         assert "tamasfe.even-better-toml" in extensions
 

--- a/tests/format/test_toml.py
+++ b/tests/format/test_toml.py
@@ -124,7 +124,8 @@ def describe_update_tomlsort_config():
             _update_tomlsort_config(session)
         assert "sort_first" not in (tmp_path / "pyproject.toml").read_text()
         with Session() as session:
-            assert _update_tomlsort_config(session) == []
+            _update_tomlsort_config(session)
+            assert session.collect_changes() == []
 
 
 def describe_update_taplo_config():
@@ -136,7 +137,8 @@ def describe_update_taplo_config():
         git_init(tmp_path)
         monkeypatch.chdir(tmp_path)
         with Session() as session:
-            changes = _update_taplo_config(session)
+            _update_taplo_config(session)
+            changes = session.collect_changes()
         assert any(".taplo.toml" in m for m in changes)
         assert (tmp_path / ".taplo.toml").exists()
 
@@ -148,10 +150,12 @@ def describe_update_taplo_config():
         git_init(tmp_path)
         monkeypatch.chdir(tmp_path)
         with Session() as session:
-            assert _update_taplo_config(session)
+            _update_taplo_config(session)
+            assert session.collect_changes()
         before = (tmp_path / ".taplo.toml").read_text()
         with Session() as session:
-            assert _update_taplo_config(session) == []
+            _update_taplo_config(session)
+            assert session.collect_changes() == []
         assert (tmp_path / ".taplo.toml").read_text() == before
 
 

--- a/tests/nb/test_binder.py
+++ b/tests/nb/test_binder.py
@@ -67,7 +67,7 @@ def describe_update_post_build():
             pytest.raises(NotImplementedError, match=r"conda is not supported"),
             Session() as session,
         ):
-            binder._update_post_build(session, "conda")
+            binder._update_post_build(session, package_manager="conda")
 
 
 def describe_make_executable():

--- a/tests/nb/test_binder.py
+++ b/tests/nb/test_binder.py
@@ -67,7 +67,7 @@ def describe_update_post_build():
             pytest.raises(NotImplementedError, match=r"conda is not supported"),
             Session() as session,
         ):
-            binder._update_post_build("conda", session=session)
+            binder._update_post_build(session, "conda")
 
 
 def describe_make_executable():

--- a/tests/nb/test_binder.py
+++ b/tests/nb/test_binder.py
@@ -63,8 +63,11 @@ def describe_update_apt_txt():
 def describe_update_post_build():
     def raises_for_unsupported_manager(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
         monkeypatch.chdir(tmp_path)
-        with pytest.raises(NotImplementedError, match=r"conda is not supported"):
-            binder._update_post_build("conda")
+        with (
+            pytest.raises(NotImplementedError, match=r"conda is not supported"),
+            Session() as session,
+        ):
+            binder._update_post_build("conda", session=session)
 
 
 def describe_make_executable():

--- a/tests/pyright/test_pyright.py
+++ b/tests/pyright/test_pyright.py
@@ -149,7 +149,7 @@ def describe_update_vscode_settings():
     def recommends_pylance_when_active(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
         monkeypatch.chdir(tmp_path)
         with Session() as session:
-            _update_vscode_settings(active=True, session=session)
+            _update_vscode_settings(session, active=True)
         extensions = json.loads((tmp_path / ".vscode" / "extensions.json").read_text())
         assert "ms-python.vscode-pylance" in extensions["recommendations"]
 
@@ -161,7 +161,7 @@ def describe_update_vscode_settings():
             json.dumps({"recommendations": ["ms-python.vscode-pylance"]})
         )
         with Session() as session:
-            _update_vscode_settings(active=False, session=session)
+            _update_vscode_settings(session, active=False)
         extensions = json.loads((vscode_dir / "extensions.json").read_text())
         assert "ms-python.vscode-pylance" not in extensions.get("recommendations", [])
 
@@ -198,7 +198,7 @@ def describe_remove_pyright():
             ModifiablePyproject.load(pyproject_path) as pyproject,
             Session(precommit=precommit, pyproject=pyproject) as session,
         ):
-            _remove_pyright(session=session)
+            _remove_pyright(session)
         assert not (tmp_path / "pyrightconfig.json").exists()
         assert "tool.pyright" not in pyproject.dumps()
         assert "id: pyright" not in precommit.dumps()

--- a/tests/pyright/test_pyright.py
+++ b/tests/pyright/test_pyright.py
@@ -148,7 +148,8 @@ def describe_remove_excludes():
 def describe_update_vscode_settings():
     def recommends_pylance_when_active(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
         monkeypatch.chdir(tmp_path)
-        _update_vscode_settings(active=True)
+        with Session() as session:
+            _update_vscode_settings(active=True, session=session)
         extensions = json.loads((tmp_path / ".vscode" / "extensions.json").read_text())
         assert "ms-python.vscode-pylance" in extensions["recommendations"]
 
@@ -159,7 +160,8 @@ def describe_update_vscode_settings():
         (vscode_dir / "extensions.json").write_text(
             json.dumps({"recommendations": ["ms-python.vscode-pylance"]})
         )
-        _update_vscode_settings(active=False)
+        with Session() as session:
+            _update_vscode_settings(active=False, session=session)
         extensions = json.loads((vscode_dir / "extensions.json").read_text())
         assert "ms-python.vscode-pylance" not in extensions.get("recommendations", [])
 
@@ -194,8 +196,9 @@ def describe_remove_pyright():
         with (
             ModifiablePrecommit.load(precommit_path) as precommit,
             ModifiablePyproject.load(pyproject_path) as pyproject,
+            Session() as session,
         ):
-            _remove_pyright(precommit, pyproject)
+            _remove_pyright(precommit, pyproject, session=session)
         assert not (tmp_path / "pyrightconfig.json").exists()
         assert "tool.pyright" not in pyproject.dumps()
         assert "id: pyright" not in precommit.dumps()

--- a/tests/pyright/test_pyright.py
+++ b/tests/pyright/test_pyright.py
@@ -196,7 +196,7 @@ def describe_remove_pyright():
         with (
             ModifiablePrecommit.load(precommit_path) as precommit,
             ModifiablePyproject.load(pyproject_path) as pyproject,
-            Session(precommit=precommit, pyproject=pyproject) as session,
+            Session(precommit, pyproject) as session,
         ):
             _remove_pyright(session)
         assert not (tmp_path / "pyrightconfig.json").exists()

--- a/tests/pyright/test_pyright.py
+++ b/tests/pyright/test_pyright.py
@@ -196,9 +196,9 @@ def describe_remove_pyright():
         with (
             ModifiablePrecommit.load(precommit_path) as precommit,
             ModifiablePyproject.load(pyproject_path) as pyproject,
-            Session() as session,
+            Session(precommit=precommit, pyproject=pyproject) as session,
         ):
-            _remove_pyright(precommit, pyproject, session=session)
+            _remove_pyright(session=session)
         assert not (tmp_path / "pyrightconfig.json").exists()
         assert "tool.pyright" not in pyproject.dumps()
         assert "id: pyright" not in precommit.dumps()

--- a/tests/python/test_mypy.py
+++ b/tests/python/test_mypy.py
@@ -77,8 +77,9 @@ def describe_remove_mypy():
         with (
             ModifiablePrecommit.load(io.StringIO(_PRECOMMIT_WITH_MYPY)) as precommit,
             ModifiablePyproject.load(io.StringIO(pyproject_config)) as pyproject,
+            Session() as session,
         ):
-            _remove_mypy(precommit, pyproject)
+            _remove_mypy(precommit, pyproject, session=session)
         assert "mypy" not in precommit.dumps()
         assert "tool.mypy" not in pyproject.dumps()
 
@@ -86,8 +87,9 @@ def describe_remove_mypy():
         with (
             ModifiablePrecommit.load(io.StringIO("repos: []\n")) as precommit,
             ModifiablePyproject.load(io.StringIO("")) as pyproject,
+            Session() as session,
         ):
-            _remove_mypy(precommit, pyproject)  # no tool.mypy table to remove
+            _remove_mypy(precommit, pyproject, session=session)
 
 
 def describe_update_vscode_settings():
@@ -95,7 +97,8 @@ def describe_update_vscode_settings():
         tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ):
         monkeypatch.chdir(tmp_path)
-        _update_vscode_settings(mypy=True)
+        with Session() as session:
+            _update_vscode_settings(mypy=True, session=session)
         settings = json.loads((tmp_path / ".vscode" / "settings.json").read_text())
         assert "mypy-type-checker.args" in settings
 
@@ -103,7 +106,8 @@ def describe_update_vscode_settings():
         tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ):
         monkeypatch.chdir(tmp_path)
-        _update_vscode_settings(mypy=False)
+        with Session() as session:
+            _update_vscode_settings(mypy=False, session=session)
         extensions = json.loads((tmp_path / ".vscode" / "extensions.json").read_text())
         assert "ms-python.mypy-type-checker" in extensions["unwantedRecommendations"]
 

--- a/tests/python/test_mypy.py
+++ b/tests/python/test_mypy.py
@@ -77,9 +77,9 @@ def describe_remove_mypy():
         with (
             ModifiablePrecommit.load(io.StringIO(_PRECOMMIT_WITH_MYPY)) as precommit,
             ModifiablePyproject.load(io.StringIO(pyproject_config)) as pyproject,
-            Session() as session,
+            Session(precommit=precommit, pyproject=pyproject) as session,
         ):
-            _remove_mypy(precommit, pyproject, session=session)
+            _remove_mypy(session=session)
         assert "mypy" not in precommit.dumps()
         assert "tool.mypy" not in pyproject.dumps()
 
@@ -87,9 +87,9 @@ def describe_remove_mypy():
         with (
             ModifiablePrecommit.load(io.StringIO("repos: []\n")) as precommit,
             ModifiablePyproject.load(io.StringIO("")) as pyproject,
-            Session() as session,
+            Session(precommit=precommit, pyproject=pyproject) as session,
         ):
-            _remove_mypy(precommit, pyproject, session=session)
+            _remove_mypy(session=session)
 
 
 def describe_update_vscode_settings():

--- a/tests/python/test_mypy.py
+++ b/tests/python/test_mypy.py
@@ -77,7 +77,7 @@ def describe_remove_mypy():
         with (
             ModifiablePrecommit.load(io.StringIO(_PRECOMMIT_WITH_MYPY)) as precommit,
             ModifiablePyproject.load(io.StringIO(pyproject_config)) as pyproject,
-            Session(precommit=precommit, pyproject=pyproject) as session,
+            Session(precommit, pyproject) as session,
         ):
             _remove_mypy(session)
         assert "mypy" not in precommit.dumps()
@@ -87,7 +87,7 @@ def describe_remove_mypy():
         with (
             ModifiablePrecommit.load(io.StringIO("repos: []\n")) as precommit,
             ModifiablePyproject.load(io.StringIO("")) as pyproject,
-            Session(precommit=precommit, pyproject=pyproject) as session,
+            Session(precommit, pyproject) as session,
         ):
             _remove_mypy(session)
 

--- a/tests/python/test_mypy.py
+++ b/tests/python/test_mypy.py
@@ -79,7 +79,7 @@ def describe_remove_mypy():
             ModifiablePyproject.load(io.StringIO(pyproject_config)) as pyproject,
             Session(precommit=precommit, pyproject=pyproject) as session,
         ):
-            _remove_mypy(session=session)
+            _remove_mypy(session)
         assert "mypy" not in precommit.dumps()
         assert "tool.mypy" not in pyproject.dumps()
 
@@ -89,7 +89,7 @@ def describe_remove_mypy():
             ModifiablePyproject.load(io.StringIO("")) as pyproject,
             Session(precommit=precommit, pyproject=pyproject) as session,
         ):
-            _remove_mypy(session=session)
+            _remove_mypy(session)
 
 
 def describe_update_vscode_settings():
@@ -98,7 +98,7 @@ def describe_update_vscode_settings():
     ):
         monkeypatch.chdir(tmp_path)
         with Session() as session:
-            _update_vscode_settings(mypy=True, session=session)
+            _update_vscode_settings(session, mypy=True)
         settings = json.loads((tmp_path / ".vscode" / "settings.json").read_text())
         assert "mypy-type-checker.args" in settings
 
@@ -107,7 +107,7 @@ def describe_update_vscode_settings():
     ):
         monkeypatch.chdir(tmp_path)
         with Session() as session:
-            _update_vscode_settings(mypy=False, session=session)
+            _update_vscode_settings(session, mypy=False)
         extensions = json.loads((tmp_path / ".vscode" / "extensions.json").read_text())
         assert "ms-python.mypy-type-checker" in extensions["unwantedRecommendations"]
 

--- a/tests/python/test_pytest.py
+++ b/tests/python/test_pytest.py
@@ -179,7 +179,13 @@ def describe_update_vscode_settings():
     def enables_coverage_gutters(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
         monkeypatch.chdir(tmp_path)
         pyproject = Pyproject.load(io.StringIO('[project]\nname = "my-package"\n'))
-        _update_vscode_settings(pyproject, coverage_gutters=True, single_threaded=False)
+        with Session() as session:
+            _update_vscode_settings(
+                pyproject,
+                coverage_gutters=True,
+                single_threaded=False,
+                session=session,
+            )
         settings = json.loads((tmp_path / ".vscode" / "settings.json").read_text())
         assert settings["testing.showCoverageInExplorer"] is True
         extensions = json.loads((tmp_path / ".vscode" / "extensions.json").read_text())

--- a/tests/python/test_pytest.py
+++ b/tests/python/test_pytest.py
@@ -15,7 +15,7 @@ from compwa_policy.python.pytest import (
     _update_vscode_settings,
     main,
 )
-from compwa_policy.utilities.pyproject import ModifiablePyproject, Pyproject
+from compwa_policy.utilities.pyproject import ModifiablePyproject
 from compwa_policy.utilities.session import Session
 
 # cspell:ignore minversion ryanluker xdist
@@ -178,13 +178,14 @@ def describe_update_codecov_settings():
 def describe_update_vscode_settings():
     def enables_coverage_gutters(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
         monkeypatch.chdir(tmp_path)
-        pyproject = Pyproject.load(io.StringIO('[project]\nname = "my-package"\n'))
-        with Session() as session:
+        pyproject = ModifiablePyproject.load(
+            io.StringIO('[project]\nname = "my-package"\n')
+        )
+        with Session(pyproject=pyproject) as session:
             _update_vscode_settings(
-                pyproject,
+                session,
                 coverage_gutters=True,
                 single_threaded=False,
-                session=session,
             )
         settings = json.loads((tmp_path / ".vscode" / "settings.json").read_text())
         assert settings["testing.showCoverageInExplorer"] is True

--- a/tests/python/test_ruff.py
+++ b/tests/python/test_ruff.py
@@ -158,8 +158,11 @@ def describe_update_lint_dependencies():
             classifiers = ["Programming Language :: Python :: 3.10"]
         """).lstrip()
         (tmp_path / "pyproject.toml").write_text(config)
-        with ModifiablePyproject.load(io.StringIO(config)) as pyproject:
-            _update_lint_dependencies(pyproject)
+        with (
+            ModifiablePyproject.load(io.StringIO(config)) as pyproject,
+            Session() as session,
+        ):
+            _update_lint_dependencies(pyproject, session=session)
         assert pyproject.changelog  # something changed
         assert "ruff" in pyproject.dumps()
 
@@ -173,8 +176,11 @@ def describe_update_lint_dependencies():
             classifiers = ["Programming Language :: Python :: 3.6"]
         """).lstrip()
         (tmp_path / "pyproject.toml").write_text(config)
-        with ModifiablePyproject.load(io.StringIO(config)) as pyproject:
-            _update_lint_dependencies(pyproject)
+        with (
+            ModifiablePyproject.load(io.StringIO(config)) as pyproject,
+            Session() as session,
+        ):
+            _update_lint_dependencies(pyproject, session=session)
         assert pyproject.changelog  # something changed
         result = pyproject.dumps()
         assert "python_version" in result
@@ -187,5 +193,8 @@ def describe_update_lint_dependencies():
             [project]
             classifiers = ["Programming Language :: Python :: 3.10"]
         """).lstrip()
-        with ModifiablePyproject.load(io.StringIO(config)) as pyproject:
-            _update_lint_dependencies(pyproject)  # no package name -> no-op
+        with (
+            ModifiablePyproject.load(io.StringIO(config)) as pyproject,
+            Session() as session,
+        ):
+            _update_lint_dependencies(pyproject, session=session)

--- a/tests/python/test_ruff.py
+++ b/tests/python/test_ruff.py
@@ -158,13 +158,12 @@ def describe_update_lint_dependencies():
             classifiers = ["Programming Language :: Python :: 3.10"]
         """).lstrip()
         (tmp_path / "pyproject.toml").write_text(config)
-        with (
-            ModifiablePyproject.load(io.StringIO(config)) as pyproject,
-            Session() as session,
-        ):
-            _update_lint_dependencies(pyproject, session=session)
-        assert pyproject.changelog  # something changed
-        assert "ruff" in pyproject.dumps()
+        with Session() as session:
+            pyproject = session.pyproject
+            _update_lint_dependencies(session=session)
+            assert pyproject is not None
+            assert pyproject.changelog  # something changed
+            assert "ruff" in pyproject.dumps()
 
     def pins_python_version_for_legacy_python(
         tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -176,25 +175,17 @@ def describe_update_lint_dependencies():
             classifiers = ["Programming Language :: Python :: 3.6"]
         """).lstrip()
         (tmp_path / "pyproject.toml").write_text(config)
-        with (
-            ModifiablePyproject.load(io.StringIO(config)) as pyproject,
-            Session() as session,
-        ):
-            _update_lint_dependencies(pyproject, session=session)
-        assert pyproject.changelog  # something changed
-        result = pyproject.dumps()
+        with Session() as session:
+            pyproject = session.pyproject
+            _update_lint_dependencies(session=session)
+            assert pyproject is not None
+            assert pyproject.changelog  # something changed
+            result = pyproject.dumps()
         assert "python_version" in result
         assert "3.7.0" in result
 
     def is_noop_without_package_name(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
         monkeypatch.chdir(tmp_path)
         (tmp_path / "pyproject.toml").write_text("[tool.foo]\nx = 1\n")
-        config = dedent("""
-            [project]
-            classifiers = ["Programming Language :: Python :: 3.10"]
-        """).lstrip()
-        with (
-            ModifiablePyproject.load(io.StringIO(config)) as pyproject,
-            Session() as session,
-        ):
-            _update_lint_dependencies(pyproject, session=session)
+        with Session() as session:
+            _update_lint_dependencies(session=session)

--- a/tests/python/test_ruff.py
+++ b/tests/python/test_ruff.py
@@ -160,7 +160,7 @@ def describe_update_lint_dependencies():
         (tmp_path / "pyproject.toml").write_text(config)
         with Session() as session:
             pyproject = session.pyproject
-            _update_lint_dependencies(session=session)
+            _update_lint_dependencies(session)
             assert pyproject is not None
             assert pyproject.changelog  # something changed
             assert "ruff" in pyproject.dumps()
@@ -177,7 +177,7 @@ def describe_update_lint_dependencies():
         (tmp_path / "pyproject.toml").write_text(config)
         with Session() as session:
             pyproject = session.pyproject
-            _update_lint_dependencies(session=session)
+            _update_lint_dependencies(session)
             assert pyproject is not None
             assert pyproject.changelog  # something changed
             result = pyproject.dumps()
@@ -188,4 +188,4 @@ def describe_update_lint_dependencies():
         monkeypatch.chdir(tmp_path)
         (tmp_path / "pyproject.toml").write_text("[tool.foo]\nx = 1\n")
         with Session() as session:
-            _update_lint_dependencies(session=session)
+            _update_lint_dependencies(session)

--- a/tests/python/test_ty.py
+++ b/tests/python/test_ty.py
@@ -76,11 +76,10 @@ def describe_update_precommit_config():
             style = ["ty"]
             """,
         )
-        with (
-            ModifiablePrecommit.load(config) as precommit,
-            ModifiablePyproject.load(pyproject_path) as pyproject,
-        ):
-            _update_precommit_config(precommit, pyproject)
+        precommit = ModifiablePrecommit.load(config)
+        pyproject = ModifiablePyproject.load(pyproject_path)
+        with Session(precommit=precommit, pyproject=pyproject) as session:
+            _update_precommit_config(session)
         result = precommit.dumps()
         assert "https://github.com/astral-sh/ty-pre-commit" in result
         assert "id: ty" in result
@@ -105,11 +104,10 @@ def describe_update_precommit_config():
             typechecking = ["ty"]
             """,
         )
-        with (
-            ModifiablePrecommit.load(config) as precommit,
-            ModifiablePyproject.load(pyproject_path) as pyproject,
-        ):
-            _update_precommit_config(precommit, pyproject)
+        precommit = ModifiablePrecommit.load(config)
+        pyproject = ModifiablePyproject.load(pyproject_path)
+        with Session(precommit=precommit, pyproject=pyproject) as session:
+            _update_precommit_config(session)
         assert "args: [--no-default-groups, --group=types]" in precommit.dumps()
 
     def omits_args_without_matching_group(tmp_path: Path):
@@ -123,11 +121,10 @@ def describe_update_precommit_config():
             """,
         )
         pyproject_path = _write_pyproject(tmp_path, "[project]\nname = 'x'\n")
-        with (
-            ModifiablePrecommit.load(config) as precommit,
-            ModifiablePyproject.load(pyproject_path) as pyproject,
-        ):
-            _update_precommit_config(precommit, pyproject)
+        precommit = ModifiablePrecommit.load(config)
+        pyproject = ModifiablePyproject.load(pyproject_path)
+        with Session(precommit=precommit, pyproject=pyproject) as session:
+            _update_precommit_config(session)
         assert "args:" not in precommit.dumps()
 
     def migrates_local_hook(tmp_path: Path):
@@ -154,11 +151,10 @@ def describe_update_precommit_config():
             typechecking = ["ty"]
             """,
         )
-        with (
-            ModifiablePrecommit.load(config) as precommit,
-            ModifiablePyproject.load(pyproject_path) as pyproject,
-        ):
-            _update_precommit_config(precommit, pyproject)
+        precommit = ModifiablePrecommit.load(config)
+        pyproject = ModifiablePyproject.load(pyproject_path)
+        with Session(precommit=precommit, pyproject=pyproject) as session:
+            _update_precommit_config(session)
         result = precommit.dumps()
         assert "repo: local" not in result
         assert "https://github.com/astral-sh/ty-pre-commit" in result
@@ -174,7 +170,7 @@ def describe_update_vscode_settings():
     ):
         monkeypatch.chdir(tmp_path)
         with Session() as session:
-            _update_vscode_settings({"ty"}, session=session)
+            _update_vscode_settings(session, {"ty"})
         extensions = json.loads((tmp_path / ".vscode" / "extensions.json").read_text())
         assert "astral-sh.ty" in extensions["recommendations"]
 
@@ -188,7 +184,7 @@ def describe_update_vscode_settings():
             json.dumps({"recommendations": ["astral-sh.ty"]})
         )
         with Session() as session:
-            _update_vscode_settings({"mypy"}, session=session)
+            _update_vscode_settings(session, {"mypy"})
         extensions = json.loads((vscode_dir / "extensions.json").read_text())
         assert "astral-sh.ty" not in extensions.get("recommendations", [])
 
@@ -227,7 +223,7 @@ def describe_remove_ty():
             ModifiablePyproject.load(pyproject_path) as pyproject,
             Session(precommit=precommit, pyproject=pyproject) as session,
         ):
-            _remove_ty(session=session)
+            _remove_ty(session)
         assert not (tmp_path / "ty.toml").exists()
         assert "tool.ty" not in pyproject.dumps()
         assert "id: ty" not in precommit.dumps()

--- a/tests/python/test_ty.py
+++ b/tests/python/test_ty.py
@@ -78,7 +78,7 @@ def describe_update_precommit_config():
         )
         precommit = ModifiablePrecommit.load(config)
         pyproject = ModifiablePyproject.load(pyproject_path)
-        with Session(precommit=precommit, pyproject=pyproject) as session:
+        with Session(precommit, pyproject) as session:
             _update_precommit_config(session)
         result = precommit.dumps()
         assert "https://github.com/astral-sh/ty-pre-commit" in result
@@ -106,7 +106,7 @@ def describe_update_precommit_config():
         )
         precommit = ModifiablePrecommit.load(config)
         pyproject = ModifiablePyproject.load(pyproject_path)
-        with Session(precommit=precommit, pyproject=pyproject) as session:
+        with Session(precommit, pyproject) as session:
             _update_precommit_config(session)
         assert "args: [--no-default-groups, --group=types]" in precommit.dumps()
 
@@ -123,7 +123,7 @@ def describe_update_precommit_config():
         pyproject_path = _write_pyproject(tmp_path, "[project]\nname = 'x'\n")
         precommit = ModifiablePrecommit.load(config)
         pyproject = ModifiablePyproject.load(pyproject_path)
-        with Session(precommit=precommit, pyproject=pyproject) as session:
+        with Session(precommit, pyproject) as session:
             _update_precommit_config(session)
         assert "args:" not in precommit.dumps()
 
@@ -153,7 +153,7 @@ def describe_update_precommit_config():
         )
         precommit = ModifiablePrecommit.load(config)
         pyproject = ModifiablePyproject.load(pyproject_path)
-        with Session(precommit=precommit, pyproject=pyproject) as session:
+        with Session(precommit, pyproject) as session:
             _update_precommit_config(session)
         result = precommit.dumps()
         assert "repo: local" not in result
@@ -170,7 +170,7 @@ def describe_update_vscode_settings():
     ):
         monkeypatch.chdir(tmp_path)
         with Session() as session:
-            _update_vscode_settings(session, {"ty"})
+            _update_vscode_settings(session, type_checkers={"ty"})
         extensions = json.loads((tmp_path / ".vscode" / "extensions.json").read_text())
         assert "astral-sh.ty" in extensions["recommendations"]
 
@@ -184,7 +184,7 @@ def describe_update_vscode_settings():
             json.dumps({"recommendations": ["astral-sh.ty"]})
         )
         with Session() as session:
-            _update_vscode_settings(session, {"mypy"})
+            _update_vscode_settings(session, type_checkers={"mypy"})
         extensions = json.loads((vscode_dir / "extensions.json").read_text())
         assert "astral-sh.ty" not in extensions.get("recommendations", [])
 
@@ -221,7 +221,7 @@ def describe_remove_ty():
         with (
             ModifiablePrecommit.load(precommit_path) as precommit,
             ModifiablePyproject.load(pyproject_path) as pyproject,
-            Session(precommit=precommit, pyproject=pyproject) as session,
+            Session(precommit, pyproject) as session,
         ):
             _remove_ty(session)
         assert not (tmp_path / "ty.toml").exists()

--- a/tests/python/test_ty.py
+++ b/tests/python/test_ty.py
@@ -225,9 +225,9 @@ def describe_remove_ty():
         with (
             ModifiablePrecommit.load(precommit_path) as precommit,
             ModifiablePyproject.load(pyproject_path) as pyproject,
-            Session() as session,
+            Session(precommit=precommit, pyproject=pyproject) as session,
         ):
-            _remove_ty(precommit, pyproject, session=session)
+            _remove_ty(session=session)
         assert not (tmp_path / "ty.toml").exists()
         assert "tool.ty" not in pyproject.dumps()
         assert "id: ty" not in precommit.dumps()

--- a/tests/python/test_ty.py
+++ b/tests/python/test_ty.py
@@ -173,7 +173,8 @@ def describe_update_vscode_settings():
         tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ):
         monkeypatch.chdir(tmp_path)
-        _update_vscode_settings({"ty"})
+        with Session() as session:
+            _update_vscode_settings({"ty"}, session=session)
         extensions = json.loads((tmp_path / ".vscode" / "extensions.json").read_text())
         assert "astral-sh.ty" in extensions["recommendations"]
 
@@ -186,7 +187,8 @@ def describe_update_vscode_settings():
         (vscode_dir / "extensions.json").write_text(
             json.dumps({"recommendations": ["astral-sh.ty"]})
         )
-        _update_vscode_settings({"mypy"})
+        with Session() as session:
+            _update_vscode_settings({"mypy"}, session=session)
         extensions = json.loads((vscode_dir / "extensions.json").read_text())
         assert "astral-sh.ty" not in extensions.get("recommendations", [])
 
@@ -223,8 +225,9 @@ def describe_remove_ty():
         with (
             ModifiablePrecommit.load(precommit_path) as precommit,
             ModifiablePyproject.load(pyproject_path) as pyproject,
+            Session() as session,
         ):
-            _remove_ty(precommit, pyproject)
+            _remove_ty(precommit, pyproject, session=session)
         assert not (tmp_path / "ty.toml").exists()
         assert "tool.ty" not in pyproject.dumps()
         assert "id: ty" not in precommit.dumps()

--- a/tests/repo/test_citation.py
+++ b/tests/repo/test_citation.py
@@ -225,7 +225,7 @@ def describe_main():
         with Session.load(precommit) as session:
             citation.main(session)
             changes = session.collect_changes()
-        assert changes == ["Updated VS Code settings"]
+        assert "Updated VS Code settings" in changes
         assert (vscode_dir / "settings.json").exists()
 
     def removes_zenodo_when_citation_present(

--- a/tests/test_cspell.py
+++ b/tests/test_cspell.py
@@ -50,7 +50,8 @@ def describe_remove_configuration():
         monkeypatch.chdir(tmp_path)
         (tmp_path / ".cspell.json").write_text("{}")
         with Session() as session:
-            changes = _remove_configuration(session)
+            _remove_configuration(session)
+            changes = session.collect_changes()
         assert any("no longer required" in m for m in changes)
         assert not (tmp_path / ".cspell.json").exists()
 
@@ -58,7 +59,8 @@ def describe_remove_configuration():
         monkeypatch.chdir(tmp_path)
         (tmp_path / ".editorconfig").write_text(".cspell.json\nother-entry\n")
         with Session() as session:
-            changes = _remove_configuration(session)
+            _remove_configuration(session)
+            changes = session.collect_changes()
         assert any("no longer" in m for m in changes)
         assert ".cspell.json" not in (tmp_path / ".editorconfig").read_text()
 

--- a/tests/test_cspell.py
+++ b/tests/test_cspell.py
@@ -50,7 +50,7 @@ def describe_remove_configuration():
         monkeypatch.chdir(tmp_path)
         (tmp_path / ".cspell.json").write_text("{}")
         with Session() as session:
-            changes = _remove_configuration(session=session)
+            changes = _remove_configuration(session)
         assert any("no longer required" in m for m in changes)
         assert not (tmp_path / ".cspell.json").exists()
 
@@ -58,7 +58,7 @@ def describe_remove_configuration():
         monkeypatch.chdir(tmp_path)
         (tmp_path / ".editorconfig").write_text(".cspell.json\nother-entry\n")
         with Session() as session:
-            changes = _remove_configuration(session=session)
+            changes = _remove_configuration(session)
         assert any("no longer" in m for m in changes)
         assert ".cspell.json" not in (tmp_path / ".editorconfig").read_text()
 

--- a/tests/test_cspell.py
+++ b/tests/test_cspell.py
@@ -49,14 +49,16 @@ def describe_remove_configuration():
     def removes_config_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
         monkeypatch.chdir(tmp_path)
         (tmp_path / ".cspell.json").write_text("{}")
-        changes = _remove_configuration()
+        with Session() as session:
+            changes = _remove_configuration(session=session)
         assert any("no longer required" in m for m in changes)
         assert not (tmp_path / ".cspell.json").exists()
 
     def cleans_editorconfig(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
         monkeypatch.chdir(tmp_path)
         (tmp_path / ".editorconfig").write_text(".cspell.json\nother-entry\n")
-        changes = _remove_configuration()
+        with Session() as session:
+            changes = _remove_configuration(session=session)
         assert any("no longer" in m for m in changes)
         assert ".cspell.json" not in (tmp_path / ".editorconfig").read_text()
 

--- a/tests/test_gitpod.py
+++ b/tests/test_gitpod.py
@@ -5,7 +5,7 @@ from compwa_policy.utilities.session import Session
 def describe_generate_gitpod_config():
     def builds_expected_sections():
         with Session() as session:
-            gitpod_content = _generate_gitpod_config(session, "3.8")
+            gitpod_content = _generate_gitpod_config(session, python_version="3.8")
         assert set(gitpod_content) == {
             "github",
             "tasks",

--- a/tests/test_gitpod.py
+++ b/tests/test_gitpod.py
@@ -1,9 +1,11 @@
 from compwa_policy.repo.gitpod import _extract_extensions, _generate_gitpod_config
+from compwa_policy.utilities.session import Session
 
 
 def describe_generate_gitpod_config():
     def builds_expected_sections():
-        gitpod_content = _generate_gitpod_config("3.8")
+        with Session() as session:
+            gitpod_content = _generate_gitpod_config("3.8", session=session)
         assert set(gitpod_content) == {
             "github",
             "tasks",
@@ -24,4 +26,7 @@ def describe_generate_gitpod_config():
             {"init": "pyenv local 3.8"},
             {"init": "pip install -e .[dev]"},
         ]
-        assert gitpod_content["vscode"]["extensions"] == _extract_extensions()
+        with Session() as session:
+            assert gitpod_content["vscode"]["extensions"] == _extract_extensions(
+                session=session
+            )

--- a/tests/test_gitpod.py
+++ b/tests/test_gitpod.py
@@ -5,7 +5,7 @@ from compwa_policy.utilities.session import Session
 def describe_generate_gitpod_config():
     def builds_expected_sections():
         with Session() as session:
-            gitpod_content = _generate_gitpod_config("3.8", session=session)
+            gitpod_content = _generate_gitpod_config(session, "3.8")
         assert set(gitpod_content) == {
             "github",
             "tasks",
@@ -28,5 +28,5 @@ def describe_generate_gitpod_config():
         ]
         with Session() as session:
             assert gitpod_content["vscode"]["extensions"] == _extract_extensions(
-                session=session
+                session
             )

--- a/tests/test_pixi.py
+++ b/tests/test_pixi.py
@@ -13,6 +13,7 @@ from compwa_policy.env.pixi._update import (
     update_pixi_configuration,
 )
 from compwa_policy.utilities.pyproject import ModifiablePyproject
+from compwa_policy.utilities.session import Session
 
 _ENVIRONMENT_YML = dedent("""
     dependencies:
@@ -65,11 +66,13 @@ def describe_update_docnb_and_doclive():
 def describe_update_pixi_configuration():
     def skips_non_pixi(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
         monkeypatch.chdir(tmp_path)
-        update_pixi_configuration(
-            is_python_package=True,
-            dev_python_version="3.12",
-            package_manager="uv",  # not a pixi manager -> no-op
-        )
+        with Session() as session:
+            update_pixi_configuration(
+                is_python_package=True,
+                dev_python_version="3.12",
+                package_manager="uv",  # not a pixi manager -> no-op
+                session=session,
+            )
         assert not (tmp_path / "pixi.toml").exists()
 
     def configures_pyproject(
@@ -93,11 +96,13 @@ def describe_update_pixi_configuration():
             cmd = "outdated"
             """).lstrip()
         )
-        update_pixi_configuration(
-            is_python_package=True,
-            dev_python_version="3.12",
-            package_manager="pixi",
-        )
+        with Session() as session:
+            update_pixi_configuration(
+                is_python_package=True,
+                dev_python_version="3.12",
+                package_manager="pixi",
+                session=session,
+            )
 
         pyproject = (tmp_path / "pyproject.toml").read_text()
         assert "[tool.pixi.workspace]" in pyproject  # project table renamed
@@ -124,11 +129,13 @@ def describe_update_pixi_configuration():
             cmd = "build docs"
             """).lstrip()
         )
-        update_pixi_configuration(
-            is_python_package=True,
-            dev_python_version="3.12",
-            package_manager="pixi+uv",
-        )
+        with Session() as session:
+            update_pixi_configuration(
+                is_python_package=True,
+                dev_python_version="3.12",
+                package_manager="pixi+uv",
+                session=session,
+            )
 
         pixi = (tmp_path / "pixi.toml").read_text()
         assert "[feature.dev.tasks.ci]" in pixi  # combined CI job defined

--- a/tests/test_pixi.py
+++ b/tests/test_pixi.py
@@ -68,10 +68,10 @@ def describe_update_pixi_configuration():
         monkeypatch.chdir(tmp_path)
         with Session() as session:
             update_pixi_configuration(
+                session,
                 is_python_package=True,
                 dev_python_version="3.12",
                 package_manager="uv",  # not a pixi manager -> no-op
-                session=session,
             )
         assert not (tmp_path / "pixi.toml").exists()
 
@@ -98,10 +98,10 @@ def describe_update_pixi_configuration():
         )
         with Session() as session:
             update_pixi_configuration(
+                session,
                 is_python_package=True,
                 dev_python_version="3.12",
                 package_manager="pixi",
-                session=session,
             )
 
         pyproject = (tmp_path / "pyproject.toml").read_text()
@@ -131,10 +131,10 @@ def describe_update_pixi_configuration():
         )
         with Session() as session:
             update_pixi_configuration(
+                session,
                 is_python_package=True,
                 dev_python_version="3.12",
                 package_manager="pixi+uv",
-                session=session,
             )
 
         pixi = (tmp_path / "pixi.toml").read_text()

--- a/tests/utilities/test_session.py
+++ b/tests/utilities/test_session.py
@@ -65,11 +65,11 @@ def test_file_helpers_defer_changes_until_session_flush(tmp_path, monkeypatch) -
     obsolete_path.touch()
 
     with Session() as session:
-        vscode.remove_settings(["remove"], session=session)
-        vscode.update_settings({"added": True}, session=session)
-        vscode.add_extension_recommendation("Example.Extension", session=session)
-        add_badge("[![Badge](badge.svg)](example.org)", session=session)
-        remove_configs([str(obsolete_path)], session=session)
+        vscode.remove_settings(session, ["remove"])
+        vscode.update_settings(session, {"added": True})
+        vscode.add_extension_recommendation(session, "Example.Extension")
+        add_badge(session, "[![Badge](badge.svg)](example.org)")
+        remove_configs(session, [str(obsolete_path)])
 
         assert json.loads(settings_path.read_text()) == {"remove": True}
         assert json.loads(extensions_path.read_text()) == {"recommendations": []}
@@ -102,9 +102,9 @@ def test_generic_file_operations_share_deferred_state(tmp_path, monkeypatch) -> 
     renamed = tmp_path / "renamed.txt"
 
     with Session() as session:
-        remove_lines(source, "remove", session=session)
-        assert append_safe("added", source, session=session)
-        rename_file(str(source), str(renamed), session=session)
+        remove_lines(session, source, "remove")
+        assert append_safe(session, "added", source)
+        rename_file(session, str(source), str(renamed))
         assert source.read_text() == "keep\nremove\n"
         assert not renamed.exists()
 
@@ -125,5 +125,5 @@ def test_gitpod_reads_in_memory_vscode_extensions(tmp_path, monkeypatch) -> None
     vscode_dir.mkdir()
     (vscode_dir / "extensions.json").write_text('{"recommendations": []}\n')
     with Session() as session:
-        vscode.add_extension_recommendation("Example.Extension", session=session)
-        assert _extract_extensions(session=session) == ["example.extension"]
+        vscode.add_extension_recommendation(session, "Example.Extension")
+        assert _extract_extensions(session) == ["example.extension"]

--- a/tests/utilities/test_session.py
+++ b/tests/utilities/test_session.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import json
+from typing import ClassVar
+
+from compwa_policy.utilities import remove_configs, vscode
+from compwa_policy.utilities.readme import add_badge
+from compwa_policy.utilities.resource import Changelog, ModifiableResource
+from compwa_policy.utilities.session import Session
+
+
+class CountingResource(ModifiableResource):
+    loads: ClassVar[int] = 0
+    dumps: ClassVar[int] = 0
+
+    def __init__(self) -> None:
+        self._changelog: Changelog = []
+
+    @classmethod
+    def load(cls) -> CountingResource:
+        cls.loads += 1
+        return cls()
+
+    @property
+    def changelog(self) -> Changelog:
+        return self._changelog
+
+    def dump(self) -> None:
+        type(self).dumps += 1
+
+
+def test_get_loads_once_and_flush_dumps_once() -> None:
+    CountingResource.loads = 0
+    CountingResource.dumps = 0
+    with Session() as session:
+        first = session.get(CountingResource)
+        second = session.get(CountingResource)
+        first.changelog.append("Changed counting resource")
+        assert first is second
+        assert session.flush() == ["Changed counting resource"]
+        assert session.flush() == ["Changed counting resource"]
+    assert CountingResource.loads == 1
+    assert CountingResource.dumps == 1
+
+
+def test_file_helpers_defer_changes_until_session_flush(tmp_path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    vscode_dir = tmp_path / ".vscode"
+    vscode_dir.mkdir()
+    settings_path = vscode_dir / "settings.json"
+    settings_path.write_text('{"remove": true}\n')
+    extensions_path = vscode_dir / "extensions.json"
+    extensions_path.write_text('{"recommendations": []}\n')
+    readme_path = tmp_path / "README.md"
+    readme_path.write_text("# Title\n")
+    obsolete_path = tmp_path / ".obsolete.yml"
+    obsolete_path.touch()
+
+    with Session() as session:
+        vscode.remove_settings(["remove"])
+        vscode.update_settings({"added": True})
+        vscode.add_extension_recommendation("Example.Extension")
+        add_badge("[![Badge](badge.svg)](example.org)")
+        remove_configs([str(obsolete_path)])
+
+        assert json.loads(settings_path.read_text()) == {"remove": True}
+        assert json.loads(extensions_path.read_text()) == {"recommendations": []}
+        assert readme_path.read_text() == "# Title\n"
+        assert obsolete_path.exists()
+        assert session.collect_changes()
+
+    assert json.loads(settings_path.read_text()) == {"added": True}
+    assert json.loads(extensions_path.read_text()) == {
+        "recommendations": ["example.extension"]
+    }
+    assert "[![Badge](badge.svg)](example.org)" in readme_path.read_text()
+    assert not obsolete_path.exists()

--- a/tests/utilities/test_session.py
+++ b/tests/utilities/test_session.py
@@ -37,93 +37,93 @@ class CountingResource(ModifiableResource):
         type(self).dumps += 1
 
 
-def test_get_loads_once_and_flush_dumps_once() -> None:
-    CountingResource.loads = 0
-    CountingResource.dumps = 0
-    with Session() as session:
-        first = session.get(CountingResource)
-        second = session.get(CountingResource)
-        first.changelog.append("Changed counting resource")
-        assert first is second
-        assert session.flush() == ["Changed counting resource"]
-        assert session.flush() == ["Changed counting resource"]
-    assert CountingResource.loads == 1
-    assert CountingResource.dumps == 1
+def describe_session():
+    def loads_resources_once_and_dumps_them_once_on_flush():
+        CountingResource.loads = 0
+        CountingResource.dumps = 0
+        with Session() as session:
+            first = session.get(CountingResource)
+            second = session.get(CountingResource)
+            first.changelog.append("Changed counting resource")
+            assert first is second
+            assert session.flush() == ["Changed counting resource"]
+            assert session.flush() == ["Changed counting resource"]
+        assert CountingResource.loads == 1
+        assert CountingResource.dumps == 1
+
+    def defers_file_helper_changes_until_flush(tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        vscode_dir = tmp_path / ".vscode"
+        vscode_dir.mkdir()
+        settings_path = vscode_dir / "settings.json"
+        settings_path.write_text('{"remove": true}\n')
+        extensions_path = vscode_dir / "extensions.json"
+        extensions_path.write_text('{"recommendations": []}\n')
+        readme_path = tmp_path / "README.md"
+        readme_path.write_text("# Title\n")
+        obsolete_path = tmp_path / ".obsolete.yml"
+        obsolete_path.touch()
+
+        with Session() as session:
+            vscode.remove_settings(session, ["remove"])
+            vscode.update_settings(session, {"added": True})
+            vscode.add_extension_recommendation(session, "Example.Extension")
+            add_badge(session, "[![Badge](badge.svg)](example.org)")
+            remove_configs(session, [str(obsolete_path)])
+
+            assert json.loads(settings_path.read_text()) == {"remove": True}
+            assert json.loads(extensions_path.read_text()) == {"recommendations": []}
+            assert readme_path.read_text() == "# Title\n"
+            assert obsolete_path.exists()
+            assert session.collect_changes()
+
+        assert json.loads(settings_path.read_text()) == {"added": True}
+        assert json.loads(extensions_path.read_text()) == {
+            "recommendations": ["example.extension"]
+        }
+        assert "[![Badge](badge.svg)](example.org)" in readme_path.read_text()
+        assert not obsolete_path.exists()
+
+    def distinguishes_resources_by_path(tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        with Session() as session:
+            first = session.get_path(tmp_path / "first.txt")
+            same = session.get_path(tmp_path / "first.txt")
+            other = session.get_path(tmp_path / "other.txt")
+            assert first is same
+            assert first is not other
+
+    def shares_deferred_state_between_file_operations(tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        source = tmp_path / "source.txt"
+        source.write_text("keep\nremove\n")
+        renamed = tmp_path / "renamed.txt"
+
+        with Session() as session:
+            remove_lines(session, source, "remove")
+            assert append_safe(session, "added", source)
+            rename_file(session, str(source), str(renamed))
+            assert source.read_text() == "keep\nremove\n"
+            assert not renamed.exists()
+
+        assert not source.exists()
+        assert renamed.read_text() == "keep\nadded\n"
 
 
-def test_file_helpers_defer_changes_until_session_flush(tmp_path, monkeypatch) -> None:
-    monkeypatch.chdir(tmp_path)
-    vscode_dir = tmp_path / ".vscode"
-    vscode_dir.mkdir()
-    settings_path = vscode_dir / "settings.json"
-    settings_path.write_text('{"remove": true}\n')
-    extensions_path = vscode_dir / "extensions.json"
-    extensions_path.write_text('{"recommendations": []}\n')
-    readme_path = tmp_path / "README.md"
-    readme_path.write_text("# Title\n")
-    obsolete_path = tmp_path / ".obsolete.yml"
-    obsolete_path.touch()
-
-    with Session() as session:
-        vscode.remove_settings(session, ["remove"])
-        vscode.update_settings(session, {"added": True})
-        vscode.add_extension_recommendation(session, "Example.Extension")
-        add_badge(session, "[![Badge](badge.svg)](example.org)")
-        remove_configs(session, [str(obsolete_path)])
-
-        assert json.loads(settings_path.read_text()) == {"remove": True}
-        assert json.loads(extensions_path.read_text()) == {"recommendations": []}
-        assert readme_path.read_text() == "# Title\n"
-        assert obsolete_path.exists()
-        assert session.collect_changes()
-
-    assert json.loads(settings_path.read_text()) == {"added": True}
-    assert json.loads(extensions_path.read_text()) == {
-        "recommendations": ["example.extension"]
-    }
-    assert "[![Badge](badge.svg)](example.org)" in readme_path.read_text()
-    assert not obsolete_path.exists()
+def describe_pyproject_load():
+    def uses_session_identity(tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "pyproject.toml").write_text('[project]\nname = "example"\n')
+        with Session() as session:
+            assert Pyproject.load(session=session) is session.pyproject
 
 
-def test_path_identity_distinguishes_files(tmp_path, monkeypatch) -> None:
-    monkeypatch.chdir(tmp_path)
-    with Session() as session:
-        first = session.get_path(tmp_path / "first.txt")
-        same = session.get_path(tmp_path / "first.txt")
-        other = session.get_path(tmp_path / "other.txt")
-        assert first is same
-        assert first is not other
-
-
-def test_generic_file_operations_share_deferred_state(tmp_path, monkeypatch) -> None:
-    monkeypatch.chdir(tmp_path)
-    source = tmp_path / "source.txt"
-    source.write_text("keep\nremove\n")
-    renamed = tmp_path / "renamed.txt"
-
-    with Session() as session:
-        remove_lines(session, source, "remove")
-        assert append_safe(session, "added", source)
-        rename_file(session, str(source), str(renamed))
-        assert source.read_text() == "keep\nremove\n"
-        assert not renamed.exists()
-
-    assert not source.exists()
-    assert renamed.read_text() == "keep\nadded\n"
-
-
-def test_readonly_pyproject_load_uses_session_identity(tmp_path, monkeypatch) -> None:
-    monkeypatch.chdir(tmp_path)
-    (tmp_path / "pyproject.toml").write_text('[project]\nname = "example"\n')
-    with Session() as session:
-        assert Pyproject.load(session=session) is session.pyproject
-
-
-def test_gitpod_reads_in_memory_vscode_extensions(tmp_path, monkeypatch) -> None:
-    monkeypatch.chdir(tmp_path)
-    vscode_dir = tmp_path / ".vscode"
-    vscode_dir.mkdir()
-    (vscode_dir / "extensions.json").write_text('{"recommendations": []}\n')
-    with Session() as session:
-        vscode.add_extension_recommendation(session, "Example.Extension")
-        assert _extract_extensions(session) == ["example.extension"]
+def describe_extract_extensions():
+    def reads_in_memory_vscode_extensions(tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        vscode_dir = tmp_path / ".vscode"
+        vscode_dir.mkdir()
+        (vscode_dir / "extensions.json").write_text('{"recommendations": []}\n')
+        with Session() as session:
+            vscode.add_extension_recommendation(session, "Example.Extension")
+            assert _extract_extensions(session) == ["example.extension"]

--- a/tests/utilities/test_session.py
+++ b/tests/utilities/test_session.py
@@ -3,7 +3,15 @@ from __future__ import annotations
 import json
 from typing import ClassVar
 
-from compwa_policy.utilities import remove_configs, vscode
+from compwa_policy.repo.gitpod import _extract_extensions
+from compwa_policy.utilities import (
+    append_safe,
+    remove_configs,
+    remove_lines,
+    rename_file,
+    vscode,
+)
+from compwa_policy.utilities.pyproject import Pyproject
 from compwa_policy.utilities.readme import add_badge
 from compwa_policy.utilities.resource import Changelog, ModifiableResource
 from compwa_policy.utilities.session import Session
@@ -75,3 +83,47 @@ def test_file_helpers_defer_changes_until_session_flush(tmp_path, monkeypatch) -
     }
     assert "[![Badge](badge.svg)](example.org)" in readme_path.read_text()
     assert not obsolete_path.exists()
+
+
+def test_path_identity_distinguishes_files(tmp_path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    with Session() as session:
+        first = session.get_path(tmp_path / "first.txt")
+        same = session.get_path(tmp_path / "first.txt")
+        other = session.get_path(tmp_path / "other.txt")
+        assert first is same
+        assert first is not other
+
+
+def test_generic_file_operations_share_deferred_state(tmp_path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    source = tmp_path / "source.txt"
+    source.write_text("keep\nremove\n")
+    renamed = tmp_path / "renamed.txt"
+
+    with Session():
+        remove_lines(source, "remove")
+        assert append_safe("added", source)
+        rename_file(str(source), str(renamed))
+        assert source.read_text() == "keep\nremove\n"
+        assert not renamed.exists()
+
+    assert not source.exists()
+    assert renamed.read_text() == "keep\nadded\n"
+
+
+def test_readonly_pyproject_load_uses_active_identity(tmp_path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "pyproject.toml").write_text('[project]\nname = "example"\n')
+    with Session() as session:
+        assert Pyproject.load() is session.pyproject
+
+
+def test_gitpod_reads_in_memory_vscode_extensions(tmp_path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    vscode_dir = tmp_path / ".vscode"
+    vscode_dir.mkdir()
+    (vscode_dir / "extensions.json").write_text('{"recommendations": []}\n')
+    with Session():
+        vscode.add_extension_recommendation("Example.Extension")
+        assert _extract_extensions() == ["example.extension"]

--- a/tests/utilities/test_session.py
+++ b/tests/utilities/test_session.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import json
-from typing import ClassVar
+from typing import TYPE_CHECKING, ClassVar
 
 from compwa_policy.repo.gitpod import _extract_extensions
 from compwa_policy.utilities import (
@@ -15,6 +15,11 @@ from compwa_policy.utilities.pyproject import Pyproject
 from compwa_policy.utilities.readme import add_badge
 from compwa_policy.utilities.resource import Changelog, ModifiableResource
 from compwa_policy.utilities.session import Session
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    import pytest
 
 
 class CountingResource(ModifiableResource):
@@ -37,8 +42,8 @@ class CountingResource(ModifiableResource):
         type(self).dumps += 1
 
 
-def describe_session():
-    def loads_resources_once_and_dumps_them_once_on_flush():
+def describe_session() -> None:
+    def loads_resources_once_and_dumps_them_once_on_flush() -> None:
         CountingResource.loads = 0
         CountingResource.dumps = 0
         with Session() as session:
@@ -51,7 +56,9 @@ def describe_session():
         assert CountingResource.loads == 1
         assert CountingResource.dumps == 1
 
-    def defers_file_helper_changes_until_flush(tmp_path, monkeypatch):
+    def defers_file_helper_changes_until_flush(
+        tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         monkeypatch.chdir(tmp_path)
         vscode_dir = tmp_path / ".vscode"
         vscode_dir.mkdir()
@@ -84,7 +91,9 @@ def describe_session():
         assert "[![Badge](badge.svg)](example.org)" in readme_path.read_text()
         assert not obsolete_path.exists()
 
-    def distinguishes_resources_by_path(tmp_path, monkeypatch):
+    def distinguishes_resources_by_path(
+        tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         monkeypatch.chdir(tmp_path)
         with Session() as session:
             first = session.get_path(tmp_path / "first.txt")
@@ -93,7 +102,9 @@ def describe_session():
             assert first is same
             assert first is not other
 
-    def shares_deferred_state_between_file_operations(tmp_path, monkeypatch):
+    def shares_deferred_state_between_file_operations(
+        tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         monkeypatch.chdir(tmp_path)
         source = tmp_path / "source.txt"
         source.write_text("keep\nremove\n")
@@ -110,16 +121,18 @@ def describe_session():
         assert renamed.read_text() == "keep\nadded\n"
 
 
-def describe_pyproject_load():
-    def uses_session_identity(tmp_path, monkeypatch):
+def describe_pyproject_load() -> None:
+    def uses_session_identity(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.chdir(tmp_path)
         (tmp_path / "pyproject.toml").write_text('[project]\nname = "example"\n')
         with Session() as session:
             assert Pyproject.load(session=session) is session.pyproject
 
 
-def describe_extract_extensions():
-    def reads_in_memory_vscode_extensions(tmp_path, monkeypatch):
+def describe_extract_extensions() -> None:
+    def reads_in_memory_vscode_extensions(
+        tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         monkeypatch.chdir(tmp_path)
         vscode_dir = tmp_path / ".vscode"
         vscode_dir.mkdir()

--- a/tests/utilities/test_session.py
+++ b/tests/utilities/test_session.py
@@ -65,11 +65,11 @@ def test_file_helpers_defer_changes_until_session_flush(tmp_path, monkeypatch) -
     obsolete_path.touch()
 
     with Session() as session:
-        vscode.remove_settings(["remove"])
-        vscode.update_settings({"added": True})
-        vscode.add_extension_recommendation("Example.Extension")
-        add_badge("[![Badge](badge.svg)](example.org)")
-        remove_configs([str(obsolete_path)])
+        vscode.remove_settings(["remove"], session=session)
+        vscode.update_settings({"added": True}, session=session)
+        vscode.add_extension_recommendation("Example.Extension", session=session)
+        add_badge("[![Badge](badge.svg)](example.org)", session=session)
+        remove_configs([str(obsolete_path)], session=session)
 
         assert json.loads(settings_path.read_text()) == {"remove": True}
         assert json.loads(extensions_path.read_text()) == {"recommendations": []}
@@ -101,10 +101,10 @@ def test_generic_file_operations_share_deferred_state(tmp_path, monkeypatch) -> 
     source.write_text("keep\nremove\n")
     renamed = tmp_path / "renamed.txt"
 
-    with Session():
-        remove_lines(source, "remove")
-        assert append_safe("added", source)
-        rename_file(str(source), str(renamed))
+    with Session() as session:
+        remove_lines(source, "remove", session=session)
+        assert append_safe("added", source, session=session)
+        rename_file(str(source), str(renamed), session=session)
         assert source.read_text() == "keep\nremove\n"
         assert not renamed.exists()
 
@@ -112,11 +112,11 @@ def test_generic_file_operations_share_deferred_state(tmp_path, monkeypatch) -> 
     assert renamed.read_text() == "keep\nadded\n"
 
 
-def test_readonly_pyproject_load_uses_active_identity(tmp_path, monkeypatch) -> None:
+def test_readonly_pyproject_load_uses_session_identity(tmp_path, monkeypatch) -> None:
     monkeypatch.chdir(tmp_path)
     (tmp_path / "pyproject.toml").write_text('[project]\nname = "example"\n')
     with Session() as session:
-        assert Pyproject.load() is session.pyproject
+        assert Pyproject.load(session=session) is session.pyproject
 
 
 def test_gitpod_reads_in_memory_vscode_extensions(tmp_path, monkeypatch) -> None:
@@ -124,6 +124,6 @@ def test_gitpod_reads_in_memory_vscode_extensions(tmp_path, monkeypatch) -> None
     vscode_dir = tmp_path / ".vscode"
     vscode_dir.mkdir()
     (vscode_dir / "extensions.json").write_text('{"recommendations": []}\n')
-    with Session():
-        vscode.add_extension_recommendation("Example.Extension")
-        assert _extract_extensions() == ["example.extension"]
+    with Session() as session:
+        vscode.add_extension_recommendation("Example.Extension", session=session)
+        assert _extract_extensions(session=session) == ["example.extension"]


### PR DESCRIPTION
Closes #631

## ⚙️ Enhancements

- Generalized `Session` around a lazy resource registry. The new `ModifiableResource` contract and `Session.get()` let checks share any file-backed resource, while `Session.get_path()` provides the same identity and lifecycle guarantees for arbitrary files and directories.
- Added session-managed resources for generic paths, `pixi.toml`, `README.md`, and VS Code settings and extensions. Repeated operations now share in-memory state, and `Session.flush()` writes each changed resource at most once while returning the aggregated changelog.

## ⚠️ Interface changes

| Old name | New name |
| --- | --- |
| File helpers such as `append_safe(...)`, `remove_configs(...)`, `remove_lines(...)`, `rename_file(...)`, and `update_file(...)` returned changelog entries directly | The helpers take `session` as their first positional-only argument, mutate session-owned resources, and return `None` |
| README and VS Code helpers operated on disk and returned a changelog | The helpers take `session` as their first positional-only argument and report changes through the managed resource |
| Environment helpers such as `update_conda_environment(...)`, `update_pixi_configuration(...)`, `remove_pixi_configuration(...)`, and `has_pixi_config(...)` accepted standalone configuration values | The helpers take `session` as their first positional-only argument and use its shared configuration resources |
| `has_pyproject_package_name()` | `has_pyproject_package_name(session, /)` |

## ❗ Behavioral changes

- File mutations made through a `Session` remain in memory until `flush()` or successful context-manager exit. This lets later checks observe earlier pending changes without partially updating the working tree, and an exception prevents those pending writes from being committed.

## 🖱️ Developer experience

- Run the `style` task before the longer coverage, documentation, link-check, and multi-version test tasks in the aggregate `all` workflow, so formatting and lint failures surface earlier.
- Ignore local `.codex` configuration in Git.
- Reorganized touched tests into the `pytest-describe` structure and added focused coverage for lazy resource identity, deferred writes, path operations, and flush idempotency.

## 🔨 Maintenance

- Migrated policy checks to pass one `Session` through nested helpers instead of repeatedly loading configuration objects, writing files eagerly, and combining returned changelog lists.
- Centralized the load, change-detection, context-manager, and dump contracts shared by modifiable pre-commit, pyproject, path, README, and VS Code resources.

## Squash commit messages

```text
* BREAK: require Session in resource helpers
* DX: ignore Codex configuration
* DX: run style before remaining CI tasks
* MAINT: organize tests with pytest-describe
```
