### PR TITLE
FIX: preserve custom Tombi schemas

### DIFF
--- a/src/compwa_policy/format/toml.py
+++ b/src/compwa_policy/format/toml.py
@@ -163,16 +163,22 @@ def _add_tombi_hook_and_config(
         "format": {"rules": {"indent-width": 4, "line-width": 88}},
         "lint": {"rules": {"key-empty": "off"}},
     })
+    tool = pyproject.get_table("tool", create=True)
+    tombi = tool.get("tombi", {})
+    schemas = [
+        schema
+        for schema in tombi.get("schemas", [])
+        if schema.get("root") != "tool.compwa.policy"
+    ]
     schema_path = _get_policy_schema_path(precommit)
     if schema_path is not None:
-        expected["schemas"] = [
-            {
-                "root": "tool.compwa.policy",
-                "path": schema_path,
-                "include": ["pyproject.toml"],
-            }
-        ]
-    tool = pyproject.get_table("tool", create=True)
+        schemas.append({
+            "root": "tool.compwa.policy",
+            "path": schema_path,
+            "include": ["pyproject.toml"],
+        })
+    if schemas:
+        expected["schemas"] = schemas
     if tool.get("tombi") == expected:
         return
     tool["tombi"] = expected

--- a/tests/format/test_toml.py
+++ b/tests/format/test_toml.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from textwrap import dedent
 
 import pytest
+import tomlkit
 
 from compwa_policy.format.toml import (
     _add_tombi_hook_and_config,
@@ -263,6 +264,66 @@ def describe_tombi_configuration():
         assert 'root = "tool.compwa.policy"' in pyproject
         assert "https://raw.githubusercontent.com/ComPWA/policy/v0.12.3/" in pyproject
         assert "compwa-policy.schema.json" in pyproject
+
+    def preserves_repository_specific_schemas(
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        git_init: Callable[[Path], None],
+    ):
+        git_init(tmp_path)
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "pyproject.toml").write_text(
+            dedent("""
+                [project]
+                name = "x"
+
+                [[tool.tombi.schemas]]
+                root = "tool.pwa"
+                path = "pwa.schema.json"
+                include = ["pyproject.toml"]
+
+                [[tool.tombi.schemas]]
+                path = "pwa.schema.json"
+                include = ["pwa.toml"]
+
+                [[tool.tombi.schemas]]
+                root = "tool.compwa.policy"
+                path = "outdated-policy.schema.json"
+                include = ["pyproject.toml"]
+            """).lstrip()
+        )
+        (tmp_path / ".pre-commit-config.yaml").write_text(
+            dedent("""
+                repos:
+                  - repo: https://github.com/ComPWA/policy
+                    rev: v0.12.3
+                    hooks:
+                      - id: check-dev-files
+            """).lstrip()
+        )
+
+        with Session() as session:
+            _add_tombi_hook_and_config(session, session.precommit)
+
+        tombi = tomlkit.loads((tmp_path / "pyproject.toml").read_text())["tool"][
+            "tombi"
+        ]
+        assert tombi["schemas"] == [
+            {
+                "root": "tool.pwa",
+                "path": "pwa.schema.json",
+                "include": ["pyproject.toml"],
+            },
+            {
+                "path": "pwa.schema.json",
+                "include": ["pwa.toml"],
+            },
+            {
+                "root": "tool.compwa.policy",
+                "path": "https://raw.githubusercontent.com/ComPWA/policy/v0.12.3/compwa-policy.schema.json",
+                "include": ["pyproject.toml"],
+            },
+        ]
 
     def follows_tombi_table_order(
         tmp_path: Path,


### PR DESCRIPTION
Closes #670

## 🐛 Bug fixes

- `_add_tombi_hook_and_config()` no longer overwrites the entire `[[tool.tombi.schemas]]` array. Repository-specific schema entries (e.g. a `tool.pwa` schema, or one scoped to another file such as `pwa.toml`) are now preserved, and only the entry with `root = "tool.compwa.policy"` is replaced with the policy schema for the pinned `rev`. Previously, running the policy wiped any schema a repository had configured itself.
- The `schemas` key is now only written if there is at least one schema entry, so repositories without a policy schema path no longer get an empty array.