### PR TITLE
FIX: keep `repos` round-trippable when sorting

### DIFF
--- a/src/compwa_policy/cli/bootstrap.py
+++ b/src/compwa_policy/cli/bootstrap.py
@@ -20,6 +20,7 @@ if TYPE_CHECKING:
     from pathlib import Path
 
 _POLICY_REPO = "https://github.com/ComPWA/policy"
+_CONFIGURATION_URL = "https://compwa.github.io/policy/check-dev-files/configuration"
 
 
 def bootstrap() -> None:
@@ -30,6 +31,7 @@ def bootstrap() -> None:
     rich.print(
         "[green]Bootstrapped policy configuration and the check-dev-files hook.[/green]"
     )
+    rich.print(f"Configure policy further:\n{_CONFIGURATION_URL}")
 
 
 def _write_policy_configuration(

--- a/src/compwa_policy/format/precommit.py
+++ b/src/compwa_policy/format/precommit.py
@@ -6,6 +6,7 @@ import re
 from pathlib import Path
 from typing import TYPE_CHECKING, cast
 
+from ruamel.yaml.comments import CommentedSeq
 from ruamel.yaml.tokens import CommentToken
 
 from compwa_policy.utilities import CONFIG_PATH
@@ -47,7 +48,10 @@ def _sort_hooks(precommit: ModifiablePrecommit) -> None:
         return
     sorted_repos = sorted(repos, key=__repo_sort_key)
     if sorted_repos != repos:
-        precommit.document["repos"] = sorted_repos
+        if isinstance(repos, CommentedSeq):
+            repos[:] = sorted_repos  # keep the round-trip container
+        else:
+            precommit.document["repos"] = sorted_repos
         msg = "Sorted all pre-commit hooks"
         precommit.changelog.append(msg)
 

--- a/src/compwa_policy/format/precommit.py
+++ b/src/compwa_policy/format/precommit.py
@@ -6,7 +6,6 @@ import re
 from pathlib import Path
 from typing import TYPE_CHECKING, cast
 
-from ruamel.yaml.comments import CommentedSeq
 from ruamel.yaml.tokens import CommentToken
 
 from compwa_policy.utilities import CONFIG_PATH
@@ -48,10 +47,7 @@ def _sort_hooks(precommit: ModifiablePrecommit) -> None:
         return
     sorted_repos = sorted(repos, key=__repo_sort_key)
     if sorted_repos != repos:
-        if isinstance(repos, CommentedSeq):
-            repos[:] = sorted_repos  # keep the round-trip container
-        else:
-            precommit.document["repos"] = sorted_repos
+        repos[:] = sorted_repos  # in place, to keep the round-trip container
         msg = "Sorted all pre-commit hooks"
         precommit.changelog.append(msg)
 

--- a/src/compwa_policy/utilities/precommit/setters.py
+++ b/src/compwa_policy/utilities/precommit/setters.py
@@ -89,9 +89,8 @@ def update_single_hook_precommit_repo(
         if existing_rev is not None:
             expected_yaml.insert(1, "rev", PlainScalarString(existing_rev))
         repos[idx] = expected_yaml  # ty:ignore[invalid-assignment]
-        repos_yaml = cast("CommentedSeq", repos)
-        if isinstance(repos_yaml, CommentedSeq):
-            repos_yaml.yaml_set_comment_before_after_key(idx + 1, before="\n")
+        if isinstance(repos, CommentedSeq):
+            repos.yaml_set_comment_before_after_key(idx + 1, before="\n")
         msg = f"Updated {hook_id} hook"
         precommit.changelog.append(msg)
 
@@ -161,7 +160,7 @@ def update_precommit_hook(
         hook_idx = __determine_expected_hook_idx(hooks, expected_hook["id"])
         hooks.insert(hook_idx, expected_hook)
         if hook_idx == len(hooks) - 1:
-            repos_yaml = cast("CommentedSeq", precommit.document["repos"])
+            repos_yaml = precommit.document["repos"]
             if isinstance(repos_yaml, CommentedSeq):
                 repos_yaml.yaml_set_comment_before_after_key(repo_idx + 1, before="\n")
         msg = f"Added {expected_hook['id']!r} to {repo_name} pre-commit config"

--- a/src/compwa_policy/utilities/precommit/setters.py
+++ b/src/compwa_policy/utilities/precommit/setters.py
@@ -161,8 +161,9 @@ def update_precommit_hook(
         hook_idx = __determine_expected_hook_idx(hooks, expected_hook["id"])
         hooks.insert(hook_idx, expected_hook)
         if hook_idx == len(hooks) - 1:
-            repos = cast("CommentedMap", precommit.document["repos"][hook_idx])
-            repos.yaml_set_comment_before_after_key(repo_idx + 1, before="\n")
+            repos_yaml = cast("CommentedSeq", precommit.document["repos"])
+            if isinstance(repos_yaml, CommentedSeq):
+                repos_yaml.yaml_set_comment_before_after_key(repo_idx + 1, before="\n")
         msg = f"Added {expected_hook['id']!r} to {repo_name} pre-commit config"
         precommit.changelog.append(msg)
 

--- a/src/compwa_policy/utilities/precommit/setters.py
+++ b/src/compwa_policy/utilities/precommit/setters.py
@@ -89,8 +89,9 @@ def update_single_hook_precommit_repo(
         if existing_rev is not None:
             expected_yaml.insert(1, "rev", PlainScalarString(existing_rev))
         repos[idx] = expected_yaml  # ty:ignore[invalid-assignment]
-        repos_map = cast("CommentedMap", repos)
-        repos_map.yaml_set_comment_before_after_key(idx + 1, before="\n")
+        repos_yaml = cast("CommentedSeq", repos)
+        if isinstance(repos_yaml, CommentedSeq):
+            repos_yaml.yaml_set_comment_before_after_key(idx + 1, before="\n")
         msg = f"Updated {hook_id} hook"
         precommit.changelog.append(msg)
 

--- a/tests/cli/test_bootstrap.py
+++ b/tests/cli/test_bootstrap.py
@@ -12,6 +12,7 @@ def describe_bootstrap():
         tmp_path: Path,
         monkeypatch: pytest.MonkeyPatch,
         git_init,
+        capsys: pytest.CaptureFixture,
     ) -> None:
         monkeypatch.chdir(tmp_path)
         git_init(tmp_path)
@@ -29,6 +30,11 @@ def describe_bootstrap():
         policy_repo = precommit["repos"][0]
         assert policy_repo["repo"] == "https://github.com/ComPWA/policy"
         assert policy_repo["hooks"] == [{"id": "check-dev-files"}]
+        assert (
+            "Configure policy further:\n"
+            "https://compwa.github.io/policy/check-dev-files/configuration\n"
+            in capsys.readouterr().out
+        )
 
     def preserves_existing_precommit_hooks(
         tmp_path: Path,

--- a/tests/cli/test_bootstrap.py
+++ b/tests/cli/test_bootstrap.py
@@ -30,11 +30,9 @@ def describe_bootstrap():
         policy_repo = precommit["repos"][0]
         assert policy_repo["repo"] == "https://github.com/ComPWA/policy"
         assert policy_repo["hooks"] == [{"id": "check-dev-files"}]
-        assert (
-            "Configure policy further:\n"
-            "https://compwa.github.io/policy/check-dev-files/configuration\n"
-            in capsys.readouterr().out
-        )
+        output = capsys.readouterr().out
+        assert "Configure policy further:" in output
+        assert "https://compwa.github.io/policy/check-dev-files/configuration" in output
 
     def preserves_existing_precommit_hooks(
         tmp_path: Path,

--- a/tests/format/test_precommit.py
+++ b/tests/format/test_precommit.py
@@ -5,9 +5,11 @@ from textwrap import dedent
 from typing import TYPE_CHECKING
 
 import yaml
+from ruamel.yaml.comments import CommentedSeq
 
 from compwa_policy.format import precommit
 from compwa_policy.utilities.precommit import ModifiablePrecommit, Precommit
+from compwa_policy.utilities.precommit.struct import Hook, Repo
 from compwa_policy.utilities.session import Session
 
 if TYPE_CHECKING:
@@ -158,6 +160,49 @@ def describe_sort_hooks():
         ]
         positions = [result.index(token) for token in expected_order]
         assert positions == sorted(positions)
+
+    def keeps_repos_a_round_trip_sequence():
+        with _load("""
+                repos:
+                  - repo: https://github.com/psf/black
+                    hooks:
+                      - id: black
+                  - repo: meta
+                    hooks:
+                      - id: check-hooks-apply
+            """) as pc:
+            precommit._sort_hooks(pc)
+            repos = pc.document["repos"]
+        assert isinstance(repos, CommentedSeq)
+
+    def allows_updating_a_hook_after_sorting():
+        """Sorting used to replace ``repos`` with a plain `list`.
+
+        Later checks then crashed on the round-trip-only
+        ``yaml_set_comment_before_after_key``.
+        """
+        expected = Repo(
+            repo="https://github.com/streetsidesoftware/cspell-cli",
+            rev="v10.0.1",
+            hooks=[Hook(id="cspell", language_version="25.9.0")],
+        )
+        with _load("""
+                repos:
+                  - repo: https://github.com/ComPWA/policy
+                    rev: 0.9.2
+                    hooks:
+                      - id: check-dev-files
+                  - repo: meta
+                    hooks:
+                      - id: check-hooks-apply
+                  - repo: https://github.com/streetsidesoftware/cspell-cli
+                    rev: v10.0.1
+                    hooks:
+                      - id: cspell
+            """) as pc:
+            precommit._sort_hooks(pc)
+            pc.update_single_hook_repo(expected)
+        assert "language_version: 25.9.0" in pc.dumps()
 
 
 def describe_update_precommit_ci():

--- a/tests/utilities/precommit/test_setters.py
+++ b/tests/utilities/precommit/test_setters.py
@@ -108,10 +108,9 @@ def describe_update_precommit_hook():
                   - id: nbqa-black
                   - id: nbqa-isort
         """).lstrip()
-
         with ModifiablePrecommit.load(io.StringIO(config)) as precommit:
             precommit.update_hook(
-                "https://github.com/nbQA-dev/nbQA", Hook(id="nbqa-pyupgrade")
+                repo_url="https://github.com/nbQA-dev/nbQA",
+                expected_hook=Hook(id="nbqa-pyupgrade"),
             )
-
         assert "id: nbqa-pyupgrade" in precommit.dumps()

--- a/tests/utilities/precommit/test_setters.py
+++ b/tests/utilities/precommit/test_setters.py
@@ -1,14 +1,8 @@
-from __future__ import annotations
-
 import io
 from textwrap import dedent
-from typing import TYPE_CHECKING, cast
 
 from compwa_policy.utilities.precommit import ModifiablePrecommit
 from compwa_policy.utilities.precommit.struct import Hook, Repo
-
-if TYPE_CHECKING:
-    from ruamel.yaml.comments import CommentedMap, CommentedSeq
 
 
 def _expected_ty_repo() -> Repo:
@@ -121,25 +115,3 @@ def describe_update_precommit_hook():
             )
 
         assert "id: nbqa-pyupgrade" in precommit.dumps()
-
-    def sets_the_separator_on_the_repo_sequence():
-        config = dedent("""
-            repos:
-              - repo: https://github.com/nbQA-dev/nbQA
-                rev: 1.9.1
-                hooks:
-                  - id: nbqa-isort
-
-              - repo: meta
-                hooks:
-                  - id: check-hooks-apply
-        """).lstrip()
-
-        with ModifiablePrecommit.load(io.StringIO(config)) as precommit:
-            precommit.update_hook(
-                "https://github.com/nbQA-dev/nbQA", Hook(id="nbqa-pyupgrade")
-            )
-            repos = cast("CommentedSeq", precommit.document["repos"])
-            first_repo = cast("CommentedMap", repos[0])
-            assert 1 in repos.ca.items  # separator before the next repo
-            assert not any(isinstance(key, int) for key in first_repo.ca.items)

--- a/tests/utilities/precommit/test_setters.py
+++ b/tests/utilities/precommit/test_setters.py
@@ -1,8 +1,14 @@
+from __future__ import annotations
+
 import io
 from textwrap import dedent
+from typing import TYPE_CHECKING, cast
 
 from compwa_policy.utilities.precommit import ModifiablePrecommit
 from compwa_policy.utilities.precommit.struct import Hook, Repo
+
+if TYPE_CHECKING:
+    from ruamel.yaml.comments import CommentedMap, CommentedSeq
 
 
 def _expected_ty_repo() -> Repo:
@@ -87,3 +93,53 @@ def describe_update_single_hook_precommit_repo():
         assert "id: check-foo" in result
         assert "entry: ty check" in result
         assert result.count("repo: local") == 1
+
+
+def describe_update_precommit_hook():
+    def appends_hook_to_repo_with_fewer_repos_than_hooks():
+        """The separator used to be keyed on the hook index, not the repo index.
+
+        Indexing ``repos`` with a hook index raises `IndexError` as soon as the
+        hook lands beyond the last repo.
+        """
+        config = dedent("""
+            repos:
+              - repo: meta
+                hooks:
+                  - id: check-hooks-apply
+
+              - repo: https://github.com/nbQA-dev/nbQA
+                rev: 1.9.1
+                hooks:
+                  - id: nbqa-black
+                  - id: nbqa-isort
+        """).lstrip()
+
+        with ModifiablePrecommit.load(io.StringIO(config)) as precommit:
+            precommit.update_hook(
+                "https://github.com/nbQA-dev/nbQA", Hook(id="nbqa-pyupgrade")
+            )
+
+        assert "id: nbqa-pyupgrade" in precommit.dumps()
+
+    def sets_the_separator_on_the_repo_sequence():
+        config = dedent("""
+            repos:
+              - repo: https://github.com/nbQA-dev/nbQA
+                rev: 1.9.1
+                hooks:
+                  - id: nbqa-isort
+
+              - repo: meta
+                hooks:
+                  - id: check-hooks-apply
+        """).lstrip()
+
+        with ModifiablePrecommit.load(io.StringIO(config)) as precommit:
+            precommit.update_hook(
+                "https://github.com/nbQA-dev/nbQA", Hook(id="nbqa-pyupgrade")
+            )
+            repos = cast("CommentedSeq", precommit.document["repos"])
+            first_repo = cast("CommentedMap", repos[0])
+            assert 1 in repos.ca.items  # separator before the next repo
+            assert not any(isinstance(key, int) for key in first_repo.ca.items)


### PR DESCRIPTION
Closes #674

## 🐛 Bug fixes

- **`_sort_hooks()` no longer degrades the round-trip document.** Sorting used to rebind `precommit.document["repos"]` to the plain `list` returned by `sorted()`, discarding ruamel's `CommentedSeq` container. Any check running after `format.precommit` then crashed on the round-trip-only `yaml_set_comment_before_after_key()` with `AttributeError: 'list' object has no attribute …` — reproducibly so right after `policy bootstrap`, which emits a repo order that `__repo_sort_key()` immediately reorders. The sorted order is now written back in place (`repos[:] = sorted_repos`), so the container, comments and blank lines survive sorting.
- **The unguarded separator call in `update_single_hook_precommit_repo()` is now guarded.** The _update existing repo_ branch called `yaml_set_comment_before_after_key()` directly, unlike the _insert new repo_ branch a few lines above. It also cast `repos` to `CommentedMap` — the wrong type for a sequence — which is precisely why `ty` never flagged the unguarded access. The bogus cast is gone, replaced by an `isinstance(repos, CommentedSeq)` check.
- **The blank-line separator is keyed on the repo index again.** `update_precommit_hook()` looked up `precommit.document["repos"][hook_idx]` — a _hook_ index used to index the _repo_ sequence — and set the comment on the resulting repo mapping. As soon as a hook landed beyond the last repo, this raised `IndexError`; when it did not, the separator was set on the wrong object. The call now goes to the `repos` sequence itself at `repo_idx + 1`.

## ⚙️ Enhancements

- `policy bootstrap` now prints a link to <https://compwa.github.io/policy/check-dev-files/configuration> after bootstrapping, pointing users at the settings they can configure next.

## Squash commit messages

```text
* ENH: print link to ComPWA/policy config documentation
* FIX: key pre-commit repo separator on the repo index
```