### PR TITLE
DOC: automatically generate TOML example

### DIFF
--- a/docs/_ext/__init__.py
+++ b/docs/_ext/__init__.py
@@ -1,0 +1,1 @@
+"""Local Sphinx extensions."""

--- a/docs/_ext/policy_settings.py
+++ b/docs/_ext/policy_settings.py
@@ -2,47 +2,76 @@
 
 from __future__ import annotations
 
+import html
 import json
+import re
+from dataclasses import dataclass
 from types import MappingProxyType
 from typing import TYPE_CHECKING, Any
 
 from docutils import nodes
 from docutils.parsers.rst import directives
+from pygments import highlight
+from pygments.formatters.html import HtmlFormatter
+from pygments.lexers import get_lexer_by_name
 from sphinx.directives.code import container_wrapper
 from sphinx.util.docutils import SphinxDirective
 from typing_extensions import override
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
+    from pathlib import Path
 
     from sphinx.application import Sphinx
 
+ROOT_TABLE = "tool.compwa.policy"
+
+
+@dataclass(frozen=True)
+class Setting:
+    """One key-value pair in the generated TOML example."""
+
+    table: str
+    name: str
+    value: Any
+    description: str
+
+    @property
+    def path(self) -> str:
+        return f"{self.table}.{self.name}"
+
+    @property
+    def anchor(self) -> str:
+        return nodes.make_id(self.path)
+
 
 class PolicySettingsDirective(SphinxDirective):
-    """Render a copyable TOML example from the policy settings schema."""
+    """Render a copyable TOML example from the policy settings schema.
+
+    Each key in the example is an anchor that sphinx-tippy turns into a tooltip with the
+    description of that setting, see :func:`_register_tooltips`.
+    """
 
     has_content = False
     option_spec = MappingProxyType({"caption": directives.unchanged_required})
 
     @override
     def run(self) -> list[nodes.Node]:
-        schema_path = self.env.srcdir.parent / "compwa-policy.schema.json"
-        schema = json.loads(schema_path.read_text())
-        source = _render_toml(schema)
-        example = nodes.literal_block(source, source)
-        example["language"] = "toml"
+        settings = list(_iter_settings(_load_schema(self.env.srcdir.parent)))
+        example: nodes.Node = nodes.raw("", _render_html(settings), format="html")
+        self.set_source_info(example)
         caption = self.options.get("caption")
         if caption is not None:
             example = container_wrapper(self, example, caption)
         return [example]
 
 
-def _render_toml(schema: dict[str, Any]) -> str:
-    lines: list[str] = []
-    for table, properties in _iter_tables("tool.compwa.policy", schema["properties"]):
-        if lines:
-            lines.append("")
-        lines.append(f"[{table}]")
+def _load_schema(repo_dir: Path) -> dict[str, Any]:
+    return json.loads((repo_dir / "compwa-policy.schema.json").read_text())
+
+
+def _iter_settings(schema: dict[str, Any]) -> Iterator[Setting]:
+    for table, properties in _iter_tables(ROOT_TABLE, schema["properties"]):
         for name, field_schema in properties.items():
             if field_schema.get("type") == "object":
                 continue
@@ -54,11 +83,7 @@ def _render_toml(schema: dict[str, Any]) -> str:
                 value = examples[0]
             if value is None:
                 continue
-            description = field_schema.get("description")
-            if description:
-                lines.append(f"# {description}")
-            lines.append(f"{name} = {json.dumps(value, ensure_ascii=False)}")
-    return "\n".join(lines)
+            yield Setting(table, name, value, field_schema.get("description", ""))
 
 
 def _iter_tables(
@@ -73,6 +98,102 @@ def _iter_tables(
             yield from _iter_tables(f"{table}.{name}", nested_properties)
 
 
+def _render_toml(settings: list[Setting]) -> tuple[str, dict[int, Setting]]:
+    """Render the TOML example and map each of its lines to a setting.
+
+    >>> settings = [Setting("tool.compwa.policy", "no-ruff", False, "")]
+    >>> source, line_map = _render_toml(settings)
+    >>> print(source)
+    [tool.compwa.policy]
+    no-ruff = false
+    >>> line_map[1].name
+    'no-ruff'
+    """
+    lines: list[str] = []
+    line_map: dict[int, Setting] = {}
+    table = None
+    for setting in settings:
+        if setting.table != table:
+            if lines:
+                lines.append("")
+            lines.append(f"[{setting.table}]")
+            table = setting.table
+        line_map[len(lines)] = setting
+        value = json.dumps(setting.value, ensure_ascii=False)
+        lines.append(f"{setting.name} = {value}")
+    return "\n".join(lines), line_map
+
+
+_KEY_PATTERN = re.compile(r'^(<span class="[^"]+">)?(?P<key>[\w.-]+)(</span>)?')
+
+
+def _render_html(settings: list[Setting]) -> str:
+    source, line_map = _render_toml(settings)
+    lexer = get_lexer_by_name("toml")
+    highlighted = highlight(source, lexer, HtmlFormatter(nowrap=True))
+    lines = highlighted.rstrip("\n").split("\n")
+    for number, setting in line_map.items():
+        lines[number] = _link_key(lines[number], setting)
+    body = "\n".join(lines)
+    return (
+        '<div class="highlight-toml notranslate">'
+        f'<div class="highlight"><pre>{body}</pre></div>'
+        "</div>"
+    )
+
+
+def _link_key(line: str, setting: Setting) -> str:
+    """Turn the highlighted key at the start of a line into a self-referencing anchor.
+
+    The anchor is what sphinx-tippy attaches the tooltip to; it points to itself so that
+    the key doubles as a permalink to the setting.
+
+    >>> setting = Setting("tool.compwa.policy", "no-ruff", False, "")
+    >>> _link_key('<span class="n">no-ruff</span> = false', setting)
+    '<a class="policy-setting" id="tool-compwa-policy-no-ruff" href="#tool-compwa-policy-no-ruff"><span class="n">no-ruff</span></a> = false'
+    """
+    match = _KEY_PATTERN.match(line)
+    if match is None or match.group("key") != setting.name:
+        msg = f"Could not find key {setting.name} in highlighted line: {line}"
+        raise ValueError(msg)
+    anchor = setting.anchor
+    link = (
+        f'<a class="policy-setting" id="{anchor}" href="#{anchor}">{match.group()}</a>'
+    )
+    return link + line[match.end() :]
+
+
+_LITERAL_PATTERN = re.compile(r"``(?P<text>[^`]+)``")
+
+
+def _to_tooltip(description: str) -> str:
+    """Convert a schema description to the HTML shown in its tooltip.
+
+    Only inline literals are supported, as that is the only reStructuredText markup that
+    the descriptions in the settings model use.
+
+    >>> _to_tooltip("Run pytest without the parallel ``-n`` argument.")
+    '<p>Run pytest without the parallel <code>-n</code> argument.</p>'
+    """
+    escaped = html.escape(description)
+    body = _LITERAL_PATTERN.sub(r"<code>\g<text></code>", escaped)
+    return f"<p>{body}</p>"
+
+
+def _register_tooltips(app: Sphinx) -> None:
+    """Feed the setting descriptions to sphinx-tippy as custom tips.
+
+    Custom tips are keyed by the ``href`` of the anchors created by :func:`_link_key`,
+    so the descriptions do not have to appear anywhere on the page itself.
+    """
+    settings = _iter_settings(_load_schema(app.srcdir.parent))
+    app.config.tippy_custom_tips |= {
+        f"#{setting.anchor}": _to_tooltip(setting.description) for setting in settings
+    }
+
+
 def setup(app: Sphinx) -> dict[str, bool]:
     app.add_directive("policy-settings", PolicySettingsDirective)
+    app.add_css_file("policy-settings.css")
+    app.connect("builder-inited", _register_tooltips, priority=400)
     return {"parallel_read_safe": True}

--- a/docs/_ext/policy_settings.py
+++ b/docs/_ext/policy_settings.py
@@ -1,0 +1,78 @@
+"""Render the generated policy settings schema in Sphinx."""
+
+from __future__ import annotations
+
+import json
+from types import MappingProxyType
+from typing import TYPE_CHECKING, Any
+
+from docutils import nodes
+from docutils.parsers.rst import directives
+from sphinx.directives.code import container_wrapper
+from sphinx.util.docutils import SphinxDirective
+from typing_extensions import override
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    from sphinx.application import Sphinx
+
+
+class PolicySettingsDirective(SphinxDirective):
+    """Render a copyable TOML example from the policy settings schema."""
+
+    has_content = False
+    option_spec = MappingProxyType({"caption": directives.unchanged_required})
+
+    @override
+    def run(self) -> list[nodes.Node]:
+        schema_path = self.env.srcdir.parent / "compwa-policy.schema.json"
+        schema = json.loads(schema_path.read_text())
+        source = _render_toml(schema)
+        example = nodes.literal_block(source, source)
+        example["language"] = "toml"
+        caption = self.options.get("caption")
+        if caption is not None:
+            example = container_wrapper(self, example, caption)
+        return [example]
+
+
+def _render_toml(schema: dict[str, Any]) -> str:
+    lines: list[str] = []
+    for table, properties in _iter_tables("tool.compwa.policy", schema["properties"]):
+        if lines:
+            lines.append("")
+        lines.append(f"[{table}]")
+        for name, field_schema in properties.items():
+            if field_schema.get("type") == "object":
+                continue
+            value = field_schema.get("default")
+            if value is None:
+                examples = field_schema.get("examples", [])
+                if not examples:
+                    continue
+                value = examples[0]
+            if value is None:
+                continue
+            description = field_schema.get("description")
+            if description:
+                lines.append(f"# {description}")
+            lines.append(f"{name} = {json.dumps(value, ensure_ascii=False)}")
+    return "\n".join(lines)
+
+
+def _iter_tables(
+    table: str, properties: dict[str, Any]
+) -> Iterator[tuple[str, dict[str, Any]]]:
+    yield table, properties
+    for name, field_schema in properties.items():
+        if field_schema.get("type") != "object":
+            continue
+        nested_properties = field_schema.get("properties")
+        if nested_properties is not None:
+            yield from _iter_tables(f"{table}.{name}", nested_properties)
+
+
+def setup(app: Sphinx) -> dict[str, bool]:
+    app.add_directive("policy-settings", PolicySettingsDirective)
+    return {"parallel_read_safe": True}

--- a/docs/_static/policy-settings.css
+++ b/docs/_static/policy-settings.css
@@ -1,0 +1,7 @@
+a.policy-setting,
+a.policy-setting:hover {
+  border-bottom: 1px dotted currentcolor;
+  color: inherit;
+  cursor: help;
+  text-decoration: none;
+}

--- a/docs/check-dev-files.md
+++ b/docs/check-dev-files.md
@@ -1,31 +1,6 @@
-# `check-dev-files`
+# Command-line interface
 
-This hook is responsible for standardizing and synchronizing the [developer environment](https://compwa.github.io/develop) of repositories by the [ComPWA organization](https://github.com/ComPWA). Coding conventions are enforced through automated checks instead of through a contribution guide. These conventions have to be regularly updated across all repositories as developer tools introduce new features and deprecate old ones.
-
-The `check-dev-files` hook can also be used as a **cookie cutter** for new repositories by adding the following to your [`.pre-commit-config.yaml`](https://pre-commit.com/index.html#adding-pre-commit-plugins-to-your-project) file:
-
-```yaml
-repos:
-  - repo: https://github.com/ComPWA/policy
-    rev: ""
-    hooks:
-      - id: check-dev-files
-        args:
-          - --repo-name="short name for your repository"
-```
-
-and running
-
-```shell
-pre-commit autoupdate --repo=https://github.com/ComPWA/policy
-pre-commit run check-dev-files -a
-```
-
-For more implementation details of this hook, check the {mod}`compwa_policy.cli` module.
-
-## Command-line interface
-
-The checks are also exposed through a short [Typer](https://typer.tiangolo.com)-based `policy` command. Running `policy` without a subcommand runs every check at once, which is exactly what the `check-dev-files` pre-commit hook does. The subcommands group the checks by domain, so you can run just a subset.
+The `check-dev-files` checks are also exposed through a short [Typer](https://typer.tiangolo.com)-based `policy` command. Running `policy` without a subcommand runs every check at once, exactly like the `check-dev-files` pre-commit hook. The subcommands group the checks by domain, so you can run just a subset.
 
 You do not need to install anything: with [`uv`](https://docs.astral.sh/uv), `uvx` fetches and runs the command on the fly. For example, to see which subcommands are available:
 
@@ -41,7 +16,9 @@ If you run the command often, you can install it as a persistent tool with [`uv 
 
 ## Hook arguments
 
-The `check-dev-files` hook (and the `policy` command without a subcommand) only accepts the options that are shared across the whole repository, such as `--repo-name`. These can be added to the [`args`](https://pre-commit.com/#config-args) key in your `.pre-commit-config.yaml` file. Options scoped to a single area (e.g. `--no-pypi`) are exposed on the matching subcommand instead and are configured through its `[tool.compwa.policy.<group>]` table (see [below](#configuration)). The full command tree and its options are:
+The `check-dev-files` hook (and the `policy` command without a subcommand) only accepts the options that are shared across the whole repository, such as `--repo-name`. These can be added to the [`args`](https://pre-commit.com/#config-args) key in your `.pre-commit-config.yaml` file. Options scoped to a single area (for example, `--no-pypi`) are exposed on the matching subcommand and are configured through its `[tool.compwa.policy.<group>]` table. See {doc}`check-dev-files/configuration` for details.
+
+The full command tree and its options are:
 
 ```{typer} compwa_policy.cli:app
 :prog: policy
@@ -57,49 +34,8 @@ Run `policy bootstrap` in an existing repository to detect whether it contains P
 uvx --from git+https://github.com/ComPWA/policy policy bootstrap
 ```
 
-<!-- prettier-ignore-start -->
-(configuration)=
-## Configuration in `pyproject.toml`
-<!-- prettier-ignore-end -->
-
-Instead of repeating the same flags under `args:` in every `.pre-commit-config.yaml`, a repository can declare its options once in a `[tool.compwa.policy]` table in its `pyproject.toml`. Each option is resolved with the following precedence (first match wins):
-
-1. the option explicitly passed on the command line (e.g. under `args:`);
-2. the `[tool.compwa.policy]` table in `pyproject.toml`;
-3. the built-in default.
-
-The table mirrors the subcommand tree. Shared options live at the top level, while
-subcommand-specific options live in nested tables. The following copyable example is
-generated from the settings schema and shows every built-in default. Hover over an
-option to see what it does:
-
-```{eval-rst}
-.. policy-settings::
-    :caption: pyproject.toml
+```{toctree}
+:hidden:
+Configuration <check-dev-files/configuration>
+Migrations <check-dev-files/migrations>
 ```
-
-The `env` subcommand maps to the `setup` table. Environment variables can be added as
-key-value pairs under `[tool.compwa.policy.setup.env]`.
-
-Both the native TOML form (arrays, tables, booleans) and the legacy command-line string form (`"mypy,pyright"`, `"A=1,B=2"`) are accepted, so an existing `args:` list can be moved into `pyproject.toml` verbatim.
-
-## Migrating after breaking changes
-
-Some policy updates introduce breaking changes to a repository's configuration. The `check-dev-files` pre-commit hook cannot rewrite your files to apply such a change itself — it can only detect it and fail. The `policy migrate` command applies these migrations for you, but because it modifies configuration files it has to be run **outside of `pre-commit`**, as a one-off command.
-
-:::{important}
-If the `check-dev-files` hook starts failing after an upgrade, run `policy migrate` to bring your configuration up to date. You do **not** need to install anything first:
-
-```shell
-uvx --from git+https://github.com/ComPWA/policy --refresh policy migrate
-```
-
-:::
-
-To preview the changes without writing any files, add `--dry-run`:
-
-```shell
-uvx --from git+https://github.com/ComPWA/policy --refresh policy migrate --dry-run
-```
-
-If you already installed the `policy` command, you can drop the `uvx --from git+https://github.com/ComPWA/policy` prefix and simply run `policy migrate`.

--- a/docs/check-dev-files.md
+++ b/docs/check-dev-files.md
@@ -68,33 +68,17 @@ Instead of repeating the same flags under `args:` in every `.pre-commit-config.y
 2. the `[tool.compwa.policy]` table in `pyproject.toml`;
 3. the built-in default.
 
-The table is organized hierarchically, mirroring the subcommand tree: options shared by several checks live in the top-level table, while options that belong to a single subcommand live in a sub-table named after it. The `env` subcommand maps to a `setup` table, and environment variables are a plain nested table under `[tool.compwa.policy.setup.env]`:
+The table mirrors the subcommand tree. Shared options live at the top level, while
+subcommand-specific options live in nested tables. The following copyable example is
+generated from the settings schema and shows every built-in default:
 
-```toml
-[tool.compwa.policy]
-# options shared by several checks
-dev-python-version = "3.13"
-package-manager = "pixi"
-
-[tool.compwa.policy.python]
-imports-on-top = true
-type-checker = ["mypy", "pyright"]
-
-[tool.compwa.policy.nb]
-no-binder = true
-allowed-cell-metadata = ["scrolled"]
-
-# options of the `env` subcommand (uv, conda, pixi, direnv)
-[tool.compwa.policy.setup]
-keep-contributing-md = true
-
-# environment variables, as a plain TOML table
-[tool.compwa.policy.setup.env]
-PYTHONHASHSEED = "0"
-
-[tool.compwa.policy.repo]
-gitpod = true
+```{eval-rst}
+.. policy-settings::
+    :caption: pyproject.toml
 ```
+
+The `env` subcommand maps to the `setup` table. Environment variables can be added as
+key-value pairs under `[tool.compwa.policy.setup.env]`.
 
 Both the native TOML form (arrays, tables, booleans) and the legacy command-line string form (`"mypy,pyright"`, `"A=1,B=2"`) are accepted, so an existing `args:` list can be moved into `pyproject.toml` verbatim.
 

--- a/docs/check-dev-files.md
+++ b/docs/check-dev-files.md
@@ -70,7 +70,8 @@ Instead of repeating the same flags under `args:` in every `.pre-commit-config.y
 
 The table mirrors the subcommand tree. Shared options live at the top level, while
 subcommand-specific options live in nested tables. The following copyable example is
-generated from the settings schema and shows every built-in default:
+generated from the settings schema and shows every built-in default. Hover over an
+option to see what it does:
 
 ```{eval-rst}
 .. policy-settings::

--- a/docs/check-dev-files/configuration.md
+++ b/docs/check-dev-files/configuration.md
@@ -1,0 +1,30 @@
+<!-- prettier-ignore-start -->
+(configuration)=
+# Configuration
+<!-- prettier-ignore-end -->
+
+Instead of repeating the same flags under `args:` in every
+`.pre-commit-config.yaml`, a repository can declare its options once in a
+`[tool.compwa.policy]` table in `pyproject.toml`. Each option is resolved with the
+following precedence (first match wins):
+
+1. the option explicitly passed on the command line (for example, under `args:`);
+2. the `[tool.compwa.policy]` table in `pyproject.toml`;
+3. the built-in default.
+
+The table mirrors the {doc}`subcommand tree <../check-dev-files>`. Shared options
+live at the top level, while subcommand-specific options live in nested tables. The
+following copyable example is generated from the settings schema and shows every
+built-in default. Hover over an option to see what it does:
+
+```{eval-rst}
+.. policy-settings::
+    :caption: pyproject.toml
+```
+
+The `env` subcommand maps to the `setup` table. Environment variables can be added
+as key-value pairs under `[tool.compwa.policy.setup.env]`.
+
+Both the native TOML form (arrays, tables, booleans) and the legacy command-line
+string form (`"mypy,pyright"`, `"A=1,B=2"`) are accepted, so an existing `args:` list
+can be moved into `pyproject.toml` verbatim.

--- a/docs/check-dev-files/migrations.md
+++ b/docs/check-dev-files/migrations.md
@@ -1,0 +1,28 @@
+# Migrating after breaking changes
+
+Some policy updates introduce breaking changes to a repository's configuration.
+The `check-dev-files` pre-commit hook cannot rewrite your files to apply such a
+change itself—it can only detect it and fail. The `policy migrate` command applies
+these migrations for you, but because it modifies configuration files it has to be
+run **outside of pre-commit**, as a one-off command.
+
+:::{important}
+If the `check-dev-files` hook starts failing after an upgrade, run `policy migrate`
+to bring your configuration up to date. You do **not** need to install anything
+first:
+
+```shell
+uvx --from git+https://github.com/ComPWA/policy --refresh policy migrate
+```
+
+:::
+
+To preview the changes without writing any files, add `--dry-run`:
+
+```shell
+uvx --from git+https://github.com/ComPWA/policy --refresh policy migrate --dry-run
+```
+
+If you already installed the `policy` command, you can drop the
+`uvx --from git+https://github.com/ComPWA/policy` prefix and simply run
+`policy migrate`.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -58,6 +58,7 @@ extensions = [
     "sphinx_api_relink",
     "sphinx_codeautolink",
     "sphinx_copybutton",
+    "sphinx_tippy",
     "sphinx.ext.autodoc",
     "sphinx.ext.autosectionlabel",
     "sphinx.ext.doctest",
@@ -131,4 +132,10 @@ nitpicky = True
 primary_domain = "py"
 project = PACKAGE_NAME
 release = get_package_version(PACKAGE_NAME)
+tippy_anchor_parent_selector = "article.bd-article"
+tippy_props = {
+    "delay": [200, 100],
+    "maxWidth": 500,
+    "placement": "auto-start",
+}
 version = get_package_version(PACKAGE_NAME)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -101,6 +101,7 @@ html_theme_options = {
     "show_toc_level": 2,
     "use_download_button": False,
     "use_edit_page_button": True,
+    "use_fullscreen_button": False,
     "use_issues_button": True,
     "use_repository_button": True,
     "use_source_button": True,

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,6 +1,11 @@
 from __future__ import annotations
 
+import sys
+from pathlib import Path
+
 from sphinx_api_relink.helpers import get_branch_name, get_package_version
+
+sys.path.insert(0, str(Path(__file__).parent))
 
 BRANCH = get_branch_name()
 ORGANIZATION = "ComPWA"
@@ -48,6 +53,7 @@ copybutton_prompt_text = r">>> |\.\.\. "  # doctest
 copyright = "2023, Common Partial Wave Analysis"  # noqa: A001
 default_role = "py:obj"
 extensions = [
+    "_ext.policy_settings",
     "myst_parser",
     "sphinx_api_relink",
     "sphinx_codeautolink",

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,9 +3,9 @@
 :::{title} Welcome
 :::
 
-This repository sets policies for [repositories of the ComPWA organization](https://github.com/orgs/ComPWA/repositories). The policies are enforced through [pre-commit](https://pre-commit.com) with the use of a number of pre-commit hooks as defined by [`.pre-commit-hooks.yaml`](../.pre-commit-hooks.yaml). The [`check-dev-files`](./check-dev-files.md) in particular can be used as a **cookie cutter** for new repositories.
+This repository standardizes and synchronizes the developer environment of [ComPWA repositories](https://github.com/orgs/ComPWA/repositories). Its [`check-dev-files`](./check-dev-files.md) hook keeps configuration files up to date as developer tools introduce new features and deprecate old ones. The policies are enforced through [pre-commit](https://pre-commit.com); all available hooks are listed in [`.pre-commit-hooks.yaml`](https://github.com/ComPWA/policy/blob/main/.pre-commit-hooks.yaml).
 
-## Usage
+## Set up a repository
 
 Add a [`.pre-commit-config.yaml`](https://pre-commit.com/index.html#adding-pre-commit-plugins-to-your-project) file to your repository and list which hooks you want to use:
 
@@ -19,7 +19,7 @@ repos:
           - --repo-name="short name for your repository"
 ```
 
-and install and activate [`pre-commit`](https://pre-commit.com/#install) as follows:
+Then install and activate [`pre-commit`](https://pre-commit.com/#install):
 
 ```shell
 pip install pre-commit
@@ -27,11 +27,19 @@ pre-commit autoupdate --repo=https://github.com/ComPWA/policy
 pre-commit install
 ```
 
-The **ComPWA/policy** repository provides the [`check-dev-files`](./check-dev-files.md) hook. The notebook formatting hooks that used to be served from here now live in [ComPWA/nbhooks](https://github.com/ComPWA/nbhooks).
+Running the hook for the first time turns this minimal configuration into the standard ComPWA developer setup:
+
+```shell
+pre-commit run check-dev-files --all-files
+```
+
+For an existing repository, `policy bootstrap` can detect its current setup and configure the hook automatically. See the {doc}`command-line guide <check-dev-files>` for bootstrapping, individual checks, and installation options.
+
+The notebook formatting hooks that used to be served from this repository now live in [ComPWA/nbhooks](https://github.com/ComPWA/nbhooks).
 
 ```{toctree}
 :hidden:
-check-dev-files
+Command-line interface <check-dev-files>
 API <api/compwa_policy>
 Continuous benchmarks <https://compwa.github.io/policy-benchmark-results>
 Changelog <https://github.com/ComPWA/policy/releases>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,7 @@ doc = [
     "sphinx-book-theme",
     "sphinx-codeautolink",
     "sphinx-copybutton",
+    "sphinx-tippy",
     "sphinxcontrib-typer",
 ]
 style = [
@@ -310,6 +311,7 @@ filterwarnings = [
 minversion = "9.0"
 testpaths = [
     "benchmarks",
+    "docs/_ext",
     "src",
     "tests",
 ]


### PR DESCRIPTION
Closes #672 

## 📝 Documentation

- The `[tool.compwa.policy]` example in the configuration guide is no longer maintained by hand. A new `policy-settings` Sphinx directive renders a copyable TOML example straight from `compwa-policy.schema.json`, listing every setting with its built-in default (or first example value).
- Each key in the generated example is an anchor that doubles as a permalink and carries a [sphinx-tippy](https://sphinx-tippy.readthedocs.io) tooltip with the description of that setting, so the options document themselves on hover without cluttering the page.
- The `check-dev-files` page has been split up: it is now a focused **Command-line interface** page, with **Configuration** and **Migrations** moved to their own subpages under `docs/check-dev-files/`.
- The landing page has been rewritten around setting up a repository, pointing to `policy bootstrap` and the command-line guide instead of repeating the cookiecutter instructions.
- Removed the fullscreen button from the Sphinx Book Theme header.

## 🖱️ Developer experience

- Added `sphinx-tippy` to the `doc` dependencies and registered `docs/_ext` as a `testpaths` entry, so the doctests in the new Sphinx extension run as part of the test suite.

## Squash commit messages

```text
* DOC: remove fullscreen button
* DOC: split `check-dev-files` page into subpages
* ENH: embed option documentation as tooltips
```