### PR TITLE
FIX: do not set `language_version` in cspell hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -125,7 +125,6 @@ repos:
     rev: v10.0.1
     hooks:
       - id: cspell
-        language_version: 25.9.0
 
   - repo: https://github.com/editorconfig-checker/editorconfig-checker.python
     rev: 3.6.1

--- a/src/compwa_policy/format/cspell.py
+++ b/src/compwa_policy/format/cspell.py
@@ -114,7 +114,7 @@ def _update_precommit_repo(precommit: ModifiablePrecommit) -> None:
     expected_hook = Repo(
         repo=__REPO_URL,
         rev="",
-        hooks=[Hook(id="cspell", language_version="25.9.0")],
+        hooks=[Hook(id="cspell")],
     )
     precommit.update_single_hook_repo(expected_hook)
 

--- a/tests/format/test_precommit.py
+++ b/tests/format/test_precommit.py
@@ -184,7 +184,7 @@ def describe_sort_hooks():
         expected = Repo(
             repo="https://github.com/streetsidesoftware/cspell-cli",
             rev="v10.0.1",
-            hooks=[Hook(id="cspell", language_version="25.9.0")],
+            hooks=[Hook(id="cspell", args=["--gitignore"])],
         )
         with _load("""
                 repos:
@@ -202,7 +202,7 @@ def describe_sort_hooks():
             """) as pc:
             precommit._sort_hooks(pc)
             pc.update_single_hook_repo(expected)
-        assert "language_version: 25.9.0" in pc.dumps()
+        assert "args:\n          - --gitignore" in pc.dumps()
 
 
 def describe_update_precommit_ci():


### PR DESCRIPTION
Closes #678

## 🐛 Bug fixes

- Stop pinning `language_version` on the `cspell` pre-commit hook, so `check-dev-files` no longer forces a specific `cspell` release and instead lets the hook use whichever version is resolved normally.