### PR TITLE
FIX: make TOML updates idempotent

### DIFF
--- a/src/compwa_policy/repo/poe.py
+++ b/src/compwa_policy/repo/poe.py
@@ -427,13 +427,25 @@ def _set_upgrade_task(
         "parallel": to_toml_array(helper_tasks),
     }
     existing_helpers = {name: tasks[name] for name in helper_names if name in tasks}
-    if tasks.get("upgrade") != expected or existing_helpers != helper_tasks:
+    if _unwrap_toml(tasks.get("upgrade")) != _unwrap_toml(expected) or _unwrap_toml(
+        existing_helpers
+    ) != _unwrap_toml(helper_tasks):
         tasks["upgrade"] = expected
         for name in helper_names - helper_tasks.keys():
             tasks.pop(name, None)
         tasks.update(helper_tasks)
         msg = f"Set Poe the Poet upgrade task in {CONFIG_PATH.pyproject}"
         pyproject.changelog.append(msg)
+
+
+def _unwrap_toml(value: Any) -> Any:
+    """Recursively convert Tomlkit items into formatting-independent Python values."""
+    if isinstance(value, Mapping):
+        return {key: _unwrap_toml(item) for key, item in value.items()}
+    if isinstance(value, Sequence) and not isinstance(value, str):
+        return [_unwrap_toml(item) for item in value]
+    unwrap = getattr(value, "unwrap", None)
+    return unwrap() if unwrap is not None else value
 
 
 def _get_julia_upgrade_task() -> dict[str, Any] | None:

--- a/src/compwa_policy/utilities/pyproject/__init__.py
+++ b/src/compwa_policy/utilities/pyproject/__init__.py
@@ -171,7 +171,7 @@ class ModifiablePyproject(Pyproject, ModifiableResource):
 
     @override
     def dumps(self) -> str:
-        src = tomlkit.dumps(self._document, sort_keys=True)
+        src = tomlkit.dumps(self._document)
         return f"{src.strip()}\n"
 
     def __enter__(self) -> Self:
@@ -199,7 +199,7 @@ class ModifiablePyproject(Pyproject, ModifiableResource):
         if isinstance(target, io.IOBase):
             current_position = target.tell()
             target.seek(0)
-            tomlkit.dump(self._document, target, sort_keys=True)  # ty:ignore[invalid-argument-type]
+            tomlkit.dump(self._document, target)  # ty:ignore[invalid-argument-type]
             target.seek(current_position)
         elif isinstance(target, (Path, str)):
             src = self.dumps()

--- a/src/compwa_policy/utilities/toml.py
+++ b/src/compwa_policy/utilities/toml.py
@@ -25,10 +25,15 @@ def to_toml_array(items: Iterable[Any], multiline: bool | None = None) -> Array:
 
 def to_inline_table(value: Mapping[str, Any]) -> InlineTable:
     table = tomlkit.inline_table()
+    if value:
+        table.append(None, tomlkit.ws(" "))
     for key, val in value.items():
         table[key] = val
+    if value:
+        table.append(None, tomlkit.ws(" "))
     return table
 
 
 def to_multiline_string(value: str) -> String:
-    return String(StringType.MLB, value, value, Trivia())
+    parsed_value = value.removeprefix("\n")
+    return String(StringType.MLB, parsed_value, value, Trivia())

--- a/tests/repo/test_poe.py
+++ b/tests/repo/test_poe.py
@@ -247,6 +247,31 @@ def describe_set_upgrade_task():
         assert task["imports"] == ["pathlib", "subprocess"]
         assert task["assert"] is True
 
+    def is_idempotent_after_dumping_tombi_spaced_inline_tables(
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        git_init: Callable[[Path], None],
+        git_add: Callable[[Path], None],
+    ):
+        git_init(tmp_path)
+        pyproject_path = tmp_path / "pyproject.toml"
+        pyproject_path.write_text("[tool.poe.tasks]\n")
+        (tmp_path / ".pre-commit-config.yaml").touch()
+        (tmp_path / "uv.lock").touch()
+        nested = tmp_path / "nested"
+        nested.mkdir()
+        (nested / "pyproject.toml").touch()
+        (nested / "uv.lock").touch()
+        git_add(tmp_path)
+        monkeypatch.chdir(tmp_path)
+        with ModifiablePyproject.load(pyproject_path) as pyproject:
+            _set_upgrade_task(pyproject, package_manager="uv")
+
+        with ModifiablePyproject.load(pyproject_path) as pyproject:
+            _set_upgrade_task(pyproject, package_manager="uv")
+
+        assert pyproject.changelog == []
+
     def adds_julia_upgrade_for_single_manifest(
         tmp_path: Path,
         monkeypatch: pytest.MonkeyPatch,

--- a/tests/utilities/test_pyproject.py
+++ b/tests/utilities/test_pyproject.py
@@ -61,6 +61,24 @@ def describe_load():
 
 
 def describe_edit_and_dump():
+    def preserves_table_order(tmp_path: Path):
+        pyproject_path = tmp_path / "pyproject.toml"
+        pyproject_path.write_text(
+            dedent("""
+                [project]
+                name = "my-package"
+
+                [dependency-groups]
+                dev = ["pytest"]
+            """)
+        )
+        pyproject = ModifiablePyproject.load(pyproject_path)
+
+        pyproject.dump()
+
+        result = pyproject_path.read_text()
+        assert result.index("[project]") < result.index("[dependency-groups]")
+
     def creates_and_modifies_tables():
         src = dedent("""
             [owner]

--- a/tests/utilities/test_toml.py
+++ b/tests/utilities/test_toml.py
@@ -5,11 +5,41 @@ from textwrap import dedent
 import pytest
 import tomlkit
 
-from compwa_policy.utilities.toml import to_toml_array
+from compwa_policy.utilities.toml import (
+    to_inline_table,
+    to_multiline_string,
+    to_toml_array,
+)
 
 
 def _dump(array):
     return tomlkit.dumps({"a": array}).strip()
+
+
+def describe_to_inline_table():
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [
+            ({}, "a = {}"),
+            ({"type": "simple"}, 'a = { type = "simple" }'),
+            (
+                {"name": "path", "positional": True},
+                'a = { name = "path", positional = true }',
+            ),
+        ],
+    )
+    def renders_with_tombi_spacing(value: dict, expected: str):
+        assert _dump(to_inline_table(value)) == expected
+
+
+def describe_to_multiline_string():
+    def has_the_same_value_after_serialization():
+        value = "\nline one\nline two\n"
+        string = to_multiline_string(value)
+
+        parsed_again = tomlkit.loads(tomlkit.dumps({"value": string}))["value"]
+
+        assert string == parsed_again
 
 
 def describe_to_toml_array():


### PR DESCRIPTION
Closes #663

## 🐛 Bug fixes

- Stop alphabetically sorting TOML tables when dumping `pyproject.toml` (`tomlkit.dumps`/`tomlkit.dump` no longer pass `sort_keys=True`), so `check-dev-files` preserves the original table order instead of fighting Tombi over it.
- Render inline tables (e.g. `executor = { type = "simple" }`) with the space padding Tombi expects, instead of the unpadded `{type = "simple"}` form.
- Preserve multiline string values through a formatting round-trip by stripping a redundant leading newline in `to_multiline_string`.
- Compare Poe `upgrade` task definitions as plain Python values (via a new `_unwrap_toml` helper) rather than as Tomlkit items, so re-running `check-dev-files` after Tombi has formatted the file no longer reports a spurious change to the upgrade task.

## Squash commit messages

```text
* FIX: do not sort TOML tables on export
```