### PR TITLE
FEAT: implement `pixi run upgrade` task

### DIFF
--- a/src/compwa_policy/env/pixi/_update.py
+++ b/src/compwa_policy/env/pixi/_update.py
@@ -5,7 +5,14 @@ from typing import TYPE_CHECKING, Any
 import yaml
 
 from compwa_policy.env.pixi._helpers import has_pixi_config
+from compwa_policy.repo.upgrade import (
+    get_julia_manifest_paths,
+    get_julia_upgrade_command,
+    get_uv_upgrade_script,
+    has_nested_uv_lock,
+)
 from compwa_policy.utilities import CONFIG_PATH, append_safe, vscode
+from compwa_policy.utilities.match import is_committed
 from compwa_policy.utilities.pyproject import (
     ModifiablePyproject,
     Pyproject,
@@ -13,7 +20,11 @@ from compwa_policy.utilities.pyproject import (
 )
 from compwa_policy.utilities.pyproject.setters import split_dependency_definition
 from compwa_policy.utilities.readme import add_badge
-from compwa_policy.utilities.toml import to_inline_table, to_toml_array
+from compwa_policy.utilities.toml import (
+    to_inline_table,
+    to_multiline_string,
+    to_toml_array,
+)
 
 if TYPE_CHECKING:
     from collections.abc import MutableMapping
@@ -55,6 +66,7 @@ def update_pixi_configuration(
         _update_docnb_and_doclive(config, "tasks")
         _update_docnb_and_doclive(config, "feature.dev.tasks")
     _clean_up_task_env(config)
+    _set_upgrade_task(config, package_manager)
     vscode.update_settings(
         session,
         {"files.associations": {"**/pixi.lock": "yaml"}},
@@ -250,6 +262,57 @@ def _set_dev_python_version(
         dependencies["python"] = version
         msg = f"Set Python version for Pixi developer environment to {version}"
         config.changelog.append(msg)
+
+
+def _set_upgrade_task(
+    config: ModifiablePyproject, package_manager: PackageManagerChoice
+) -> None:
+    tasks = __get_table(config, "tasks", create=True)
+    helper_tasks: dict[str, dict[str, Any]] = {"_upgrade-pixi": {"cmd": "pixi update"}}
+    if is_committed(".pre-commit-config.yaml"):
+        helper_tasks["_upgrade-precommit"] = {"cmd": "pre-commit autoupdate -j8"}
+    if "uv" in package_manager:
+        helper_tasks["_upgrade-uv"] = _get_uv_upgrade_task()
+    manifest_paths = get_julia_manifest_paths()
+    if manifest_paths:
+        helper_tasks["_upgrade-julia"] = _get_julia_upgrade_task(manifest_paths)
+    helper_names = {
+        "_upgrade-pixi",
+        "_upgrade-precommit",
+        "_upgrade-uv",
+        "_upgrade-julia",
+    }
+    expected = {
+        "depends-on": to_toml_array(helper_tasks),
+        "description": "Upgrade all lock files",
+    }
+    existing_helpers = {name: tasks[name] for name in helper_names if name in tasks}
+    if tasks.get("upgrade") != expected or existing_helpers != helper_tasks:
+        tasks["upgrade"] = expected
+        for name in helper_names - helper_tasks.keys():
+            tasks.pop(name, None)
+        tasks.update(helper_tasks)
+        config.changelog.append("Set Pixi upgrade task")
+
+
+def _get_uv_upgrade_task() -> dict[str, Any]:
+    if not has_nested_uv_lock():
+        return {"cmd": "uv lock --upgrade"}
+    script = get_uv_upgrade_script()
+    return {
+        "cmd": to_multiline_string(f"""
+uv run --no-project python -c '
+{script}
+'
+""")
+    }
+
+
+def _get_julia_upgrade_task(manifest_paths: list[str]) -> dict[str, Any]:
+    command: Any = get_julia_upgrade_command(manifest_paths)
+    if "\n" in command:
+        command = to_multiline_string(command)
+    return {"cmd": command}
 
 
 def __update_gitattributes(session: Session, /) -> None:

--- a/src/compwa_policy/repo/poe.py
+++ b/src/compwa_policy/repo/poe.py
@@ -12,6 +12,13 @@ import tomlkit
 
 from compwa_policy._characterization import has_documentation
 from compwa_policy.errors import PolicyError
+from compwa_policy.repo.upgrade import (
+    UV_UPGRADE_EXPRESSION,
+    UV_UPGRADE_IMPORTS,
+    get_julia_manifest_paths,
+    get_julia_upgrade_command,
+    has_nested_uv_lock,
+)
 from compwa_policy.utilities import CONFIG_PATH, remove_lines
 from compwa_policy.utilities.check_hook import check_hook
 from compwa_policy.utilities.match import git_ls_files, is_committed
@@ -397,7 +404,15 @@ def _set_upgrade_task(
             "cmd": "pixi upgrade",
             "executor": to_inline_table({"type": "simple"}),
         }
-    helper_names = {"_upgrade-precommit", "_upgrade-uv", "_upgrade-pixi"}
+    julia_task = _get_julia_upgrade_task()
+    if julia_task is not None:
+        helper_tasks["_upgrade-julia"] = julia_task
+    helper_names = {
+        "_upgrade-precommit",
+        "_upgrade-uv",
+        "_upgrade-pixi",
+        "_upgrade-julia",
+    }
     if not helper_tasks:
         removed = {"upgrade", *helper_names} & tasks.keys()
         for task_name in removed:
@@ -421,35 +436,30 @@ def _set_upgrade_task(
         pyproject.changelog.append(msg)
 
 
+def _get_julia_upgrade_task() -> dict[str, Any] | None:
+    manifest_paths = get_julia_manifest_paths()
+    if not manifest_paths:
+        return None
+    command: Any = get_julia_upgrade_command(manifest_paths)
+    if "\n" in command:
+        command = to_multiline_string(command)
+    return {
+        "cmd": command,
+        "executor": to_inline_table({"type": "simple"}),
+    }
+
+
 def _get_uv_upgrade_task() -> dict[str, Any]:
     task: dict[str, Any] = {"executor": to_inline_table({"type": "simple"})}
-    if _has_nested_uv_lock():
+    if has_nested_uv_lock():
         task.update({
-            "expr": to_multiline_string("""
-all(
-    subprocess.run(
-        ["uv", "lock", "--upgrade", "--directory", str(pathlib.Path(file).parent)],
-        check=False,
-    ).returncode == 0
-    for file in subprocess.run(
-        ["git", "ls-files"],
-        check=True,
-        capture_output=True,
-        text=True,
-    ).stdout.splitlines()
-    if pathlib.Path(file).name == "pyproject.toml"
-)
-"""),
-            "imports": to_toml_array(["pathlib", "subprocess"], multiline=False),
+            "expr": to_multiline_string(UV_UPGRADE_EXPRESSION),
+            "imports": to_toml_array(UV_UPGRADE_IMPORTS, multiline=False),
             "assert": True,
         })
     else:
         task["cmd"] = "uv lock --upgrade"
     return task
-
-
-def _has_nested_uv_lock() -> bool:
-    return any(path != "uv.lock" for path in git_ls_files("uv.lock", "**/uv.lock"))
 
 
 def _update_doclive(pyproject: ModifiablePyproject, /) -> None:

--- a/src/compwa_policy/repo/upgrade.py
+++ b/src/compwa_policy/repo/upgrade.py
@@ -1,0 +1,61 @@
+"""Generate dependency upgrade commands for supported project types."""
+
+from __future__ import annotations
+
+from compwa_policy.utilities.match import git_ls_files
+
+UV_UPGRADE_IMPORTS = ["pathlib", "subprocess"]
+UV_UPGRADE_EXPRESSION = """
+all(
+    subprocess.run(
+        ["uv", "lock", "--upgrade", "--directory", str(pathlib.Path(file).parent)],
+        check=False,
+    ).returncode == 0
+    for file in subprocess.run(
+        ["git", "ls-files"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.splitlines()
+    if pathlib.Path(file).name == "pyproject.toml"
+)
+"""
+
+
+def has_nested_uv_lock() -> bool:
+    return any(path != "uv.lock" for path in git_ls_files("uv.lock", "**/uv.lock"))
+
+
+def get_uv_upgrade_script() -> str:
+    imports = "\n".join(f"import {module}" for module in UV_UPGRADE_IMPORTS)
+    return f"{imports}\n\nraise SystemExit(not {UV_UPGRADE_EXPRESSION.strip()})"
+
+
+def get_julia_manifest_paths() -> list[str]:
+    return git_ls_files("Manifest.toml", "**/Manifest.toml")
+
+
+def get_julia_upgrade_command(manifest_paths: list[str]) -> str:
+    if len(manifest_paths) == 1:
+        project = manifest_paths[0].rpartition("/")[0] or "."
+        return f"julia --eval='using Pkg; Pkg.update()' --project={project}"
+    return """
+julia --eval='
+using Pkg
+
+files = readlines(`git ls-files`)
+projects = (dirname(file) for file in files if basename(file) == "Manifest.toml")
+failed = [
+    project
+    for project in projects
+    if try
+        Pkg.activate(project)
+        Pkg.update()
+        false
+    catch
+        true
+    end
+]
+exit(!isempty(failed))
+'
+"""

--- a/tests/repo/test_poe.py
+++ b/tests/repo/test_poe.py
@@ -246,3 +246,48 @@ def describe_set_upgrade_task():
         assert "--directory" in task["expr"]
         assert task["imports"] == ["pathlib", "subprocess"]
         assert task["assert"] is True
+
+    def adds_julia_upgrade_for_single_manifest(
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        git_init: Callable[[Path], None],
+        git_add: Callable[[Path], None],
+    ):
+        git_init(tmp_path)
+        monkeypatch.chdir(tmp_path)
+        julia_project = tmp_path / "julia"
+        julia_project.mkdir()
+        (julia_project / "Manifest.toml").touch()
+        config_path = tmp_path / "pyproject.toml"
+        config_path.write_text("[tool.poe.tasks]\n")
+        git_add(tmp_path)
+
+        with ModifiablePyproject.load(config_path) as pyproject:
+            _set_upgrade_task(pyproject, package_manager="uv")
+
+        tasks = Pyproject.load(config_path).get_table("tool.poe.tasks")
+        assert tasks["upgrade"]["parallel"] == ["_upgrade-uv", "_upgrade-julia"]
+        assert tasks["_upgrade-julia"]["cmd"].endswith("--project=julia")
+
+    def loops_over_multiple_julia_manifests(
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        git_init: Callable[[Path], None],
+        git_add: Callable[[Path], None],
+    ):
+        git_init(tmp_path)
+        monkeypatch.chdir(tmp_path)
+        for name in ["julia-a", "julia-b"]:
+            project = tmp_path / name
+            project.mkdir()
+            (project / "Manifest.toml").touch()
+        config_path = tmp_path / "pyproject.toml"
+        config_path.write_text("[tool.poe.tasks]\n")
+        git_add(tmp_path)
+
+        with ModifiablePyproject.load(config_path) as pyproject:
+            _set_upgrade_task(pyproject, package_manager="uv")
+
+        task = Pyproject.load(config_path).get_table("tool.poe.tasks._upgrade-julia")
+        assert "git ls-files" in task["cmd"]
+        assert "Pkg.activate(project)" in task["cmd"]

--- a/tests/test_pixi.py
+++ b/tests/test_pixi.py
@@ -8,11 +8,12 @@ from compwa_policy.env.pixi._update import (
     _clean_up_task_env,
     _define_combined_ci_job,
     _set_dev_python_version,
+    _set_upgrade_task,
     _update_dev_environment,
     _update_docnb_and_doclive,
     update_pixi_configuration,
 )
-from compwa_policy.utilities.pyproject import ModifiablePyproject
+from compwa_policy.utilities.pyproject import ModifiablePyproject, Pyproject
 from compwa_policy.utilities.session import Session
 
 _ENVIRONMENT_YML = dedent("""
@@ -204,3 +205,66 @@ def describe_set_dev_python_version():
             _set_dev_python_version(config, "3.12")
         assert any("Set Python version" in m for m in config.changelog)
         assert 'python = "3.12.*"' in config.dumps()
+
+
+def describe_set_upgrade_task():
+    def defines_applicable_helpers(
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        git_init: Callable[[Path], None],
+        git_add: Callable[[Path], None],
+    ):
+        git_init(tmp_path)
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / ".pre-commit-config.yaml").touch()
+        (tmp_path / "uv.lock").touch()
+        julia_project = tmp_path / "julia"
+        julia_project.mkdir()
+        (julia_project / "Manifest.toml").touch()
+        git_add(tmp_path)
+        config_path = tmp_path / "pixi.toml"
+        config_path.write_text("[tasks]\n")
+
+        with ModifiablePyproject.load(config_path) as config:
+            _set_upgrade_task(config, package_manager="pixi+uv")
+
+        config = Pyproject.load(config_path)
+        tasks = config.get_table("tasks")
+        assert tasks["upgrade"]["depends-on"] == [
+            "_upgrade-pixi",
+            "_upgrade-precommit",
+            "_upgrade-uv",
+            "_upgrade-julia",
+        ]
+        assert tasks["_upgrade-pixi"]["cmd"] == "pixi update"
+        assert tasks["_upgrade-precommit"]["cmd"] == "pre-commit autoupdate -j8"
+        assert tasks["_upgrade-uv"]["cmd"] == "uv lock --upgrade"
+        assert tasks["_upgrade-julia"]["cmd"].endswith("--project=julia")
+
+    def discovers_multiple_uv_and_julia_projects(
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        git_init: Callable[[Path], None],
+        git_add: Callable[[Path], None],
+    ):
+        git_init(tmp_path)
+        monkeypatch.chdir(tmp_path)
+        for directory in [tmp_path, tmp_path / "nested"]:
+            directory.mkdir(exist_ok=True)
+            (directory / "pyproject.toml").touch()
+            (directory / "uv.lock").touch()
+            (directory / "Manifest.toml").touch()
+        git_add(tmp_path)
+        config_path = tmp_path / "pixi.toml"
+        config_path.write_text("[tasks]\n")
+
+        with ModifiablePyproject.load(config_path) as config:
+            _set_upgrade_task(config, package_manager="pixi+uv")
+
+        tasks = Pyproject.load(config_path).get_table("tasks")
+        uv_cmd = tasks["_upgrade-uv"]["cmd"]
+        julia_cmd = tasks["_upgrade-julia"]["cmd"]
+        assert '"ls-files"' in uv_cmd
+        assert '"--directory"' in uv_cmd
+        assert "git ls-files" in julia_cmd
+        assert "Pkg.activate(project)" in julia_cmd


### PR DESCRIPTION
Closes #657 

## ✨ New features

- Add an `upgrade` task to the Pixi configuration that upgrades all lock files in one go. It is composed of `depends-on` helper tasks that are only defined when they apply to the repository:
  - `_upgrade-pixi` — always defined (`pixi update`)
  - `_upgrade-precommit` — only if `.pre-commit-config.yaml` is committed (`pre-commit autoupdate -j8`)
  - `_upgrade-uv` — only if the package manager includes `uv`
  - `_upgrade-julia` — only if any `Manifest.toml` is committed
- Define an `_upgrade-julia` helper in the Poe `upgrade` task as well, so Julia environments are upgraded alongside the Python ones whenever a repository has committed `Manifest.toml` files.
- Both the Pixi and Poe upgrade tasks adapt to the repository layout. A single `Manifest.toml` results in a one-line `julia --eval='using Pkg; Pkg.update()' --project=<dir>`, whereas multiple manifests produce a Julia script that loops over `git ls-files` and exits non-zero if any project fails to update. The same distinction applies to `uv`: a single `uv.lock` gives a plain `uv lock --upgrade`, while nested lock files trigger a script that upgrades each `pyproject.toml` directory.

## Squash commit messages

```text
* FEAT: add Julia upgrade helper to `poe upgrade` task
* MAINT: extract upgrade commands into `repo.upgrade` module
```