### PR TITLE
ENH: normalize pre-commit repo spacing

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -91,4 +91,4 @@ repos:
     rev: v0.0.56
     hooks:
       - id: ty
-        args: [--no-default-groups, --group=types]
+        args: [--group=types, --no-default-groups]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
       - id: check-useless-excludes
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.20
+    rev: v0.15.21
     hooks:
       - id: ruff-check
         args: [--fix]
@@ -88,7 +88,7 @@ repos:
           )$
 
   - repo: https://github.com/astral-sh/ty-pre-commit
-    rev: v0.0.56
+    rev: v0.0.59
     hooks:
       - id: ty
         args: [--group=types, --no-default-groups]

--- a/src/compwa_policy/python/ty.py
+++ b/src/compwa_policy/python/ty.py
@@ -92,7 +92,7 @@ def _update_precommit_config(session: Session, /) -> None:
         hook["exclude"] = exclude
     group = _select_dependency_group(pyproject)
     if group is not None:
-        hook["args"] = read_preserved_yaml(f"[--no-default-groups, --group={group}]")
+        hook["args"] = read_preserved_yaml(f"[--group={group}, --no-default-groups]")
     expected_repo = Repo(
         repo="https://github.com/astral-sh/ty-pre-commit",
         rev="",

--- a/src/compwa_policy/repo/poe.py
+++ b/src/compwa_policy/repo/poe.py
@@ -36,7 +36,7 @@ _DOC_TASKS = frozenset({
     "linkcheck",
 })
 _NOTEBOOK_TASKS = frozenset({"lab", "nb"})
-_TEST_TASKS = frozenset({"cov", "test", "test-all"})
+_TEST_TASKS = frozenset({"benchmark", "cov", "test", "test-all"})
 _TEST_PY_PATTERN = re.compile(r"^test-py3\d+$")
 
 

--- a/src/compwa_policy/utilities/precommit/__init__.py
+++ b/src/compwa_policy/utilities/precommit/__init__.py
@@ -10,6 +10,7 @@ from typing import IO, TYPE_CHECKING, TypeVar
 
 from ruamel.yaml.comments import CommentedMap, CommentedSeq
 from ruamel.yaml.error import CommentMark
+from ruamel.yaml.scalarstring import FoldedScalarString, LiteralScalarString
 from ruamel.yaml.tokens import CommentToken
 
 from compwa_policy.utilities import CONFIG_PATH
@@ -165,39 +166,85 @@ def _normalize_repo_spacing(config: PrecommitConfig) -> None:
     repos = config.get("repos")
     if not isinstance(repos, CommentedSeq):
         return
+    for index, repo in enumerate(repos):
+        repos[index] = _ensure_round_trip_collections(repo)
     _remove_blank_lines(repos)
     for repo in repos[:-1]:
         _append_repo_separator(repo)
+
+
+def _ensure_round_trip_collections(node: object) -> object:
+    if isinstance(node, dict):
+        if not isinstance(node, CommentedMap):
+            node = CommentedMap(node)
+        for key, value in node.items():
+            node[key] = _ensure_round_trip_collections(value)
+    elif isinstance(node, list):
+        if not isinstance(node, CommentedSeq):
+            node = CommentedSeq(node)
+        for index, value in enumerate(node):
+            node[index] = _ensure_round_trip_collections(value)
+    return node
 
 
 def _append_repo_separator(node: object) -> None:
     if isinstance(node, CommentedSeq) and node:
         last_index = len(node) - 1
         last_value = node[last_index]
-        if isinstance(last_value, (CommentedMap, CommentedSeq)) and last_value:
+        if (
+            isinstance(last_value, (CommentedMap, CommentedSeq))
+            and last_value
+            and not last_value.fa.flow_style()
+        ):
             _append_repo_separator(last_value)
             return
         item_comments = node.ca.items.setdefault(
             last_index,
             [None, None, None, None],
         )
-        _add_blank_line(item_comments, _SEQUENCE_ITEM_COMMENT_INDEX)
+        _add_blank_line(
+            item_comments,
+            _SEQUENCE_ITEM_COMMENT_INDEX,
+            follows_block_scalar=isinstance(
+                last_value,
+                (FoldedScalarString, LiteralScalarString),
+            ),
+        )
         return
     if not isinstance(node, CommentedMap) or not node:
         return
     last_key = next(reversed(node))
     last_value = node[last_key]
-    if isinstance(last_value, (CommentedMap, CommentedSeq)) and last_value:
+    if (
+        isinstance(last_value, (CommentedMap, CommentedSeq))
+        and last_value
+        and not last_value.fa.flow_style()
+    ):
         _append_repo_separator(last_value)
         return
     item_comments = node.ca.items.setdefault(last_key, [None, None, None, None])
-    _add_blank_line(item_comments, _POST_VALUE_COMMENT_INDEX)
+    _add_blank_line(
+        item_comments,
+        _POST_VALUE_COMMENT_INDEX,
+        follows_block_scalar=isinstance(
+            last_value,
+            (FoldedScalarString, LiteralScalarString),
+        ),
+    )
 
 
-def _add_blank_line(item_comments: list, comment_index: int) -> None:
+def _add_blank_line(
+    item_comments: list,
+    comment_index: int,
+    *,
+    follows_block_scalar: bool,
+) -> None:
     comment = item_comments[comment_index]
     if not isinstance(comment, CommentToken):
-        item_comments[comment_index] = CommentToken("\n\n", CommentMark(0))
+        value = "\n" if follows_block_scalar else "\n\n"
+        item_comments[comment_index] = CommentToken(value, CommentMark(0))
+    elif follows_block_scalar:
+        comment.value = comment.value or "\n"
     elif comment.value.startswith("\n"):
         comment.value = f"\n{comment.value}"
     else:

--- a/src/compwa_policy/utilities/precommit/__init__.py
+++ b/src/compwa_policy/utilities/precommit/__init__.py
@@ -36,8 +36,6 @@ if TYPE_CHECKING:
     from compwa_policy.utilities.precommit.struct import Hook, PrecommitConfig, Repo
 
 T = TypeVar("T", bound="Precommit")
-_POST_VALUE_COMMENT_INDEX = 2
-_SEQUENCE_ITEM_COMMENT_INDEX = 0
 
 
 class Precommit:
@@ -163,9 +161,10 @@ def _load_roundtrip_precommit_config(
 
 
 def _normalize_repo_spacing(config: PrecommitConfig) -> None:
-    repos = config.get("repos")
+    repos = _ensure_round_trip_collections(config.get("repos"))
     if not isinstance(repos, CommentedSeq):
         return
+    config["repos"] = repos
     for index, repo in enumerate(repos):
         repos[index] = _ensure_round_trip_collections(repo)
     _remove_blank_lines(repos)
@@ -198,13 +197,9 @@ def _append_repo_separator(node: object) -> None:
         ):
             _append_repo_separator(last_value)
             return
-        item_comments = node.ca.items.setdefault(
-            last_index,
-            [None, None, None, None],
-        )
         _add_blank_line(
-            item_comments,
-            _SEQUENCE_ITEM_COMMENT_INDEX,
+            node,
+            last_index,
             follows_block_scalar=isinstance(
                 last_value,
                 (FoldedScalarString, LiteralScalarString),
@@ -222,10 +217,9 @@ def _append_repo_separator(node: object) -> None:
     ):
         _append_repo_separator(last_value)
         return
-    item_comments = node.ca.items.setdefault(last_key, [None, None, None, None])
     _add_blank_line(
-        item_comments,
-        _POST_VALUE_COMMENT_INDEX,
+        node,
+        last_key,
         follows_block_scalar=isinstance(
             last_value,
             (FoldedScalarString, LiteralScalarString),
@@ -234,15 +228,15 @@ def _append_repo_separator(node: object) -> None:
 
 
 def _add_blank_line(
-    item_comments: list,
-    comment_index: int,
+    node: CommentedMap | CommentedSeq,
+    key: object,
     *,
     follows_block_scalar: bool,
 ) -> None:
-    comment = item_comments[comment_index]
+    comment = _get_trailing_comment(node, key)
     if not isinstance(comment, CommentToken):
         value = "\n" if follows_block_scalar else "\n\n"
-        item_comments[comment_index] = CommentToken(value, CommentMark(0))
+        _set_trailing_comment(node, key, CommentToken(value, CommentMark(0)))
     elif follows_block_scalar:
         comment.value = comment.value or "\n"
     elif comment.value.startswith("\n"):
@@ -252,28 +246,46 @@ def _add_blank_line(
 
 
 def _remove_blank_lines(node: object) -> None:
+    if not isinstance(node, (CommentedMap, CommentedSeq)):
+        return
+    node.ca.comment = _normalize_comments(node.ca.comment)
+    node.ca.end = _normalize_comments(node.ca.end) or []
+    for key, item_comments in node.ca.items.items():
+        trailing_comment = _get_trailing_comment(node, key)
+        for index, comment in enumerate(item_comments):
+            item_comments[index] = _normalize_comments(comment)
+        _set_trailing_comment(
+            node,
+            key,
+            _normalize_comments(trailing_comment, keep_line_break=True),
+        )
+    children = node.values() if isinstance(node, CommentedMap) else node
+    for child in children:
+        _remove_blank_lines(child)
+
+
+def _get_trailing_comment(
+    node: CommentedMap | CommentedSeq,
+    key: object,
+) -> object:
+    item_comments = node.ca.items.get(key)
+    if item_comments is None:
+        return None
     if isinstance(node, CommentedMap):
-        node.ca.comment = _normalize_comments(node.ca.comment)
-        node.ca.end = _normalize_comments(node.ca.end) or []
-        for item_comments in node.ca.items.values():
-            for index, comment in enumerate(item_comments):
-                item_comments[index] = _normalize_comments(
-                    comment,
-                    keep_line_break=index == _POST_VALUE_COMMENT_INDEX,
-                )
-        for value in node.values():
-            _remove_blank_lines(value)
-    elif isinstance(node, CommentedSeq):
-        node.ca.comment = _normalize_comments(node.ca.comment)
-        node.ca.end = _normalize_comments(node.ca.end) or []
-        for item_comments in node.ca.items.values():
-            for index, comment in enumerate(item_comments):
-                item_comments[index] = _normalize_comments(
-                    comment,
-                    keep_line_break=index == _SEQUENCE_ITEM_COMMENT_INDEX,
-                )
-        for value in node:
-            _remove_blank_lines(value)
+        return item_comments[2]
+    return item_comments[0]
+
+
+def _set_trailing_comment(
+    node: CommentedMap | CommentedSeq,
+    key: object,
+    comment: object,
+) -> None:
+    item_comments = node.ca.items.setdefault(key, [None, None, None, None])
+    if isinstance(node, CommentedMap):
+        item_comments[2] = comment
+    else:
+        item_comments[0] = comment
 
 
 def _normalize_comments(comments: object, *, keep_line_break: bool = False) -> object:

--- a/src/compwa_policy/utilities/precommit/__init__.py
+++ b/src/compwa_policy/utilities/precommit/__init__.py
@@ -3,9 +3,14 @@
 from __future__ import annotations
 
 import io
+import re
 import sys
 from pathlib import Path
 from typing import IO, TYPE_CHECKING, TypeVar
+
+from ruamel.yaml.comments import CommentedMap, CommentedSeq
+from ruamel.yaml.error import CommentMark
+from ruamel.yaml.tokens import CommentToken
 
 from compwa_policy.utilities import CONFIG_PATH
 from compwa_policy.utilities.precommit.getters import find_repo, find_repo_with_index
@@ -30,6 +35,8 @@ if TYPE_CHECKING:
     from compwa_policy.utilities.precommit.struct import Hook, PrecommitConfig, Repo
 
 T = TypeVar("T", bound="Precommit")
+_POST_VALUE_COMMENT_INDEX = 2
+_SEQUENCE_ITEM_COMMENT_INDEX = 0
 
 
 class Precommit:
@@ -104,10 +111,12 @@ class ModifiablePrecommit(Precommit, ModifiableResource):
                 msg = "Target required when source is not a file or I/O stream"
                 raise ValueError(msg)
             target = self.source
+        _normalize_repo_spacing(self.document)
         if isinstance(target, io.IOBase):
             current_position = target.tell()
             target.seek(0)
             self.parser.dump(self.document, target)
+            target.truncate()
             target.seek(current_position)
         elif isinstance(target, Path):
             with open(target, "w") as stream:
@@ -150,3 +159,89 @@ def _load_roundtrip_precommit_config(
     else:
         config = parser.load(source)
     return config, parser
+
+
+def _normalize_repo_spacing(config: PrecommitConfig) -> None:
+    repos = config.get("repos")
+    if not isinstance(repos, CommentedSeq):
+        return
+    _remove_blank_lines(repos)
+    for repo in repos[:-1]:
+        _append_repo_separator(repo)
+
+
+def _append_repo_separator(node: object) -> None:
+    if isinstance(node, CommentedSeq) and node:
+        last_index = len(node) - 1
+        last_value = node[last_index]
+        if isinstance(last_value, (CommentedMap, CommentedSeq)) and last_value:
+            _append_repo_separator(last_value)
+            return
+        item_comments = node.ca.items.setdefault(
+            last_index,
+            [None, None, None, None],
+        )
+        _add_blank_line(item_comments, _SEQUENCE_ITEM_COMMENT_INDEX)
+        return
+    if not isinstance(node, CommentedMap) or not node:
+        return
+    last_key = next(reversed(node))
+    last_value = node[last_key]
+    if isinstance(last_value, (CommentedMap, CommentedSeq)) and last_value:
+        _append_repo_separator(last_value)
+        return
+    item_comments = node.ca.items.setdefault(last_key, [None, None, None, None])
+    _add_blank_line(item_comments, _POST_VALUE_COMMENT_INDEX)
+
+
+def _add_blank_line(item_comments: list, comment_index: int) -> None:
+    comment = item_comments[comment_index]
+    if not isinstance(comment, CommentToken):
+        item_comments[comment_index] = CommentToken("\n\n", CommentMark(0))
+    elif comment.value.startswith("\n"):
+        comment.value = f"\n{comment.value}"
+    else:
+        comment.value = f"{comment.value}\n"
+
+
+def _remove_blank_lines(node: object) -> None:
+    if isinstance(node, CommentedMap):
+        node.ca.comment = _normalize_comments(node.ca.comment)
+        node.ca.end = _normalize_comments(node.ca.end) or []
+        for item_comments in node.ca.items.values():
+            for index, comment in enumerate(item_comments):
+                item_comments[index] = _normalize_comments(
+                    comment,
+                    keep_line_break=index == _POST_VALUE_COMMENT_INDEX,
+                )
+        for value in node.values():
+            _remove_blank_lines(value)
+    elif isinstance(node, CommentedSeq):
+        node.ca.comment = _normalize_comments(node.ca.comment)
+        node.ca.end = _normalize_comments(node.ca.end) or []
+        for item_comments in node.ca.items.values():
+            for index, comment in enumerate(item_comments):
+                item_comments[index] = _normalize_comments(
+                    comment,
+                    keep_line_break=index == _SEQUENCE_ITEM_COMMENT_INDEX,
+                )
+        for value in node:
+            _remove_blank_lines(value)
+
+
+def _normalize_comments(comments: object, *, keep_line_break: bool = False) -> object:
+    if isinstance(comments, CommentToken):
+        comments.value = re.sub(r"\n[ \t]*(?=\n)", "", comments.value)
+        if comments.value.strip() or keep_line_break:
+            comments.value = comments.value or "\n"
+            return comments
+        return None
+    if isinstance(comments, list):
+        normalized = [
+            comment
+            for item in comments
+            if (comment := _normalize_comments(item, keep_line_break=keep_line_break))
+            is not None
+        ]
+        return normalized or None
+    return comments

--- a/tests/python/test_ty.py
+++ b/tests/python/test_ty.py
@@ -83,7 +83,7 @@ def describe_update_precommit_config():
         result = precommit.dumps()
         assert "https://github.com/astral-sh/ty-pre-commit" in result
         assert "id: ty" in result
-        assert "args: [--no-default-groups, --group=style]" in result
+        assert "args: [--group=style, --no-default-groups]" in result
 
     def prefers_types_group_over_style(tmp_path: Path):
         config = _write_precommit(
@@ -108,7 +108,7 @@ def describe_update_precommit_config():
         pyproject = ModifiablePyproject.load(pyproject_path)
         with Session(precommit, pyproject) as session:
             _update_precommit_config(session)
-        assert "args: [--no-default-groups, --group=types]" in precommit.dumps()
+        assert "args: [--group=types, --no-default-groups]" in precommit.dumps()
 
     def omits_args_without_matching_group(tmp_path: Path):
         config = _write_precommit(
@@ -161,7 +161,7 @@ def describe_update_precommit_config():
         assert "entry: ty check" not in result
         assert "language: system" not in result
         assert "exclude: docs/.*" in result
-        assert "args: [--no-default-groups, --group=typechecking]" in result
+        assert "args: [--group=typechecking, --no-default-groups]" in result
 
 
 def describe_update_vscode_settings():

--- a/tests/repo/test_poe.py
+++ b/tests/repo/test_poe.py
@@ -44,6 +44,9 @@ _PYPROJECT = dedent("""
     [tool.poe.tasks.test]
     cmd = "pytest"
 
+    [tool.poe.tasks.benchmark]
+    cmd = "pytest benchmarks"
+
     [tool.poe.tasks.nb]
     cmd = "pytest --nbmake"
 
@@ -81,6 +84,7 @@ def describe_main():
         pyproject = (poe_repo / "pyproject.toml").read_text()
         assert "[tool.poe.executor]" in pyproject  # uv executor configured
         assert "[tool.poe.groups.doc.tasks.doc]" in pyproject  # doc migrated to group
+        assert "[tool.poe.groups.test.tasks.benchmark]" in pyproject
         assert "[tool.poe.groups.test.tasks.test]" in pyproject
         assert "test-py310" in pyproject  # multi-version test-all tasks generated
         assert "test-py311" in pyproject

--- a/tests/utilities/precommit/test_class.py
+++ b/tests/utilities/precommit/test_class.py
@@ -44,6 +44,7 @@ def describe_modifiable_precommit():
                     hooks=[{"id": "second"}],
                 )
             )
+            precommit.document["repos"] = list(precommit.document["repos"])
 
         assert (
             source.read_text()

--- a/tests/utilities/precommit/test_class.py
+++ b/tests/utilities/precommit/test_class.py
@@ -1,5 +1,6 @@
 import io
 from pathlib import Path
+from textwrap import dedent
 
 import pytest
 
@@ -18,6 +19,54 @@ def example_config(this_dir: Path) -> str:
 
 
 def describe_modifiable_precommit():
+    def normalizes_spacing_between_and_within_repos(tmp_path: Path):
+        source = tmp_path / ".pre-commit-config.yaml"
+        input_yaml = dedent("""
+          repos:
+              - repo: first
+
+              # Keep this comment.
+                rev: "1"
+                hooks:
+
+                  - id: first
+
+                  - id: second
+
+
+              # Keep this repo comment.
+              - repo: second
+                hooks:
+                  - id: third
+              - repo: third
+                hooks:
+                  - id: fourth
+        """).lstrip()
+        expected = dedent("""
+          repos:
+            - repo: first
+              # Keep this comment.
+              rev: "1"
+              hooks:
+                - id: first
+                - id: second
+
+              # Keep this repo comment.
+            - repo: second
+              hooks:
+                - id: third
+
+            - repo: third
+              hooks:
+                - id: fourth
+        """).lstrip()
+        source.write_text(input_yaml)
+
+        precommit = ModifiablePrecommit.load(source)
+        precommit.dump(source)
+
+        assert source.read_text() == expected
+
     def rejects_changes_outside_context_manager(example_config: str):
         precommit = ModifiablePrecommit.load(example_config)
         precommit.document["fail_fast"] = True

--- a/tests/utilities/precommit/test_class.py
+++ b/tests/utilities/precommit/test_class.py
@@ -22,19 +22,36 @@ def example_config(this_dir: Path) -> str:
 def describe_modifiable_precommit():
     def normalizes_spacing_in_new_repo_with_plain_nested_collections(tmp_path: Path):
         source = tmp_path / ".pre-commit-config.yaml"
-        source.write_text(
-            """repos:
-  - repo: first
-    rev: "1"
-    hooks:
-      - id: first
+        input_yaml = dedent("""
+            repos:
+              - repo: first
+                rev: "1"
+                hooks:
+                  - id: first
 
-  - repo: third
-    rev: "1"
-    hooks:
-      - id: third
-"""
-        )
+              - repo: third
+                rev: "1"
+                hooks:
+                  - id: third
+        """).lstrip()
+        expected = dedent("""
+            repos:
+              - repo: first
+                rev: "1"
+                hooks:
+                  - id: first
+
+              - repo: second
+                rev: '1'
+                hooks:
+                  - id: second
+
+              - repo: third
+                rev: "1"
+                hooks:
+                  - id: third
+        """).lstrip()
+        source.write_text(input_yaml)
 
         with ModifiablePrecommit.load(source) as precommit:
             precommit.update_single_hook_repo(
@@ -46,25 +63,7 @@ def describe_modifiable_precommit():
             )
             precommit.document["repos"] = list(precommit.document["repos"])
 
-        assert (
-            source.read_text()
-            == """repos:
-  - repo: first
-    rev: "1"
-    hooks:
-      - id: first
-
-  - repo: second
-    rev: '1'
-    hooks:
-      - id: second
-
-  - repo: third
-    rev: "1"
-    hooks:
-      - id: third
-"""
-        )
+        assert source.read_text() == expected
 
     def normalizes_spacing_between_and_within_repos(tmp_path: Path):
         source = tmp_path / ".pre-commit-config.yaml"

--- a/tests/utilities/precommit/test_class.py
+++ b/tests/utilities/precommit/test_class.py
@@ -5,6 +5,7 @@ from textwrap import dedent
 import pytest
 
 from compwa_policy.utilities.precommit import ModifiablePrecommit, Precommit
+from compwa_policy.utilities.precommit.struct import Repo
 
 
 @pytest.fixture
@@ -19,46 +20,101 @@ def example_config(this_dir: Path) -> str:
 
 
 def describe_modifiable_precommit():
+    def normalizes_spacing_in_new_repo_with_plain_nested_collections(tmp_path: Path):
+        source = tmp_path / ".pre-commit-config.yaml"
+        source.write_text(
+            """repos:
+  - repo: first
+    rev: "1"
+    hooks:
+      - id: first
+
+  - repo: third
+    rev: "1"
+    hooks:
+      - id: third
+"""
+        )
+
+        with ModifiablePrecommit.load(source) as precommit:
+            precommit.update_single_hook_repo(
+                Repo(
+                    repo="second",
+                    rev="1",
+                    hooks=[{"id": "second"}],
+                )
+            )
+
+        assert (
+            source.read_text()
+            == """repos:
+  - repo: first
+    rev: "1"
+    hooks:
+      - id: first
+
+  - repo: second
+    rev: '1'
+    hooks:
+      - id: second
+
+  - repo: third
+    rev: "1"
+    hooks:
+      - id: third
+"""
+        )
+
     def normalizes_spacing_between_and_within_repos(tmp_path: Path):
         source = tmp_path / ".pre-commit-config.yaml"
         input_yaml = dedent("""
-          repos:
+            repos:
               - repo: first
 
-              # Keep this comment.
+                # Keep this comment.
                 rev: "1"
                 hooks:
 
                   - id: first
 
                   - id: second
+                    args:
+                      - |-
+                        alpha
+                        beta
 
 
               # Keep this repo comment.
               - repo: second
                 hooks:
                   - id: third
+                    types_or: [python, jupyter]
               - repo: third
                 hooks:
                   - id: fourth
         """).lstrip()
         expected = dedent("""
-          repos:
-            - repo: first
-              # Keep this comment.
-              rev: "1"
-              hooks:
-                - id: first
-                - id: second
+            repos:
+              - repo: first
+                # Keep this comment.
+                rev: "1"
+                hooks:
+                  - id: first
+                  - id: second
+                    args:
+                      - |-
+                        alpha
+                        beta
 
               # Keep this repo comment.
-            - repo: second
-              hooks:
-                - id: third
+              - repo: second
+                hooks:
+                  - id: third
+                    types_or: [python, jupyter]
 
-            - repo: third
-              hooks:
-                - id: fourth
+              - repo: third
+                hooks:
+                  - id: fourth
         """).lstrip()
         source.write_text(input_yaml)
 


### PR DESCRIPTION
Closes #650 

## ⚙️ Enhancements

- Insert a blank line between top-level entries of `repos:` in `.pre-commit-config.yaml`, so each repo block is visually separated, while collapsing any blank lines that appear elsewhere within a repo block.
- Sort the `ty` pre-commit hook's `args` so that `--group=...` comes before `--no-default-groups`.
- Move the `poe benchmark` task into the `test` poe task group alongside `cov`, `test`, and `test-all`.

```text
* ENH: move `poe benchmark` to test group
* ENH: sort `ty` arguments
* MAINT: upgrade lock files
```