### PR TITLE
ENH: support `all-fast` and `all-slow` tasks

### DIFF
--- a/src/compwa_policy/repo/poe.py
+++ b/src/compwa_policy/repo/poe.py
@@ -246,11 +246,18 @@ def _set_all_task(pyproject: ModifiablePyproject, /) -> None:
     if "all" not in task_table:
         return
     all_task = cast("Table", task_table["all"])
+    sequence = all_task.get("sequence")
+    delegates_to_tasks = isinstance(sequence, Sequence) and all(
+        isinstance(item, str) or (isinstance(item, Mapping) and "ref" in item)
+        for item in sequence
+    )
     if any([
         __safe_update(
             all_task, "help", "Run all continuous integration (CI) tasks locally"
         ),
-        __safe_update(all_task, "ignore_fail", "return_non_zero"),
+        __safe_update(all_task, "ignore_fail", "return_non_zero")
+        if not delegates_to_tasks
+        else False,
     ]):
         msg = f"Updated Poe the Poet all task in {CONFIG_PATH.pyproject}"
         pyproject.changelog.append(msg)

--- a/tests/repo/test_poe.py
+++ b/tests/repo/test_poe.py
@@ -10,6 +10,7 @@ from compwa_policy.errors import PolicyError
 from compwa_policy.repo.poe import (
     _check_expected_sections,
     _check_no_uv_run,
+    _set_all_task,
     _set_upgrade_task,
     _update_doclive,
     check,
@@ -158,6 +159,29 @@ def describe_check_no_uv_run():
         pyproject = Pyproject.load(io.StringIO(config))
         with pytest.raises(PolicyError, match=r"should not use 'uv run'"):
             _check_no_uv_run(pyproject)
+
+
+def describe_set_all_task():
+    @pytest.mark.parametrize(
+        "sequence",
+        ['["all-fast", "all-slow"]', '[{ ref = "all-fast" }, "all-slow"]'],
+        ids=["named references", "configured reference"],
+    )
+    def preserves_fail_fast_task(sequence: str, tmp_path: Path):
+        config_path = tmp_path / "pyproject.toml"
+        config_path.write_text(
+            dedent(f"""
+            [tool.poe.tasks.all]
+            sequence = {sequence}
+        """).lstrip()
+        )
+
+        with ModifiablePyproject.load(config_path) as pyproject:
+            _set_all_task(pyproject)
+
+        all_task = Pyproject.load(config_path).get_table("tool.poe.tasks.all")
+        assert "ignore_fail" not in all_task
+        assert all_task["help"] == "Run all continuous integration (CI) tasks locally"
 
 
 def describe_set_upgrade_task():


### PR DESCRIPTION
Closes https://github.com/ComPWA/policy/issues/627

## ⚙️ Enhancements

- Skip forcing `ignore_fail = "return_non_zero"` on the Poe `all` task when it is a pure sequence of task references (e.g. `["all-fast", "all-slow"]` or `[{ ref = "all-fast" }, ...]`). This lets a project stage CI into a fast and a slow phase where `all` stops as soon as `all-fast` fails, instead of always continuing on to `all-slow`.